### PR TITLE
feat: topic-keyed vocab palette for article generation (#14)

### DIFF
--- a/database/10_reading_intensity.sql
+++ b/database/10_reading_intensity.sql
@@ -1,0 +1,78 @@
+-- ============================================================
+-- Reading Intensity + Vocab Palette RPC
+-- ============================================================
+--
+-- Adds a `reading_intensity` preset to user_preferences, plus an RPC
+-- that finds JMDict candidate words whose English glosses match any of
+-- a set of topic keywords. Used by process-article to build a targeted
+-- vocabulary palette before article rewriting.
+-- ============================================================
+
+-- 1. reading_intensity column on user_preferences
+--    leisure   -> ~98% known / 1.5% review / 0.5% new
+--    balanced  -> ~95% known / 4% review / 1% new  (default)
+--    intensive -> ~90% known / 8% review / 2% new
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS reading_intensity TEXT DEFAULT 'balanced';
+
+ALTER TABLE public.user_preferences
+  DROP CONSTRAINT IF EXISTS user_preferences_reading_intensity_check;
+
+ALTER TABLE public.user_preferences
+  ADD CONSTRAINT user_preferences_reading_intensity_check
+  CHECK (reading_intensity IN ('leisure', 'balanced', 'intensive'));
+
+
+-- 2. jmdict_vocab_candidates RPC
+--    Given an array of English keyword patterns (each already wrapped
+--    in '%...%' by the caller), return matching entries at or below
+--    the user's JLPT level, along with their preferred kanji surface.
+--    JLPT numbering: 5 = N5 (easiest), 1 = N1 (hardest). A user at N4
+--    (jlpt_level = 4) can handle N5 and N4 vocab, so we filter
+--    `entry.jlpt_level >= user_jlpt`. NULL jlpt_level = untagged/rare
+--    and is excluded from the candidate pool (we don't suggest rare
+--    vocab to learners).
+
+CREATE OR REPLACE FUNCTION public.jmdict_vocab_candidates(
+  keywords     TEXT[],
+  user_jlpt    INT,
+  max_results  INT DEFAULT 200
+)
+RETURNS TABLE (
+  entry_id    TEXT,
+  jlpt_level  SMALLINT,
+  kanji       TEXT,
+  kana        TEXT,
+  is_common   BOOLEAN
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH matched_entries AS (
+    SELECT DISTINCT e.id, e.jlpt_level, e.common
+    FROM public.jmdict_senses s
+    JOIN public.jmdict_entries e ON e.id = s.entry_id
+    WHERE e.jlpt_level IS NOT NULL
+      AND e.jlpt_level >= user_jlpt
+      AND EXISTS (
+        SELECT 1 FROM unnest(s.gloss) g
+        WHERE g ILIKE ANY(keywords)
+      )
+    LIMIT max_results
+  )
+  SELECT
+    m.id                                     AS entry_id,
+    m.jlpt_level                             AS jlpt_level,
+    (SELECT k.text FROM public.jmdict_kanji k
+       WHERE k.entry_id = m.id
+       ORDER BY k.common DESC, k.id ASC LIMIT 1) AS kanji,
+    (SELECT ka.text FROM public.jmdict_kana ka
+       WHERE ka.entry_id = m.id
+       ORDER BY ka.common DESC, ka.id ASC LIMIT 1) AS kana,
+    m.common                                 AS is_common
+  FROM matched_entries m;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.jmdict_vocab_candidates(TEXT[], INT, INT)
+  TO anon, authenticated, service_role;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -4,14 +4,19 @@ import { useAppStore } from '../services/store';
 import { rtkKanjiList } from '../data/rtkKanji';
 
 export function Settings() {
-  const { 
-    jlptLevel, setJlptLevel, 
-    rtkLevel, setRtkLevel, 
+  const {
+    jlptLevel, setJlptLevel,
+    rtkLevel, setRtkLevel,
     studyMode, setStudyMode,
+    readingIntensity, setReadingIntensity,
     srsAutoBumpThreshold, setSrsAutoBumpThreshold,
     readerFontSize, setReaderFontSize,
     readerFontWeight, setReaderFontWeight
   } = useAppStore();
+
+  const intensityOptions = ['leisure', 'balanced', 'intensive'] as const;
+  const intensityLabels = ['Leisure', 'Balanced', 'Intensive'] as const;
+  const activeIntensityIndex = intensityOptions.indexOf(readingIntensity);
 
   const handleRtkChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const val = parseInt(e.target.value, 10);
@@ -81,7 +86,64 @@ export function Settings() {
         </p>
       </div>
 
-      {/* 2. Vocab Use */}
+      {/* 2. Article Intensity */}
+      <div style={{ backgroundColor: 'var(--bg-card)', padding: '1.5rem', borderRadius: '16px', marginBottom: '1.5rem' }}>
+        <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-muted)', letterSpacing: '0.1em', marginBottom: '1.5rem', textTransform: 'uppercase' }}>
+          Article Intensity
+        </label>
+
+        <div style={{ display: 'flex', backgroundColor: 'var(--border-light)', borderRadius: '100px', padding: '4px', marginBottom: '1.2rem', height: '45px', position: 'relative' }}>
+          <div style={{
+            position: 'absolute',
+            top: '4px',
+            bottom: '4px',
+            left: `calc(4px + ${activeIntensityIndex === -1 ? 1 : activeIntensityIndex} * (100% - 8px) / 3)`,
+            width: `calc((100% - 8px) / 3)`,
+            backgroundColor: 'var(--bg-pure)',
+            borderRadius: '100px',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            transition: 'all 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
+            zIndex: 0
+          }} />
+
+          {intensityOptions.map((opt, i) => {
+            const isSelected = readingIntensity === opt;
+            return (
+              <button
+                key={`i-${opt}`}
+                onClick={() => setReadingIntensity(opt)}
+                style={{
+                  flex: 1,
+                  borderRadius: '100px',
+                  backgroundColor: 'transparent',
+                  color: isSelected ? 'var(--text-main)' : 'var(--text-muted)',
+                  fontWeight: isSelected ? 700 : 600,
+                  border: 'none',
+                  outline: 'none',
+                  cursor: 'pointer',
+                  transition: 'color 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
+                  fontSize: '0.85rem',
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  position: 'relative',
+                  zIndex: 1
+                }}
+              >
+                {intensityLabels[i]}
+              </button>
+            );
+          })}
+        </div>
+
+        <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', lineHeight: 1.5 }}>
+          {readingIntensity === 'leisure' && 'Light reading — ~98% known vocabulary. Flow through articles with minimal dictionary lookups.'}
+          {readingIntensity === 'balanced' && 'Comfortable learning — ~95% known, with a handful of review words and 1–2 new words per article.'}
+          {readingIntensity === 'intensive' && 'Study-heavy — ~90% known, with more review and new vocabulary packed in. Slower but faster growth.'}
+        </p>
+      </div>
+
+      {/* 3. Vocab Use */}
       <div style={{ backgroundColor: 'var(--bg-card)', padding: '1.5rem', borderRadius: '16px', marginBottom: '1.5rem' }}>
         <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-muted)', letterSpacing: '0.1em', marginBottom: '1.5rem', textTransform: 'uppercase' }}>
           Vocab Use
@@ -138,7 +200,7 @@ export function Settings() {
         </p>
       </div>
 
-      {/* 3. Kanji Use */}
+      {/* 4. Kanji Use */}
       <div style={{ backgroundColor: 'var(--bg-card)', padding: '1.5rem', borderRadius: '16px', marginBottom: '1.5rem' }}>
         <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-muted)', letterSpacing: '0.1em', marginBottom: '1.5rem', textTransform: 'uppercase' }}>
           Kanji Use
@@ -205,7 +267,7 @@ export function Settings() {
         }
       `}</style>
 
-      {/* 4. Advanced Settings */}
+      {/* 5. Advanced Settings */}
       <details 
         style={{ 
           backgroundColor: 'var(--bg-card)', 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -348,6 +348,7 @@ export async function upsertUserPreferences(
     study_mode?: string;
     vocab_mode?: string;
     furigana_mode?: string;
+    reading_intensity?: string;
   }
 ) {
   const { error } = await supabase

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -28,6 +28,7 @@ interface AppState {
   studyMode: 'natural' | 'balanced' | 'study';
   vocabMode: 'natural' | 'balanced' | 'study';
   furiganaMode: 'always' | 'never' | 'dynamic';
+  readingIntensity: 'leisure' | 'balanced' | 'intensive';
   
   wordDatabase: Record<string, WordData>;
   studyKanji: string[];
@@ -47,6 +48,7 @@ interface AppState {
   setStudyMode: (mode: 'natural' | 'balanced' | 'study') => void;
   setVocabMode: (mode: 'natural' | 'balanced' | 'study') => void;
   setFuriganaMode: (mode: 'always' | 'never' | 'dynamic') => void;
+  setReadingIntensity: (intensity: 'leisure' | 'balanced' | 'intensive') => void;
   setCurrentArticle: (article: NewsArticle | null) => void;
   saveProcessedArticle: (id: string, article: NewsArticle) => void;
   setArticlesCache: (cache: Record<string, NewsArticle>) => void;
@@ -74,6 +76,7 @@ export const useAppStore = create<AppState>()(
       studyMode: 'balanced',
       vocabMode: 'balanced',
       furiganaMode: 'dynamic',
+      readingIntensity: 'balanced',
       wordDatabase: {},
       studyKanji: [],
       lastRtkUpdateTs: null,
@@ -112,7 +115,13 @@ export const useAppStore = create<AppState>()(
           if (user) import('./api').then(m => m.upsertUserPreferences(user.id, { vocab_mode: mode }));
         });
       },
-      
+      setReadingIntensity: (intensity) => {
+        set({ readingIntensity: intensity });
+        supabase.auth.getUser().then(({ data: { user } }) => {
+          if (user) import('./api').then(m => m.upsertUserPreferences(user.id, { reading_intensity: intensity }));
+        });
+      },
+
       setFuriganaMode: (mode) => set({ furiganaMode: mode }),
       setCurrentArticle: (article) => set({ currentArticle: article }),
       saveProcessedArticle: (id, article) => {
@@ -261,6 +270,7 @@ export const useAppStore = create<AppState>()(
             studyMode: remotePrefs.study_mode ?? state.studyMode,
             vocabMode: remotePrefs.vocab_mode ?? state.vocabMode,
             furiganaMode: remotePrefs.furigana_mode ?? state.furiganaMode,
+            readingIntensity: remotePrefs.reading_intensity ?? state.readingIntensity,
           }));
         }
 

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -7,6 +7,52 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
+const GROQ_MODEL = 'openai/gpt-oss-20b';
+const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
+
+// Approximate number of unique word tokens in a 3-paragraph article.
+// Used to translate intensity ratios into concrete palette counts.
+const WORDS_PER_ARTICLE = 200;
+
+// reading_intensity preset -> target distribution of known/review/new vocab.
+// See database/10_reading_intensity.sql for the column definition.
+const INTENSITY_RATIOS: Record<string, { known: number; review: number; new: number }> = {
+  leisure:   { known: 0.980, review: 0.015, new: 0.005 },
+  balanced:  { known: 0.950, review: 0.040, new: 0.010 },
+  intensive: { known: 0.900, review: 0.080, new: 0.020 },
+};
+
+async function extractKeywordsWithGroq(title: string, snippet: string, apiKey: string): Promise<string[]> {
+  const prompt = `Extract 10-15 topic keywords from this English news article. Return ONLY a JSON array of lowercase single-word or two-word phrases — concrete nouns and topic terms preferred (skip filler like "the", "said", "people"). No explanation.
+
+Title: ${title}
+Snippet: ${snippet}
+
+Example output: ["economy", "trade", "tariff", "minister", "election"]`;
+
+  const response = await fetch(GROQ_API_URL, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: GROQ_MODEL,
+      messages: [{ role: 'user', content: prompt }],
+      response_format: { type: 'json_object' },
+      temperature: 0.2,
+    }),
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error(`Groq keyword extraction failed: ${err.error?.message || response.statusText}`);
+  }
+  const data = await response.json();
+  const raw = data.choices?.[0]?.message?.content ?? '[]';
+  // gpt-oss-20b in json_object mode may wrap in {"keywords": [...]} or return a bare array
+  const parsed = JSON.parse(raw);
+  const arr: unknown = Array.isArray(parsed) ? parsed : (parsed.keywords ?? parsed.topics ?? parsed.terms ?? []);
+  if (!Array.isArray(arr)) return [];
+  return arr.map(String).map((s) => s.toLowerCase().trim()).filter((s) => s.length >= 2 && s.length <= 30);
+}
+
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
@@ -38,23 +84,89 @@ Deno.serve(async (req) => {
     const rtkLevel = prefs?.rtk_level ?? 0;
     const studyMode = prefs?.study_mode ?? 'balanced';
     const vocabMode = prefs?.vocab_mode ?? 'balanced';
+    const readingIntensity: string = prefs?.reading_intensity ?? 'balanced';
+    const ratios = INTENSITY_RATIOS[readingIntensity] ?? INTENSITY_RATIOS.balanced;
+    const targetReview = Math.max(1, Math.round(ratios.review * WORDS_PER_ARTICLE));
+    const targetNew = Math.max(1, Math.round(ratios.new * WORDS_PER_ARTICLE));
 
-    // 2. Fetch hard/medium vocab targets from user's SRS progress
-    const { data: wordProgress } = await supabase
-      .from('user_word_progress')
-      .select('word_id, mastery_level')
-      .eq('user_id', userId)
-      .in('mastery_level', ['hard', 'medium'])
-      .limit(30);
+    // 2. Vocabulary palette pipeline
+    //    a) Extract topic keywords from the English source (Groq)
+    //    b) Query JMDict for candidate entries whose glosses match
+    //    c) Bucket candidates into known / review / new vs. user_word_progress
+    let knownPalette: string[] = [];
+    let reviewPalette: string[] = [];
+    let newPalette: string[] = [];
+    let vocabTargets: string[] = []; // legacy: kept for vocab_mode prompt back-compat
+    try {
+      const keywords = await extractKeywordsWithGroq(title, snippet, groqKey);
+      if (keywords.length > 0) {
+        const keywordPatterns = keywords.map((k) => `%${k}%`);
+        const { data: candidates, error: candErr } = await supabase.rpc('jmdict_vocab_candidates', {
+          keywords: keywordPatterns,
+          user_jlpt: jlptLevel,
+          max_results: 200,
+        });
+        if (candErr) throw candErr;
 
-    const vocabTargetsData = (wordProgress as any[])?.map(r => r.word_id) ?? [];
-    let vocabTargets: string[] = [];
-    if (vocabTargetsData.length > 0) {
-      // Pick up to 5 random targets to avoid overwhelming the prompt
-      const shuffled = [...vocabTargetsData].sort(() => 0.5 - Math.random()).slice(0, 5);
-      const { data: kanjiRes } = await supabase.from('jmdict_kanji').select('text').in('entry_id', shuffled);
-      if (kanjiRes) {
-        vocabTargets = Array.from(new Set(kanjiRes.map((r: any) => r.text)));
+        const entryIds: string[] = (candidates ?? []).map((c: any) => c.entry_id);
+        let progressMap = new Map<string, string>();
+        if (entryIds.length > 0) {
+          const { data: progress } = await supabase
+            .from('user_word_progress')
+            .select('word_id, mastery_level')
+            .eq('user_id', userId)
+            .in('word_id', entryIds);
+          progressMap = new Map((progress ?? []).map((p: any) => [p.word_id, p.mastery_level]));
+        }
+
+        // Sort candidates: common words first, then by jlpt_level (easier first).
+        const sorted = [...(candidates ?? [])].sort((a: any, b: any) => {
+          if (a.is_common !== b.is_common) return a.is_common ? -1 : 1;
+          return (b.jlpt_level ?? 0) - (a.jlpt_level ?? 0);
+        });
+
+        for (const c of sorted) {
+          const display = c.kanji || c.kana;
+          if (!display) continue;
+          const mastery = progressMap.get(c.entry_id);
+          if (mastery === 'easy') {
+            knownPalette.push(display);
+          } else if (mastery === 'hard' || mastery === 'medium') {
+            reviewPalette.push(display);
+          } else if (c.jlpt_level > jlptLevel) {
+            // Below user's study level (easier) => treat as assumed-known
+            knownPalette.push(display);
+          } else if (c.jlpt_level === jlptLevel && !mastery) {
+            newPalette.push(display);
+          }
+        }
+        // De-dupe while preserving order
+        knownPalette = Array.from(new Set(knownPalette)).slice(0, 30);
+        reviewPalette = Array.from(new Set(reviewPalette)).slice(0, Math.max(5, targetReview + 2));
+        newPalette = Array.from(new Set(newPalette)).slice(0, Math.max(3, targetNew + 2));
+      }
+      console.log(`[process-article] Palette: ${knownPalette.length} known, ${reviewPalette.length} review, ${newPalette.length} new (intensity=${readingIntensity})`);
+    } catch (palErr) {
+      console.error('[process-article] Palette pipeline error (continuing without palette):', palErr);
+    }
+
+    // Legacy vocab_mode targets: any user review words, regardless of this article's topic.
+    // Still used below so the vocab_mode "Study" prompt keeps working even when the
+    // topic-keyed review palette is empty.
+    if (reviewPalette.length > 0) {
+      vocabTargets = reviewPalette.slice(0, 5);
+    } else {
+      const { data: wordProgress } = await supabase
+        .from('user_word_progress')
+        .select('word_id')
+        .eq('user_id', userId)
+        .in('mastery_level', ['hard', 'medium'])
+        .limit(30);
+      const ids = (wordProgress as any[])?.map((r) => r.word_id) ?? [];
+      if (ids.length > 0) {
+        const shuffled = [...ids].sort(() => 0.5 - Math.random()).slice(0, 5);
+        const { data: kanjiRes } = await supabase.from('jmdict_kanji').select('text').in('entry_id', shuffled);
+        if (kanjiRes) vocabTargets = Array.from(new Set(kanjiRes.map((r: any) => r.text)));
       }
     }
 
@@ -83,6 +195,20 @@ Deno.serve(async (req) => {
 
     const ai = new GoogleGenAI({ apiKey: geminiKey, httpOptions: { apiVersion: 'v1beta' } });
 
+    // Build targeted vocab palette block (empty string if pipeline produced nothing)
+    let palettePrompt = '';
+    if (knownPalette.length + reviewPalette.length + newPalette.length > 0) {
+      const pctKnown = Math.round(ratios.known * 100);
+      const pctReview = Math.round(ratios.review * 100);
+      const pctNew = Math.round(ratios.new * 100);
+      palettePrompt = `
+VOCABULARY PALETTE (aim for ~${pctKnown}% known / ~${pctReview}% review / ~${pctNew}% new by token count):
+- KNOWN words — draw freely from this list; these form the backbone of the article: ${knownPalette.join('、') || '(rely on natural ' + jlptStr + ' and easier vocabulary)'}
+- REVIEW words — work about ${targetReview} of these in where they fit the facts naturally: ${reviewPalette.join('、') || '(none)'}
+- NEW words — introduce about ${targetNew} of these if the topic allows, and gloss any you use in a yugen-box: ${newPalette.join('、') || '(none)'}
+Treat this palette as a GUIDE, not a quota. Never distort the facts or insert unnatural phrasing just to hit a word.`;
+    }
+
     // Pass 1: Rewrite article
     const prompt1 = `
 You are a factual Japanese news reporter writing a 3-paragraph news article for a JLPT ${jlptStr} learner.
@@ -90,6 +216,7 @@ News Headline: ${title}
 News Snippet: ${snippet}
 
 GOLDEN RULE: The article MUST accurately report on the exact events of the News Headline. DO NOT use abstract, poetic, or metaphorical language. Stick to facts.
+${palettePrompt}
 
 Rules:
 1. Tone must be like a factual Japanese news broadcast.


### PR DESCRIPTION
Closes #14.

## Summary
Adds a deterministic pre-processing pipeline that runs before Gemini article rewriting, injecting a targeted vocabulary palette at minimal token cost:

1. **Keyword extraction** — Groq (gpt-oss-20b) pulls 10–15 English topic keywords from the source article
2. **JMDict candidate pool** — new \`jmdict_vocab_candidates\` RPC joins senses/entries/kanji/kana, filters by user JLPT level via \`EXISTS + unnest(gloss) ILIKE ANY\`
3. **Bucketing** — candidates are cross-referenced with \`user_word_progress\` and split into **known** (mastery=easy OR below study level), **review** (mastery in hard/medium), and **new** (no progress, at study level)
4. **Prompt injection** — a \`VOCABULARY PALETTE\` block is added to the Pass 1 prompt, framed as guidance not a quota so the model can't distort facts to hit ratios

## Reading intensity preset
New \`reading_intensity\` column on \`user_preferences\` (default \`balanced\`):

| Preset | Known | Review | New | Feel |
|---|---|---|---|---|
| \`leisure\` | 98% | 1.5% | 0.5% | Light reading, minimal lookups |
| \`balanced\` | 95% | 4% | 1% | Comfortable learning (~2 new/article) |
| \`intensive\` | 90% | 8% | 2% | Study-heavy, denser new vocab |

Default **balanced** lands in the sweet spot of extensive-reading research (Hu & Nation 2000: 95% = comfortable comprehension with dictionary). 98% is fluent leisure; 90% is intensive study mode where every paragraph is work.

Settings UI gets a new segmented control ("Article Intensity") matching the existing Vocab Use / Kanji Use pattern.

## Robustness
- Palette pipeline is try/wrapped — if Groq or the RPC fails, article generation falls back to the previous behavior (existing \`vocab_mode\` still applies, no 500s)
- Legacy \`vocab_mode\` prompt targets still populated from general SRS progress when the topic-keyed review bucket is empty
- RPC excludes NULL-jlpt entries (207k untagged/rare words) so we don't suggest obscure vocabulary to learners

## Required deploy order
1. **Apply SQL migration first** — \`database/10_reading_intensity.sql\` via Supabase SQL editor. Must run before merge, or the edge function will 500 on the RPC call.
2. **Merge this PR**
3. **Redeploy edge function** — \`supabase functions deploy process-article\`

## Test plan
- [ ] Apply migration, verify \`SELECT reading_intensity FROM user_preferences LIMIT 1\` returns \`balanced\`
- [ ] Verify RPC: \`SELECT * FROM jmdict_vocab_candidates(ARRAY['%economy%', '%trade%'], 4, 20)\` returns rows
- [ ] Deploy process-article, check logs for \`[process-article] Palette: N known, M review, K new (intensity=balanced)\`
- [ ] Toggle Settings → Article Intensity between the three presets, confirm it persists via Supabase (row updates in user_preferences)
- [ ] Generate fresh articles at each intensity, spot-check that new/review vocabulary density shifts as expected
- [ ] Regression: if Groq key is missing/invalid, article generation still succeeds (palette skipped)