### PR TITLE
feat: content quality overhaul — RSS multi-feed + full-text extraction + dedup clustering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,7 @@ function App() {
         article.id,
         article.title,
         snippet,
+        article.sources,
         () => {}
       );
       saveProcessedArticle(article.id, { ...article, blocks: processedBlocks });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -15,6 +15,12 @@ export interface ArticleBlock {
   description?: string;
 }
 
+export interface ArticleSource {
+  title: string;
+  url: string;
+  teaser: string;
+}
+
 export interface NewsArticle {
   id: string;
   title: string;
@@ -23,6 +29,9 @@ export interface NewsArticle {
   date: string;
   readTime: string;
   category: string;
+  /** Clustered source articles — passed to process-article for full-text extraction. */
+  sources?: ArticleSource[];
+  sourceCount?: number;
 }
 
 import { supabase } from './supabase'
@@ -215,6 +224,7 @@ export async function requestArticleProcessing(
   articleId: string,
   title: string,
   snippet: string,
+  sources?: ArticleSource[],
   onProgress?: (status: string) => void
 ): Promise<ArticleBlock[]> {
   onProgress?.('Processing article on server...');
@@ -223,6 +233,7 @@ export async function requestArticleProcessing(
     articleId,
     title,
     snippet,
+    sources,
   });
   onProgress?.('Done.');
   return result.blocks;

--- a/supabase/functions/fetch-raw-news/index.ts
+++ b/supabase/functions/fetch-raw-news/index.ts
@@ -69,7 +69,16 @@ async function clusterArticles(articles: any[], groqKey: string | undefined): Pr
   if (!groqKey || articles.length < 2) return singletons();
 
   const headlineList = articles.map((a, i) => `${i + 1}. ${a.title}`).join('\n');
-  const prompt = `Group these news headlines into topic clusters. Return JSON: {"clusters": [{"topic": "short topic label", "articles": [indices]}]}. Use 1-based indices. Only cluster articles that are clearly about the same story or closely related. Singletons are fine.\n\n${headlineList}`;
+  const prompt = `Group these news headlines into topic clusters. Return JSON: {"clusters": [{"topic": "short topic label", "articles": [indices]}]}. Use 1-based indices.
+
+Rules:
+- ONLY group articles that cover the SAME specific story or event (e.g. the same product launch, the same court ruling, the same company's earnings).
+- DO NOT group by broad category. "Technology", "Gaming", "Business" are NOT valid clusters — a CPU article and a truck-engine article are different stories even though both are "tech". Never create a leftover "misc" bucket.
+- When in doubt, keep an article as its own singleton. Most clusters will be singletons; that is expected and correct.
+- The "topic" label must name the specific shared story, not a broad category.
+
+Headlines:
+${headlineList}`;
 
   try {
     const response = await fetch(GROQ_API_URL, {

--- a/supabase/functions/fetch-raw-news/index.ts
+++ b/supabase/functions/fetch-raw-news/index.ts
@@ -8,6 +8,14 @@ const corsHeaders = {
 const TOP_HEADLINES_URL = 'https://newsapi.org/v2/top-headlines';
 const EVERYTHING_URL = 'https://newsapi.org/v2/everything';
 
+// Topic clustering. Grouping related headlines from a single fetch and merging
+// their snippets gives process-article 3-4x more factual material than a lone
+// ~200-char snippet, which yields substantially richer articles (see #18).
+const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
+const CLUSTER_MODEL = 'meta-llama/llama-4-scout-17b-16e-instruct';
+// Cap merged sources so a single mega-cluster can't blow up the Gemini prompt.
+const MAX_SOURCES_PER_CLUSTER = 5;
+
 // Whitelist of real-journalism publisher IDs on NewsAPI. Used as a filter on
 // /v2/everything so we don't pull in PyPI release feeds, npm package
 // announcements, GitHub readmes, etc. that otherwise dominate the "Technology"
@@ -42,6 +50,74 @@ function pickValidArticles(raw: any[]): any[] {
     if (snippet.length < 40) return false;
     return true;
   });
+}
+
+function snippetText(a: any): string {
+  return (a?.description || a?.content || '').toString().trim();
+}
+
+interface Cluster {
+  topic: string;
+  indices: number[];
+}
+
+// Group related headlines into topic clusters via Groq so process-article can
+// synthesize multiple snippets into one richer article. Always degrades
+// gracefully to one cluster per article (today's behavior) on any failure.
+async function clusterArticles(articles: any[], groqKey: string | undefined): Promise<Cluster[]> {
+  const singletons = (): Cluster[] => articles.map((a, i) => ({ topic: a.title, indices: [i] }));
+  if (!groqKey || articles.length < 2) return singletons();
+
+  const headlineList = articles.map((a, i) => `${i + 1}. ${a.title}`).join('\n');
+  const prompt = `Group these news headlines into topic clusters. Return JSON: {"clusters": [{"topic": "short topic label", "articles": [indices]}]}. Use 1-based indices. Only cluster articles that are clearly about the same story or closely related. Singletons are fine.\n\n${headlineList}`;
+
+  try {
+    const response = await fetch(GROQ_API_URL, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${groqKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: CLUSTER_MODEL,
+        messages: [{ role: 'user', content: prompt }],
+        response_format: { type: 'json_object' },
+        temperature: 0.2,
+      }),
+    });
+    if (!response.ok) {
+      console.error(`[fetch-raw-news] clustering failed: ${response.status} ${await response.text()}`);
+      return singletons();
+    }
+
+    const data = await response.json();
+    const raw = data.choices?.[0]?.message?.content ?? '{}';
+    const parsed = JSON.parse(raw);
+    const rawClusters: any[] = Array.isArray(parsed) ? parsed : (parsed.clusters ?? []);
+    if (!Array.isArray(rawClusters) || rawClusters.length === 0) return singletons();
+
+    const used = new Set<number>();
+    const clusters: Cluster[] = [];
+    for (const c of rawClusters) {
+      const idxRaw: any[] = Array.isArray(c?.articles) ? c.articles : [];
+      const indices = idxRaw
+        .map((n) => Number(n) - 1) // model returns 1-based indices
+        .filter((n) => Number.isInteger(n) && n >= 0 && n < articles.length && !used.has(n))
+        .slice(0, MAX_SOURCES_PER_CLUSTER);
+      if (indices.length === 0) continue;
+      indices.forEach((n) => used.add(n));
+      const topic = (typeof c?.topic === 'string' && c.topic.trim()) || articles[indices[0]].title;
+      clusters.push({ topic: topic.trim(), indices });
+    }
+
+    // Any article the model omitted becomes its own singleton so nothing is lost.
+    articles.forEach((a, i) => {
+      if (!used.has(i)) clusters.push({ topic: a.title, indices: [i] });
+    });
+
+    console.log(`[fetch-raw-news] clustered ${articles.length} articles into ${clusters.length} topics`);
+    return clusters.length > 0 ? clusters : singletons();
+  } catch (err) {
+    console.error('[fetch-raw-news] clustering error:', err);
+    return singletons();
+  }
 }
 
 Deno.serve(async (req) => {
@@ -115,20 +191,34 @@ Deno.serve(async (req) => {
       });
     }
 
-    const rawArticles = articles.map((a: any) => ({
-      id: `${a.title.substring(0, 15)}-${Math.random().toString(36).substring(2, 9)}`,
-      title: a.title,
-      originalUrl: a.url,
-      date: new Date(a.publishedAt).toLocaleDateString(),
-      readTime: '3 min read',
-      category: chosenCategory,
-      blocks: [
-        {
-          type: 'paragraph',
-          content: [{ text: a.description || a.content || a.title }],
-        },
-      ],
-    }));
+    const groqKey = Deno.env.get('GROQ_API_KEY');
+    const clusters = await clusterArticles(articles, groqKey);
+
+    const rawArticles = clusters.map((cluster) => {
+      const sources = cluster.indices.map((i) => articles[i]);
+      const lead = sources[0];
+      // Numbered "Sources" block: process-article reads this as the snippet and
+      // synthesizes the merged material into one coherent Japanese article.
+      const mergedSnippet = sources
+        .map((a, n) => `${n + 1}. ${a.title} — ${snippetText(a) || a.title}`)
+        .join('\n');
+
+      return {
+        id: `${cluster.topic.substring(0, 15)}-${Math.random().toString(36).substring(2, 9)}`,
+        title: cluster.topic,
+        originalUrl: lead.url,
+        date: new Date(lead.publishedAt).toLocaleDateString(),
+        readTime: `${Math.min(2 + sources.length, 8)} min read`,
+        category: chosenCategory,
+        sourceCount: sources.length,
+        blocks: [
+          {
+            type: 'paragraph',
+            content: [{ text: mergedSnippet }],
+          },
+        ],
+      };
+    });
 
     return new Response(JSON.stringify({ articles: rawArticles }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },

--- a/supabase/functions/fetch-raw-news/index.ts
+++ b/supabase/functions/fetch-raw-news/index.ts
@@ -1,81 +1,215 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
+// ── Sources ───────────────────────────────────────────────────────────────
+// RSS is the primary discovery layer: free, unlimited, and multi-outlet, so
+// the same story shows up across several feeds and clusters into much richer
+// source material than a single NewsAPI query can (see #18 follow-up). NewsAPI
+// remains a fallback for the rare case where every feed fails.
+const FEED_LIST: { name: string; url: string; category: string }[] = [
+  { name: 'BBC',        url: 'https://feeds.bbci.co.uk/news/rss.xml',            category: 'World' },
+  { name: 'BBC Tech',   url: 'https://feeds.bbci.co.uk/news/technology/rss.xml', category: 'Technology' },
+  { name: 'The Verge',  url: 'https://www.theverge.com/rss/index.xml',           category: 'Technology' },
+  { name: 'Ars Technica', url: 'https://feeds.arstechnica.com/arstechnica/index', category: 'Technology' },
+  { name: 'TechCrunch', url: 'https://techcrunch.com/feed/',                     category: 'Technology' },
+  { name: 'NPR',        url: 'https://feeds.npr.org/1001/rss.xml',               category: 'World' },
+  { name: 'Engadget',   url: 'https://www.engadget.com/rss.xml',                 category: 'Technology' },
+  { name: 'Wired',      url: 'https://www.wired.com/feed/rss',                   category: 'Technology' },
+  { name: 'Guardian',   url: 'https://www.theguardian.com/world/rss',            category: 'World' },
+  { name: 'Guardian Tech', url: 'https://www.theguardian.com/technology/rss',    category: 'Technology' },
+  { name: 'Guardian Sci',  url: 'https://www.theguardian.com/science/rss',       category: 'Science' },
+];
+const ITEMS_PER_FEED = 12;
+const FEED_TIMEOUT_MS = 8000;
+const MAX_CARDS = 40;
+
 const TOP_HEADLINES_URL = 'https://newsapi.org/v2/top-headlines';
 const EVERYTHING_URL = 'https://newsapi.org/v2/everything';
 
-// Topic clustering. Grouping related headlines from a single fetch and merging
-// their snippets gives process-article 3-4x more factual material than a lone
-// ~200-char snippet, which yields substantially richer articles (see #18).
+// ── Clustering (dedup) ──────────────────────────────────────────────────────
+// Clustering is used conservatively, only to DEDUPE same-story coverage across
+// outlets (e.g. don't show four NASA Moon-base cards). Content richness comes
+// from full-text extraction in process-article, not from merging, so we keep
+// merges small and lean on the lead-source guard for any over-merge.
+// llama-3.3-70b is used over the smaller scout model, which produced a
+// catastrophic 91-item "misc" mega-bucket at real scale.
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
-const CLUSTER_MODEL = 'meta-llama/llama-4-scout-17b-16e-instruct';
-// Cap merged sources so a single mega-cluster can't blow up the Gemini prompt.
-const MAX_SOURCES_PER_CLUSTER = 5;
+const CLUSTER_MODEL = 'llama-3.3-70b-versatile';
+// Keep merges tight — over-merging suppresses unrelated articles and wastes
+// extraction calls. The lead article is always primary; extras are corroboration.
+const MAX_SOURCES_PER_CLUSTER = 3;
 
-// Whitelist of real-journalism publisher IDs on NewsAPI. Used as a filter on
-// /v2/everything so we don't pull in PyPI release feeds, npm package
-// announcements, GitHub readmes, etc. that otherwise dominate the "Technology"
-// firehose when sorted by publishedAt.
+// NewsAPI fallback noise filters (only used when RSS yields nothing).
 const QUALITY_SOURCES = [
   'bbc-news', 'the-verge', 'techcrunch', 'ars-technica', 'wired',
   'associated-press', 'bloomberg', 'business-insider', 'cnn',
   'nbc-news', 'engadget', 'the-next-web', 'abc-news', 'cbs-news',
   'the-washington-post', 'time',
 ].join(',');
-
-// Belt-and-suspenders against the noise sources even if a quality publisher
-// syndicates them.
 const EXCLUDE_DOMAINS = [
   'pypi.org', 'github.com', 'npmjs.com',
   'readthedocs.io', 'readthedocs.org', 'arxiv.org',
 ].join(',');
-
-// Detects titles like "axmp-ai-agent-core 1.0.0rc12" or "spanforge 2.0.0" that
-// sometimes slip through — package-release entries masquerading as articles.
 const PACKAGE_RELEASE_TITLE = /^[\w.@/-]+\s+\d+\.\d+(?:\.\d+)?(?:[\w.-]+)?$/i;
 
-function pickValidArticles(raw: any[]): any[] {
-  return (raw ?? []).filter((a: any) => {
-    if (!a?.title || typeof a.title !== 'string') return false;
-    if (a.title.includes('[Removed]')) return false;
-    if (a.title.length < 12) return false;
-    if (PACKAGE_RELEASE_TITLE.test(a.title.trim())) return false;
-    // process-article requires a non-empty snippet; drop articles with
-    // no usable body text so we don't 400 downstream.
-    const snippet = (a.description || a.content || '').toString().trim();
-    if (snippet.length < 40) return false;
-    return true;
-  });
+// A normalized article from any source, before clustering.
+interface PoolItem {
+  title: string;
+  teaser: string;
+  url: string;
+  date: string;
+  source: string;   // outlet name — drives the multi-outlet cluster heuristic
+  category: string;
 }
 
-function snippetText(a: any): string {
-  return (a?.description || a?.content || '').toString().trim();
+// ── RSS/Atom parsing ──────────────────────────────────────────────────────
+function stripHtml(s: string): string {
+  return (s || '')
+    .replace(/<!\[CDATA\[|\]\]>/g, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&#0*39;|&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, d) => String.fromCharCode(Number(d)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCharCode(parseInt(h, 16)))
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
+function extractTag(block: string, name: string): string {
+  const m = block.match(new RegExp(`<${name}[^>]*>([\\s\\S]*?)<\\/${name}>`, 'i'));
+  return m ? m[1] : '';
+}
+
+function extractLink(block: string): string {
+  const rss = block.match(/<link>([\s\S]*?)<\/link>/i);
+  if (rss && rss[1].trim()) return stripHtml(rss[1]);
+  const alt = block.match(/<link[^>]*rel=["']alternate["'][^>]*href=["']([^"']+)["']/i);
+  if (alt) return alt[1];
+  const any = block.match(/<link[^>]*href=["']([^"']+)["']/i);
+  if (any) return any[1];
+  return '';
+}
+
+function parseFeed(xml: string, source: string, category: string): PoolItem[] {
+  const blocks = xml.match(/<item[\s>][\s\S]*?<\/item>/gi)
+    || xml.match(/<entry[\s>][\s\S]*?<\/entry>/gi)
+    || [];
+  const out: PoolItem[] = [];
+  for (const b of blocks) {
+    const title = stripHtml(extractTag(b, 'title'));
+    const desc = stripHtml(extractTag(b, 'description') || extractTag(b, 'summary'));
+    // content:encoded (RSS) / content (Atom) is often the full body — keep the
+    // longer of the two so feeds that ship full text (e.g. Ars) skip extraction.
+    const content = stripHtml(extractTag(b, 'content:encoded') || extractTag(b, 'content'));
+    const teaser = (content.length > desc.length ? content : desc).slice(0, 800);
+    const url = extractLink(b);
+    const date = stripHtml(extractTag(b, 'pubDate') || extractTag(b, 'published') || extractTag(b, 'updated'));
+    out.push({ title, teaser, url, date, source, category });
+  }
+  return out;
+}
+
+function isValidItem(it: PoolItem): boolean {
+  if (!it.title || it.title.length < 12) return false;
+  if (it.title.includes('[Removed]')) return false;
+  if (PACKAGE_RELEASE_TITLE.test(it.title.trim())) return false;
+  if (!it.url) return false;
+  if ((it.teaser || '').trim().length < 40) return false;
+  return true;
+}
+
+async function fetchFeeds(): Promise<PoolItem[]> {
+  const results = await Promise.allSettled(FEED_LIST.map(async (f) => {
+    const ctrl = new AbortController();
+    const to = setTimeout(() => ctrl.abort(), FEED_TIMEOUT_MS);
+    try {
+      const res = await fetch(f.url, { headers: { 'User-Agent': 'YugenStudy/1.0' }, signal: ctrl.signal });
+      if (!res.ok) {
+        console.warn(`[fetch-raw-news] feed ${f.name} HTTP ${res.status}`);
+        return [] as PoolItem[];
+      }
+      const xml = await res.text();
+      return parseFeed(xml, f.name, f.category).filter(isValidItem).slice(0, ITEMS_PER_FEED);
+    } catch (e) {
+      console.warn(`[fetch-raw-news] feed ${f.name} failed:`, e instanceof Error ? e.message : e);
+      return [] as PoolItem[];
+    } finally {
+      clearTimeout(to);
+    }
+  }));
+
+  const pool: PoolItem[] = [];
+  const seenTitles = new Set<string>();
+  for (const r of results) {
+    if (r.status !== 'fulfilled') continue;
+    for (const it of r.value) {
+      const key = it.title.toLowerCase().slice(0, 60);
+      if (seenTitles.has(key)) continue; // drop cross-feed exact dupes
+      seenTitles.add(key);
+      pool.push(it);
+    }
+  }
+  console.log(`[fetch-raw-news] RSS pool: ${pool.length} items from ${FEED_LIST.length} feeds`);
+  return pool;
+}
+
+// ── NewsAPI fallback ─────────────────────────────────────────────────────
+async function fetchNewsApiPool(page: number, newsApiKey: string): Promise<PoolItem[]> {
+  const strategies = [
+    { category: 'Technology', url: `${TOP_HEADLINES_URL}?country=us&category=technology&pageSize=20&page=${page}&apiKey=${newsApiKey}` },
+    { category: 'Business', url: `${TOP_HEADLINES_URL}?country=us&category=business&pageSize=20&page=${page}&apiKey=${newsApiKey}` },
+    { category: 'Technology', url: `${EVERYTHING_URL}?sources=${QUALITY_SOURCES}&excludeDomains=${EXCLUDE_DOMAINS}&sortBy=popularity&language=en&pageSize=20&page=${page}&apiKey=${newsApiKey}` },
+  ];
+  for (const { url, category } of strategies) {
+    try {
+      const res = await fetch(url, { headers: { 'User-Agent': 'YugenStudy/1.0' } });
+      if (!res.ok) continue;
+      const data = await res.json();
+      const items: PoolItem[] = (data.articles ?? []).map((a: any) => ({
+        title: a.title ?? '',
+        teaser: (a.description || a.content || '').toString().trim(),
+        url: a.url ?? '',
+        date: a.publishedAt ?? '',
+        source: a.source?.name || (a.url ? new URL(a.url).host : 'NewsAPI'),
+        category,
+      })).filter(isValidItem);
+      if (items.length > 0) {
+        console.log(`[fetch-raw-news] NewsAPI fallback picked ${items.length} articles`);
+        return items;
+      }
+    } catch (e) {
+      console.error('[fetch-raw-news] NewsAPI fallback error:', e);
+    }
+  }
+  return [];
+}
+
+// ── Clustering ──────────────────────────────────────────────────────────────
 interface Cluster {
   topic: string;
   indices: number[];
 }
 
-// Group related headlines into topic clusters via Groq so process-article can
-// synthesize multiple snippets into one richer article. Always degrades
-// gracefully to one cluster per article (today's behavior) on any failure.
-async function clusterArticles(articles: any[], groqKey: string | undefined): Promise<Cluster[]> {
-  const singletons = (): Cluster[] => articles.map((a, i) => ({ topic: a.title, indices: [i] }));
-  if (!groqKey || articles.length < 2) return singletons();
+// Group same-story coverage across outlets. Multi-item clusters are only kept
+// merged if they span 2+ distinct outlets; a single-outlet multi-item group is
+// almost always the model lumping one feed's section together (grab-bag), so we
+// split those back into singletons. Degrades to one card per item on failure.
+async function clusterArticles(pool: PoolItem[], groqKey: string | undefined): Promise<Cluster[]> {
+  const singletons = (): Cluster[] => pool.map((p, i) => ({ topic: p.title, indices: [i] }));
+  if (!groqKey || pool.length < 2) return singletons();
 
-  const headlineList = articles.map((a, i) => `${i + 1}. ${a.title}`).join('\n');
+  const headlineList = pool.map((p, i) => `${i + 1}. [${p.source}] ${p.title}`).join('\n');
   const prompt = `Group these news headlines into topic clusters. Return JSON: {"clusters": [{"topic": "short topic label", "articles": [indices]}]}. Use 1-based indices.
 
 Rules:
 - ONLY group articles that cover the SAME specific story or event (e.g. the same product launch, the same court ruling, the same company's earnings).
-- DO NOT group by broad category. "Technology", "Gaming", "Business" are NOT valid clusters — a CPU article and a truck-engine article are different stories even though both are "tech". Never create a leftover "misc" bucket.
+- A shared THEME is NOT a story. Do NOT group articles merely because they share a broad subject like "AI", "social media", "space", or "climate". Two different AI announcements are two separate stories.
+- DO NOT group by broad category. "Technology", "Gaming", "Business" are NOT valid clusters. Never create a leftover "misc" bucket.
+- Example: three outlets reporting NASA's new moon base plan = ONE cluster. An article on Musk vs Altman and a separate article on the Pope discussing AI = TWO singletons (both mention AI, but are different stories).
 - When in doubt, keep an article as its own singleton. Most clusters will be singletons; that is expected and correct.
-- The "topic" label must name the specific shared story, not a broad category.
 
 Headlines:
 ${headlineList}`;
@@ -108,20 +242,28 @@ ${headlineList}`;
       const idxRaw: any[] = Array.isArray(c?.articles) ? c.articles : [];
       const indices = idxRaw
         .map((n) => Number(n) - 1) // model returns 1-based indices
-        .filter((n) => Number.isInteger(n) && n >= 0 && n < articles.length && !used.has(n))
+        .filter((n) => Number.isInteger(n) && n >= 0 && n < pool.length && !used.has(n))
         .slice(0, MAX_SOURCES_PER_CLUSTER);
       if (indices.length === 0) continue;
       indices.forEach((n) => used.add(n));
-      const topic = (typeof c?.topic === 'string' && c.topic.trim()) || articles[indices[0]].title;
+
+      const distinctOutlets = new Set(indices.map((n) => pool[n].source)).size;
+      if (indices.length > 1 && distinctOutlets < 2) {
+        // Single-outlet grab-bag — trust nothing, emit as singletons.
+        indices.forEach((n) => clusters.push({ topic: pool[n].title, indices: [n] }));
+        continue;
+      }
+      const topic = (typeof c?.topic === 'string' && c.topic.trim()) || pool[indices[0]].title;
       clusters.push({ topic: topic.trim(), indices });
     }
 
-    // Any article the model omitted becomes its own singleton so nothing is lost.
-    articles.forEach((a, i) => {
-      if (!used.has(i)) clusters.push({ topic: a.title, indices: [i] });
+    // Any item the model omitted becomes its own singleton so nothing is lost.
+    pool.forEach((p, i) => {
+      if (!used.has(i)) clusters.push({ topic: p.title, indices: [i] });
     });
 
-    console.log(`[fetch-raw-news] clustered ${articles.length} articles into ${clusters.length} topics`);
+    const merged = clusters.filter((c) => c.indices.length > 1).length;
+    console.log(`[fetch-raw-news] ${pool.length} items -> ${clusters.length} cards (${merged} multi-outlet)`);
     return clusters.length > 0 ? clusters : singletons();
   } catch (err) {
     console.error('[fetch-raw-news] clustering error:', err);
@@ -136,90 +278,57 @@ Deno.serve(async (req) => {
 
   try {
     const { page = 1 } = await req.json().catch(() => ({ page: 1 }));
-    const newsApiKey = Deno.env.get('NEWS_API_KEY');
-    if (!newsApiKey) throw new Error('NEWS_API_KEY secret missing');
 
-    // Strategy order (first non-empty wins):
-    //   1. /top-headlines — curated category-filtered feed from major publishers
-    //   2. /top-headlines — different category for variety
-    //   3. /everything   — whitelisted quality sources, sorted by popularity
-    //                      (NOT publishedAt — that's what surfaced the junk)
-    const strategies: { label: string; url: string; category?: string }[] = [
-      {
-        label: 'top-headlines:technology',
-        category: 'Technology',
-        url: `${TOP_HEADLINES_URL}?country=us&category=technology&pageSize=20&page=${page}&apiKey=${newsApiKey}`,
-      },
-      {
-        label: 'top-headlines:business',
-        category: 'Business',
-        url: `${TOP_HEADLINES_URL}?country=us&category=business&pageSize=20&page=${page}&apiKey=${newsApiKey}`,
-      },
-      {
-        label: 'everything:quality-sources',
-        category: 'Technology',
-        url: `${EVERYTHING_URL}?sources=${QUALITY_SOURCES}&excludeDomains=${EXCLUDE_DOMAINS}&sortBy=popularity&language=en&pageSize=20&page=${page}&apiKey=${newsApiKey}`,
-      },
-    ];
-
-    let articles: any[] = [];
-    let chosenCategory = 'Recent News';
-    for (const { label, url, category } of strategies) {
-      try {
-        console.log(`[fetch-raw-news] Trying ${label}`);
-        const response = await fetch(url, {
-          headers: { 'User-Agent': 'YugenStudy/1.0' },
-        });
-        console.log(`[fetch-raw-news] ${label} → ${response.status}`);
-
-        if (!response.ok) {
-          const errText = await response.text();
-          console.error(`[fetch-raw-news] ${label} API error: ${errText}`);
-          continue;
-        }
-
-        const data = await response.json();
-        console.log(`[fetch-raw-news] ${label} totalResults=${data.totalResults}`);
-
-        const filtered = pickValidArticles(data.articles);
-        if (filtered.length > 0) {
-          articles = filtered;
-          chosenCategory = category ?? 'Recent News';
-          console.log(`[fetch-raw-news] ${label} picked ${articles.length} articles`);
-          break;
-        }
-      } catch (fetchErr) {
-        console.error(`[fetch-raw-news] ${label} fetch failed:`, fetchErr);
-      }
-    }
-
-    if (articles.length === 0) {
-      console.error('[fetch-raw-news] All strategies returned 0 articles.');
-      return new Response(JSON.stringify({ articles: [], warning: 'No articles found' }), {
+    // RSS is multi-outlet and fetched fresh each session; it doesn't paginate
+    // like NewsAPI. Serve the full clustered batch on page 1 and signal
+    // end-of-feed for later pages rather than re-fetch/re-cluster (which would
+    // churn ids and surface duplicates).
+    if (page > 1) {
+      return new Response(JSON.stringify({ articles: [] }), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       });
     }
 
     const groqKey = Deno.env.get('GROQ_API_KEY');
-    const clusters = await clusterArticles(articles, groqKey);
 
-    const rawArticles = clusters.map((cluster) => {
-      const sources = cluster.indices.map((i) => articles[i]);
-      const lead = sources[0];
-      // Numbered "Sources" block: process-article reads this as the snippet and
-      // synthesizes the merged material into one coherent Japanese article.
-      const mergedSnippet = sources
-        .map((a, n) => `${n + 1}. ${a.title} — ${snippetText(a) || a.title}`)
+    let pool = await fetchFeeds();
+    if (pool.length === 0) {
+      const newsApiKey = Deno.env.get('NEWS_API_KEY');
+      if (newsApiKey) {
+        console.warn('[fetch-raw-news] RSS empty — falling back to NewsAPI');
+        pool = await fetchNewsApiPool(page, newsApiKey);
+      }
+    }
+
+    if (pool.length === 0) {
+      console.error('[fetch-raw-news] No articles from any source.');
+      return new Response(JSON.stringify({ articles: [], warning: 'No articles found' }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const clusters = await clusterArticles(pool, groqKey);
+
+    const cards = clusters.slice(0, MAX_CARDS).map((cluster) => {
+      const members = cluster.indices.map((i) => pool[i]);
+      const lead = members[0];
+      // The card title is the lead article's real headline — concrete and
+      // trustworthy even when clustering is imperfect — not a model-generated
+      // topic label (which can mislabel a loose merge).
+      const mergedSnippet = members
+        .map((m, n) => `${n + 1}. ${m.title} — ${m.teaser || m.title}`)
         .join('\n');
+      const when = lead.date ? new Date(lead.date) : new Date();
 
       return {
-        id: `${cluster.topic.substring(0, 15)}-${Math.random().toString(36).substring(2, 9)}`,
-        title: cluster.topic,
+        id: `${lead.title.substring(0, 15)}-${Math.random().toString(36).substring(2, 9)}`,
+        title: lead.title,
         originalUrl: lead.url,
-        date: new Date(lead.publishedAt).toLocaleDateString(),
-        readTime: `${Math.min(2 + sources.length, 8)} min read`,
-        category: chosenCategory,
-        sourceCount: sources.length,
+        date: (isNaN(when.getTime()) ? new Date() : when).toLocaleDateString(),
+        readTime: `${Math.min(2 + members.length, 8)} min read`,
+        category: lead.category,
+        sourceCount: members.length,
+        sources: members.map((m) => ({ title: m.title, url: m.url, teaser: m.teaser })),
         blocks: [
           {
             type: 'paragraph',
@@ -229,7 +338,7 @@ Deno.serve(async (req) => {
       };
     });
 
-    return new Response(JSON.stringify({ articles: rawArticles }), {
+    return new Response(JSON.stringify({ articles: cards }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   } catch (err) {

--- a/supabase/functions/fetch-raw-news/index.ts
+++ b/supabase/functions/fetch-raw-news/index.ts
@@ -121,6 +121,13 @@ function isValidItem(it: PoolItem): boolean {
   return true;
 }
 
+// Registrable host, used by the multi-outlet heuristic. Feed *names* aren't
+// enough — "BBC" and "BBC Tech" are different feeds from the same outlet
+// (bbc.com), so they must not count as two outlets.
+function domainOf(url: string): string {
+  try { return new URL(url).host.replace(/^www\./, ''); } catch { return url; }
+}
+
 async function fetchFeeds(): Promise<PoolItem[]> {
   const results = await Promise.allSettled(FEED_LIST.map(async (f) => {
     const ctrl = new AbortController();
@@ -247,7 +254,7 @@ ${headlineList}`;
       if (indices.length === 0) continue;
       indices.forEach((n) => used.add(n));
 
-      const distinctOutlets = new Set(indices.map((n) => pool[n].source)).size;
+      const distinctOutlets = new Set(indices.map((n) => domainOf(pool[n].url))).size;
       if (indices.length > 1 && distinctOutlets < 2) {
         // Single-outlet grab-bag — trust nothing, emit as singletons.
         indices.forEach((n) => clusters.push({ topic: pool[n].title, indices: [n] }));

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -238,8 +238,10 @@ Treat this palette as a GUIDE, not a quota. Never distort the facts or insert un
 You are a factual Japanese news reporter writing a ${levelConfig.paragraphs} paragraph news article for a JLPT ${jlptStr} learner.
 LEVEL GUIDANCE: ${levelConfig.description}
 Topic: ${title}
-Sources (real English news snippets about this topic — synthesize them into ONE coherent article; combine overlapping facts and do not repeat the same point):
+Sources (real English news snippets; the FIRST source is the primary story):
 ${snippet}
+
+SOURCE HANDLING: Build ONE coherent article around the first source as the main story. Where the other sources genuinely concern the same story, combine their overlapping facts and add their detail without repeating points. If a source is about a clearly different or unrelated story, IGNORE it — never stitch unrelated events together into one article.
 
 GOLDEN RULE: The article MUST accurately report only the events described in the Sources above. DO NOT invent facts not present in the Sources, and DO NOT use abstract, poetic, or metaphorical language. Stick to facts.
 ${palettePrompt}

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -10,6 +10,59 @@ const corsHeaders = {
 const GROQ_MODEL = 'openai/gpt-oss-20b';
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
 
+// ── Opportunistic full-text extraction ──────────────────────────────────────
+// A NewsAPI/RSS teaser is ~150-200 chars; the real article body is 10-100x
+// richer. We pull it from the source URL via Jina Reader, but only for sources
+// whose teaser is thin (full-text feeds like Ars already ship the body) and
+// only for articles the user actually opens. Always falls back to the teaser.
+const JINA_READER_URL = 'https://r.jina.ai/';
+const EXTRACT_TEASER_THRESHOLD = 600; // skip extraction when teaser already this long
+const EXTRACT_TIMEOUT_MS = 8000;
+const MAX_EXTRACT_SOURCES = 4;
+const PER_SOURCE_CHAR_CAP = 2500;
+const TOTAL_SOURCE_CHAR_CAP = 7000;
+
+interface SourceRef { title?: string; url?: string; teaser?: string }
+
+async function extractFullText(url: string, jinaKey: string | undefined): Promise<string> {
+  const ctrl = new AbortController();
+  const to = setTimeout(() => ctrl.abort(), EXTRACT_TIMEOUT_MS);
+  try {
+    const headers: Record<string, string> = { 'User-Agent': 'YugenStudy/1.0', 'Accept': 'text/plain' };
+    if (jinaKey) headers['Authorization'] = `Bearer ${jinaKey}`;
+    const res = await fetch(JINA_READER_URL + url, { headers, signal: ctrl.signal });
+    if (!res.ok) return '';
+    const txt = await res.text();
+    // Jina prepends a "Title:/URL Source:/Markdown Content:" header — keep the body.
+    return (txt.split(/Markdown Content:\s*/i).pop() || txt).trim();
+  } catch {
+    return '';
+  } finally {
+    clearTimeout(to);
+  }
+}
+
+// Build the richest source block we can: extracted full text where a teaser is
+// thin and extraction succeeds, teaser otherwise. Returns '' if no sources.
+async function buildSourceBlock(sources: SourceRef[], jinaKey: string | undefined): Promise<string> {
+  const picked = sources.filter((s) => s && (s.teaser || s.url)).slice(0, MAX_EXTRACT_SOURCES);
+  if (picked.length === 0) return '';
+
+  const parts = await Promise.all(picked.map(async (s, n) => {
+    let body = (s.teaser || '').trim();
+    if (s.url && body.length < EXTRACT_TEASER_THRESHOLD) {
+      const full = await extractFullText(s.url, jinaKey);
+      if (full && full.length > body.length) body = full;
+    }
+    body = body.slice(0, PER_SOURCE_CHAR_CAP);
+    return `${n + 1}. ${s.title || ''} — ${body}`.trim();
+  }));
+
+  let block = parts.join('\n\n');
+  if (block.length > TOTAL_SOURCE_CHAR_CAP) block = block.slice(0, TOTAL_SOURCE_CHAR_CAP);
+  return block.trim();
+}
+
 // Approximate number of unique word tokens in a 3-paragraph article.
 // Used to translate intensity ratios into concrete palette counts.
 const WORDS_PER_ARTICLE = 200;
@@ -59,9 +112,9 @@ Deno.serve(async (req) => {
   }
 
   try {
-    const { userId, articleId, title, snippet } = await req.json();
-    if (!userId || !title || !snippet) {
-      return new Response(JSON.stringify({ error: 'userId, title, and snippet are required' }), {
+    const { userId, articleId, title, snippet, sources } = await req.json();
+    if (!userId || !title || !(snippet || (Array.isArray(sources) && sources.length))) {
+      return new Response(JSON.stringify({ error: 'userId, title, and snippet or sources are required' }), {
         status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       });
     }
@@ -70,8 +123,24 @@ Deno.serve(async (req) => {
     const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
     const geminiKey = Deno.env.get('GEMINI_API_KEY')!;
     const groqKey = Deno.env.get('GROQ_API_KEY')!;
+    const jinaKey = Deno.env.get('JINA_API_KEY'); // optional — lifts extraction hit rate
 
     const supabase = createClient(supabaseUrl, supabaseKey);
+
+    // Opportunistically upgrade thin teasers to full article text. Falls back
+    // to the merged teaser block (snippet) when no sources / extraction fails.
+    let sourceText = snippet ?? '';
+    if (Array.isArray(sources) && sources.length > 0) {
+      try {
+        const built = await buildSourceBlock(sources as SourceRef[], jinaKey);
+        if (built) {
+          sourceText = built;
+          console.log(`[process-article] built source block from ${sources.length} source(s), ${built.length} chars`);
+        }
+      } catch (e) {
+        console.warn('[process-article] source extraction failed, using teaser:', e instanceof Error ? e.message : e);
+      }
+    }
 
     // 1. Fetch user preferences
     const { data: prefs } = await supabase
@@ -98,7 +167,7 @@ Deno.serve(async (req) => {
     let newPalette: string[] = [];
     let vocabTargets: string[] = []; // legacy: kept for vocab_mode prompt back-compat
     try {
-      const keywords = await extractKeywordsWithGroq(title, snippet, groqKey);
+      const keywords = await extractKeywordsWithGroq(title, sourceText.slice(0, 2000), groqKey);
       if (keywords.length > 0) {
         const keywordPatterns = keywords.map((k) => `%${k}%`);
         const { data: candidates, error: candErr } = await supabase.rpc('jmdict_vocab_candidates', {
@@ -238,8 +307,8 @@ Treat this palette as a GUIDE, not a quota. Never distort the facts or insert un
 You are a factual Japanese news reporter writing a ${levelConfig.paragraphs} paragraph news article for a JLPT ${jlptStr} learner.
 LEVEL GUIDANCE: ${levelConfig.description}
 Topic: ${title}
-Sources (real English news snippets; the FIRST source is the primary story):
-${snippet}
+Sources (real English news text; the FIRST source is the primary story):
+${sourceText}
 
 SOURCE HANDLING: Build ONE coherent article around the first source as the main story. Where the other sources genuinely concern the same story, combine their overlapping facts and add their detail without repeating points. If a source is about a clearly different or unrelated story, IGNORE it — never stitch unrelated events together into one article.
 

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -173,6 +173,30 @@ Deno.serve(async (req) => {
     // 3. Build Gemini prompts (same logic as client-side rewriteArticleWithGemini)
     const jlptStr = `N${jlptLevel}`;
 
+    const JLPT_LEVEL_CONFIG: Record<number, { description: string; paragraphs: string }> = {
+      5: {
+        description: 'N5: The reader understands some basic Japanese. Write simple sentences using hiragana, katakana, and basic kanji. Basic vocabulary and elementary grammar only.',
+        paragraphs: '3',
+      },
+      4: {
+        description: 'N4: The reader understands basic Japanese. Write about familiar daily topics using basic vocabulary and kanji. Simple compound sentences are acceptable.',
+        paragraphs: '3-4',
+      },
+      3: {
+        description: 'N3: The reader understands everyday Japanese. Write like a real newspaper article — use compound sentences, natural news phrasing, and intermediate grammar. The reader can handle newspaper headlines and slightly difficult text with context. Do NOT over-simplify to basic sentence patterns.',
+        paragraphs: '4-5',
+      },
+      2: {
+        description: 'N2: The reader understands Japanese used in everyday situations and a variety of circumstances. Write like a real newspaper article or commentary — clear, natural prose on general topics at near-natural complexity.',
+        paragraphs: '5-6',
+      },
+      1: {
+        description: 'N1: The reader understands Japanese used in a variety of circumstances. Write with full natural complexity — abstract reasoning, editorials, and nuanced prose are appropriate.',
+        paragraphs: '5-6',
+      },
+    };
+    const levelConfig = JLPT_LEVEL_CONFIG[jlptLevel] ?? JLPT_LEVEL_CONFIG[3];
+
     const HEISIG_RTK_RANGE_SIZE = 15;
     const knownKanjiCount = Math.max(0, rtkLevel - HEISIG_RTK_RANGE_SIZE);
     const studyKanji = rtkKanjiList.slice(knownKanjiCount, rtkLevel);
@@ -211,7 +235,8 @@ Treat this palette as a GUIDE, not a quota. Never distort the facts or insert un
 
     // Pass 1: Rewrite article
     const prompt1 = `
-You are a factual Japanese news reporter writing a 3-paragraph news article for a JLPT ${jlptStr} learner.
+You are a factual Japanese news reporter writing a ${levelConfig.paragraphs} paragraph news article for a JLPT ${jlptStr} learner.
+LEVEL GUIDANCE: ${levelConfig.description}
 News Headline: ${title}
 News Snippet: ${snippet}
 

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -237,10 +237,11 @@ Treat this palette as a GUIDE, not a quota. Never distort the facts or insert un
     const prompt1 = `
 You are a factual Japanese news reporter writing a ${levelConfig.paragraphs} paragraph news article for a JLPT ${jlptStr} learner.
 LEVEL GUIDANCE: ${levelConfig.description}
-News Headline: ${title}
-News Snippet: ${snippet}
+Topic: ${title}
+Sources (real English news snippets about this topic — synthesize them into ONE coherent article; combine overlapping facts and do not repeat the same point):
+${snippet}
 
-GOLDEN RULE: The article MUST accurately report on the exact events of the News Headline. DO NOT use abstract, poetic, or metaphorical language. Stick to facts.
+GOLDEN RULE: The article MUST accurately report only the events described in the Sources above. DO NOT invent facts not present in the Sources, and DO NOT use abstract, poetic, or metaphorical language. Stick to facts.
 ${palettePrompt}
 
 Rules:


### PR DESCRIPTION
## Summary

Fixes thin article content at the root. Gemini was being fed ~150-200 char teasers and padding them into filler; this PR feeds it real, rich source material.

Built and tuned empirically against live RSS/Groq/Jina across this PR's commits:

### 1. Per-JLPT-level prompts (`process-article`)
Level-specific paragraph counts + guidance (N5–N1); N3+ told to write natural newspaper prose, not over-simplify.

### 2. RSS multi-feed discovery (`fetch-raw-news`)
- ~11 free RSS feeds fetched in parallel (~130 fresh items/session, **no API quota**). NewsAPI demoted to fallback.
- Measured rationale: RSS teasers ≈ NewsAPI length, but free unlimited multi-outlet volume means the same story appears across outlets → useful dedup/corroboration.

### 3. Opportunistic full-text extraction (`process-article`)
- Extracts full article body from source URLs via Jina Reader — **only for thin teasers**, only for opened articles, budgeted/capped, teaser fallback.
- Measured: a 109-char teaser → 14,341 chars of real body (capped to 2,500). This is the primary content-quality win (88–135x).
- Optional `JINA_API_KEY` secret roughly doubles the hit rate; works without it.

### 4. Conservative dedup clustering (`fetch-raw-news`)
- **Finding:** LLM headline-clustering over-merges badly at scale (scout produced a 91-item "misc" mega-bucket; 70b swept "Best Movies" into a Pope cluster). Deterministic token-overlap chained transitively. So clustering is now **dedup-only**, not a content mechanism.
- `llama-3.3-70b`, merges capped at 3, single-outlet grab-bags split into singletons, multi-outlet heuristic, lead article's real headline as the card title, and a lead-source guard in `process-article` that ignores unrelated sources.
- Validated: 127 items → 122 cards; only genuine same-story groups merge (NASA across 3 outlets, Pope across 2).

## Deploy notes
- Redeploy **both** `fetch-raw-news` and `process-article`.
- Optional: set `JINA_API_KEY` secret to improve extraction hit rate.
- `GROQ_API_KEY` already required (used by clustering + keyword extraction).

## Verification
Frontend `tsc` passes. Pipeline + extraction validated end-to-end against live RSS, Groq, and Jina (see commit messages for measured numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)