### PR TITLE
Numeric 1-10 word difficulty driving SRS

### DIFF
--- a/database/11_difficulty.sql
+++ b/database/11_difficulty.sql
@@ -1,0 +1,20 @@
+-- 11. Numeric difficulty for word progress
+--
+-- `difficulty` (1..10, 1 = easiest for the user, 10 = hardest) is now the source of
+-- truth for SRS. The legacy `mastery_level` text column is kept in sync and derived
+-- from difficulty (1-3 = easy, 4-7 = medium, 8-10 = hard) so the article-generation
+-- pipeline (process-article) keeps working unchanged.
+
+alter table public.user_word_progress
+  add column if not exists difficulty smallint
+  check (difficulty is null or (difficulty between 1 and 10));
+
+-- Backfill from the existing bucket using each bucket's midpoint.
+update public.user_word_progress
+set difficulty = case mastery_level
+  when 'easy'   then 2
+  when 'medium' then 5
+  when 'hard'   then 9
+  else null            -- 'unseen' (or null) stays ungraded
+end
+where difficulty is null;

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -59,10 +59,9 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     } catch { return null; }
   }, []);
   
-  const { 
-    wordDatabase, saveWordDefinition, recordWordSeen, setWordMastery, setLookupDifficulty,
-    currentArticle, setCurrentArticle, articlesCache, saveProcessedArticle, 
-    srsAutoBumpThreshold,
+  const {
+    wordDatabase, saveWordDefinition, recordWordSeen, setWordMastery, applyDifficultyEvent,
+    currentArticle, setCurrentArticle, articlesCache, saveProcessedArticle,
     readerFontSize, readerFontWeight
   } = useAppStore();
 
@@ -136,23 +135,32 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
   const handleFinishArticle = () => {
     if (hasSweptRef.current) return; // once per article — button or scroll, whichever comes first
     hasSweptRef.current = true;
-    const articleWords = new Set<string>();
+    // Keep the richest token per word (one with details/jmdict id) so we can seed
+    // difficulty from JLPT and store a real entry for never-clicked new words.
+    const articleWords = new Map<string, any>();
     currentArticle?.blocks.forEach(b => {
-      if (b.content) b.content.forEach(w => { if (w.furigana) articleWords.add(w.text); });
+      if (b.content) b.content.forEach(w => {
+        if (!w.furigana) return;
+        const existing = articleWords.get(w.text);
+        if (!existing || (!existing.details && (w.details || w.jmdict_entry_id))) {
+          articleWords.set(w.text, w);
+        }
+      });
     });
 
-    articleWords.forEach(word => {
-      if (!clickedWords.has(word)) {
-        const stats = wordDatabase[word];
-        recordWordSeen(word, true);
-        const newStreak = (stats?.streak || 0) + 1;
-        if (stats && stats.mastery !== 'easy' && newStreak % (srsAutoBumpThreshold || 3) === 0) {
-          setWordMastery(word, stats.mastery === 'hard' ? 'medium' : 'easy');
-        } else if (!stats) {
-          saveWordDefinition(word, { reading: '...', meaning: 'Implicitly parsed context' });
-          setWordMastery(word, 'medium');
-        }
+    articleWords.forEach((token, word) => {
+      if (clickedWords.has(word)) return;
+      const details = token.details as WordDetails | undefined;
+      const jlptLevel = details?.jlptLevel;
+      // Make sure a never-seen word exists before grading it.
+      if (!wordDatabase[word]) {
+        saveWordDefinition(word, details
+          ? { reading: details.reading, meaning: details.meaning, jlptLevel: details.jlptLevel, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id }
+          : { reading: '...', meaning: 'Implicitly parsed context', jmdictEntryId: token.jmdict_entry_id });
       }
+      recordWordSeen(word, true);
+      // Reading past a word without a lookup nudges it toward "known".
+      applyDifficultyEvent(word, 'skip', jlptLevel);
     });
   };
   // Keep the observer pointed at the latest closure every render.
@@ -184,8 +192,8 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     setActiveHighlightId(tokenId);
     setTargetRect(e.currentTarget.getBoundingClientRect());
     saveWordDefinition(details.word, details);
-    // Looking a word up implies difficulty: seed a default grade from its JLPT level.
-    setLookupDifficulty(details.word, details.jlptLevel);
+    // Looking a word up means it wasn't known: nudge its difficulty up.
+    applyDifficultyEvent(details.word, 'click', details.jlptLevel);
 
     if (!merged.grammarNote) {
       fetchWordGrammarInsight(details.word, sentText).then(insight => {
@@ -214,7 +222,7 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     // Self-healing: If we have local data but it's missing important metadata (JLPT or JMDict ID), 
     // we allow the lookup to proceed to enrich the entry.
     if (localData && localData.meaning && localData.meaning !== 'Implicitly parsed context' && localData.jlptLevel && localData.jmdictEntryId) {
-      setLookupDifficulty(word, localData.jlptLevel);
+      applyDifficultyEvent(word, 'click', localData.jlptLevel);
       setSelectedWord({
         word,
         reading: localData.reading,
@@ -277,8 +285,8 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
 
       // Cache initial quick data
       saveWordDefinition(word, combinedInitial);
-      // Now that the JLPT level is known, seed a difficulty default for this lookup.
-      setLookupDifficulty(word, quickDef.jlptLevel);
+      // Now that the JLPT level is known, nudge difficulty up for this lookup.
+      applyDifficultyEvent(word, 'click', quickDef.jlptLevel);
       setIsModalLoading(false);
     } catch (err) {
       console.error("Word lookup failed:", err);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -9,7 +9,6 @@ export function Settings() {
     rtkLevel, setRtkLevel,
     studyMode, setStudyMode,
     readingIntensity, setReadingIntensity,
-    srsAutoBumpThreshold, setSrsAutoBumpThreshold,
     readerFontSize, setReaderFontSize,
     readerFontWeight, setReaderFontWeight
   } = useAppStore();
@@ -312,44 +311,6 @@ export function Settings() {
                 / {rtkKanjiList.length} Kanji<br/>Automatically scales up daily
               </span>
             </div>
-          </div>
-
-          <div style={{ width: '40px', height: '2px', backgroundColor: 'var(--border-light)', marginBottom: '2rem' }} />
-
-          {/* SRS Auto Bump threshold */}
-          <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-main)', marginBottom: '0.75rem' }}>
-            SRS Auto-Bump Threshold
-          </label>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '0.5rem' }}>
-            <input 
-              type="number" 
-              value={srsAutoBumpThreshold} 
-              onChange={(e) => {
-                if (e.target.value === '') {
-                  setSrsAutoBumpThreshold('');
-                  return;
-                }
-                const val = parseInt(e.target.value, 10);
-                if (!isNaN(val) && val > 0) {
-                  setSrsAutoBumpThreshold(val);
-                }
-              }}
-              min={1}
-              style={{
-                padding: '0.75rem',
-                borderRadius: '8px',
-                border: '1px solid var(--border-light)',
-                backgroundColor: 'var(--bg-pure)',
-                color: 'var(--text-main)',
-                fontSize: '1.1rem',
-                width: '80px',
-                textAlign: 'center',
-                fontWeight: 600
-              }}
-            />
-            <span style={{ color: 'var(--text-muted)', fontSize: '0.85rem', lineHeight: 1.4 }}>
-              Consecutive unclicked reads required<br/>to progress a word's mastery level
-            </span>
           </div>
 
           <div style={{ width: '40px', height: '2px', backgroundColor: 'var(--border-light)', margin: '2rem 0' }} />

--- a/src/components/WordModal.tsx
+++ b/src/components/WordModal.tsx
@@ -278,7 +278,12 @@ export function WordModal({
           <div style={{ width: '1px', backgroundColor: 'var(--border-light)' }} />
           <div style={{ flex: 1, textAlign: 'center' }}>
             <div style={{ fontSize: '0.5rem', color: 'var(--text-muted)', fontWeight: 700 }}>RANK</div>
-            <div style={{ fontSize: '0.9rem', fontWeight: 900, color: 'var(--text-main)', marginTop: '0.3rem', textTransform: 'capitalize' }}>{activeMastery}</div>
+            <div style={{ fontSize: '0.9rem', fontWeight: 900, color: 'var(--text-main)', marginTop: '0.3rem', textTransform: 'capitalize' }}>
+              {activeMastery}
+              {stats.difficulty != null && (
+                <span style={{ fontSize: '0.6rem', fontWeight: 700, color: 'var(--text-muted)', marginLeft: '0.3rem' }}>{stats.difficulty}/10</span>
+              )}
+            </div>
           </div>
         </div>
       )

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -322,6 +322,7 @@ export async function fetchUserWordProgress(userId: string): Promise<Record<stri
   data?.forEach(row => {
     progress[row.word_id] = {
       mastery: row.mastery_level,
+      difficulty: row.difficulty ?? null,
       timesSeen: row.times_seen,
       streak: row.streak,
       lastSeenTs: new Date(row.last_seen_at).getTime()
@@ -331,9 +332,9 @@ export async function fetchUserWordProgress(userId: string): Promise<Record<stri
 }
 
 export async function upsertWordProgressToSupabase(
-  userId: string, 
-  wordId: string, 
-  progress: { mastery: string; timesSeen: number; streak: number; lastSeenTs: number }
+  userId: string,
+  wordId: string,
+  progress: { mastery: string; difficulty?: number | null; timesSeen: number; streak: number; lastSeenTs: number }
 ) {
   const { error } = await supabase
     .from('user_word_progress')
@@ -341,6 +342,7 @@ export async function upsertWordProgressToSupabase(
       user_id: userId,
       word_id: wordId,
       mastery_level: progress.mastery,
+      difficulty: progress.difficulty ?? null,
       times_seen: progress.timesSeen,
       streak: progress.streak,
       last_seen_at: new Date(progress.lastSeenTs).toISOString()

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -6,6 +6,41 @@ import { supabase } from './supabase';
 
 export type MasteryLevel = 'unseen' | 'hard' | 'medium' | 'easy';
 
+// Internal difficulty is the source of truth: 1 = easiest for this user, 10 = hardest.
+// The three user-facing buckets (easy/medium/hard) are derived from it so the UI and
+// the article-generation pipeline (which reads mastery_level) stay simple.
+export const DIFFICULTY_MIN = 1;
+export const DIFFICULTY_MAX = 10;
+
+const clampDifficulty = (n: number) =>
+  Math.max(DIFFICULTY_MIN, Math.min(DIFFICULTY_MAX, Math.round(n)));
+
+export function bucketForDifficulty(difficulty: number): Exclude<MasteryLevel, 'unseen'> {
+  if (difficulty <= 3) return 'easy';
+  if (difficulty <= 7) return 'medium';
+  return 'hard';
+}
+
+// Manual selection snaps to the midpoint of the chosen bucket, so a couple of
+// passive nudges stay inside the bucket before crossing into the next one.
+export function difficultyForBucket(level: MasteryLevel): number {
+  switch (level) {
+    case 'easy': return 2;
+    case 'hard': return 9;
+    default: return 5; // medium / unseen
+  }
+}
+
+// Seed an initial difficulty from a word's JLPT level relative to the user's.
+// JLPT numbering: 5 = N5 (easiest) ... 1 = N1 (hardest). A word whose JLPT number
+// is *lower* than the user's level sits above their level => harder for them.
+export function seedDifficulty(jlptLevel: number | null | undefined, userLevel: number | null): number {
+  if (jlptLevel == null) return 9;      // no JLPT data => assume hard
+  if (userLevel == null) return 5;      // unknown user level => neutral
+  const delta = userLevel - jlptLevel;  // >0 => word harder than the user
+  return clampDifficulty(6 + delta * 2);
+}
+
 /**
  * Resolve the current user id for fire-and-forget background syncs.
  * getUser() round-trips to /auth/v1/user on every call; getSession() reads the
@@ -25,7 +60,10 @@ export interface WordData {
   jlptLevel?: number | null;
   pos?: string[];
   jmdictEntryId?: string;
-  mastery: MasteryLevel;
+  mastery: MasteryLevel;          // derived bucket, kept in sync with `difficulty`
+  difficulty?: number | null;     // 1..10 source of truth; null/undefined = unseen
+  lastAdjustedDay?: string;       // YYYY-MM-DD of the last difficulty change (daily dedup)
+  lastAdjustReason?: 'skip' | 'click' | 'manual';
   timesSeen: number;
   uniqueDaysSeen: string[];
   lastSeenTs: number;
@@ -50,7 +88,6 @@ interface AppState {
   processingArticles: string[];
   dismissedArticleIds: string[];
   readArticleIds: string[];
-  srsAutoBumpThreshold: number | '';
   readerFontSize: number;
   readerFontWeight: number;
   
@@ -67,7 +104,6 @@ interface AppState {
   dismissArticle: (id: string) => void;
   markArticleRead: (id: string) => void;
   setProcessing: (id: string, isProcessing: boolean) => void;
-  setSrsAutoBumpThreshold: (count: number | '') => void;
   resetFeedForNewDay: (now: number) => void;
   setReaderFontSize: (size: number) => void;
   setReaderFontWeight: (weight: number) => void;
@@ -75,7 +111,7 @@ interface AppState {
   
   saveWordDefinition: (word: string, def: Partial<WordData>) => void;
   recordWordSeen: (word: string, withoutLookup?: boolean) => void;
-  setLookupDifficulty: (word: string, jlptLevel?: number | null) => void;
+  applyDifficultyEvent: (word: string, event: 'skip' | 'click', jlptLevel?: number | null) => void;
   setWordMastery: (word: string, level: MasteryLevel) => void;
   checkDailyKanji: () => void;
   syncSrsWithSupabase: (userId: string) => Promise<void>;
@@ -100,7 +136,6 @@ export const useAppStore = create<AppState>()(
       processingArticles: [],
       dismissedArticleIds: [],
       readArticleIds: [],
-      srsAutoBumpThreshold: 3,
       readerFontSize: 18,
       readerFontWeight: 500,
 
@@ -170,7 +205,6 @@ export const useAppStore = create<AppState>()(
         dismissedArticleIds: [], 
         lastResetTs: now 
       }),
-      setSrsAutoBumpThreshold: (count) => set({ srsAutoBumpThreshold: count }),
       setReaderFontSize: (size) => set({ readerFontSize: size }),
       setReaderFontWeight: (weight) => set({ readerFontWeight: weight }),
       
@@ -253,35 +287,47 @@ export const useAppStore = create<AppState>()(
           };
         }),
 
-      // When a word is looked up it stops being "unseen" and gets a difficulty
-      // default derived from its JLPT level relative to the user's:
-      //   - harder than the user (or outside JLPT entirely) -> 'hard'
-      //   - at or below the user's level                    -> 'medium'
-      // Only fills in ungraded ('unseen') words; never overrides an explicit grade.
-      setLookupDifficulty: (word: string, jlptLevel?: number | null) =>
+      // A learning event nudges the word's internal difficulty (1..10):
+      //   - 'click' (looked up)        -> +2  (a lookup means it wasn't known)
+      //   - 'skip'  (seen, not looked) -> -1  (read past => a little more familiar)
+      // First encounter seeds difficulty from JLPT relative to the user, then nudges.
+      // Daily dedup: at most one passive adjustment per word per day, except a
+      // 'click' may override an earlier same-day 'skip' once (a lookup is a stronger
+      // signal). The user-facing bucket (mastery) is re-derived from difficulty.
+      applyDifficultyEvent: (word: string, event: 'skip' | 'click', jlptLevel?: number | null) =>
         set((state) => {
           const current = state.wordDatabase[word];
-          if (!current || current.mastery !== 'unseen') return {};
+          if (!current) return {}; // word must be saved first
 
-          // JLPT scale: higher number = easier (5 = N5 ... 1 = N1).
-          const userLevel = state.jlptLevel;
-          let level: MasteryLevel;
-          if (jlptLevel == null) level = 'hard';
-          else if (userLevel == null) level = 'medium';
-          else level = jlptLevel < userLevel ? 'hard' : 'medium';
+          const today = new Date().toISOString().split('T')[0];
+          if (current.lastAdjustedDay === today) {
+            const overrides = event === 'click' && current.lastAdjustReason === 'skip';
+            if (!overrides) return {};
+          }
 
-          const updatedWord = { ...current, mastery: level };
+          const base = current.difficulty ?? seedDifficulty(jlptLevel ?? current.jlptLevel, state.jlptLevel);
+          const difficulty = clampDifficulty(base + (event === 'click' ? 2 : -1));
+          const mastery = bucketForDifficulty(difficulty);
+
+          const updatedWord: WordData = {
+            ...current,
+            difficulty,
+            mastery,
+            lastAdjustedDay: today,
+            lastAdjustReason: event
+          };
 
           currentUserId().then((uid) => {
             if (uid && updatedWord.jmdictEntryId) {
               import('./api').then(m => {
                 m.upsertWordProgressToSupabase(uid, updatedWord.jmdictEntryId!, {
                   mastery: updatedWord.mastery,
+                  difficulty,
                   timesSeen: updatedWord.timesSeen,
                   streak: updatedWord.streak,
                   lastSeenTs: updatedWord.lastSeenTs
                 });
-                m.logStudyEventToSupabase(uid, updatedWord.jmdictEntryId!, 'mastery_change', { level, reason: 'lookup-default' });
+                m.logStudyEventToSupabase(uid, updatedWord.jmdictEntryId!, 'mastery_change', { difficulty, mastery, event });
               });
             }
           });
@@ -294,10 +340,15 @@ export const useAppStore = create<AppState>()(
           };
         }),
 
+      // Explicit user selection in the modal. Snaps difficulty to the bucket
+      // midpoint and always applies (bypasses daily dedup); the manual stamp also
+      // prevents passive sees later that day from overriding the user's call.
       setWordMastery: (word: string, level: MasteryLevel) =>
         set((state) => {
           const current = state.wordDatabase[word] || { reading: '', meaning: '', mastery: 'unseen', timesSeen: 0, uniqueDaysSeen: [], lastSeenTs: 0, streak: 0 };
-          const updatedWord = { ...current, mastery: level };
+          const today = new Date().toISOString().split('T')[0];
+          const difficulty = level === 'unseen' ? null : difficultyForBucket(level);
+          const updatedWord: WordData = { ...current, mastery: level, difficulty, lastAdjustedDay: today, lastAdjustReason: 'manual' };
 
           // Sync to Supabase
           currentUserId().then((uid) => {
@@ -305,12 +356,13 @@ export const useAppStore = create<AppState>()(
               import('./api').then(m => {
                 const syncData = {
                   mastery: updatedWord.mastery,
+                  difficulty,
                   timesSeen: updatedWord.timesSeen,
                   streak: updatedWord.streak,
                   lastSeenTs: updatedWord.lastSeenTs
                 };
                 m.upsertWordProgressToSupabase(uid, updatedWord.jmdictEntryId!, syncData);
-                m.logStudyEventToSupabase(uid, updatedWord.jmdictEntryId!, 'mastery_change', { level });
+                m.logStudyEventToSupabase(uid, updatedWord.jmdictEntryId!, 'mastery_change', { level, difficulty });
               });
             }
           });
@@ -383,17 +435,29 @@ export const useAppStore = create<AppState>()(
     }),
     {
       name: 'yugen-storage',
-      version: 2,
+      version: 3,
       migrate: (persistedState: any, version: number) => {
+        let state = persistedState;
         if (version < 2) {
-          return {
-            ...persistedState,
+          state = {
+            ...state,
             processingArticles: [],
             dismissedArticleIds: [],
             currentArticle: null
           };
         }
-        return persistedState;
+        // v3: seed the numeric `difficulty` from the legacy mastery bucket.
+        if (version < 3 && state?.wordDatabase) {
+          const wordDatabase = { ...state.wordDatabase };
+          Object.keys(wordDatabase).forEach((key) => {
+            const w = wordDatabase[key];
+            if (w && w.difficulty == null && w.mastery && w.mastery !== 'unseen') {
+              wordDatabase[key] = { ...w, difficulty: difficultyForBucket(w.mastery) };
+            }
+          });
+          state = { ...state, wordDatabase };
+        }
+        return state;
       },
       onRehydrateStorage: () => (state) => {
         // Post-hydration cleanup


### PR DESCRIPTION
## Summary
Replaces the conflated `easy/medium/hard` mastery grade with an internal **1–10 difficulty** as the source of truth (1 = easiest for the user, 10 = hardest). The three user-facing buckets are now *derived* (1–3 easy, 4–7 medium, 8–10 hard) and still synced to `mastery_level`, so the `process-article` palette logic keeps working unchanged.

### Fixes the original bug
A word **seen but not clicked** used to get a flat `medium` regardless of difficulty. Now first encounter **seeds difficulty from JLPT** relative to the user's level, then applies the event nudge — easy words drift to easy, hard words stay hard.

### Behavior
- **Skip** (read past, no lookup) → **−1**; **Click** (looked up) → **+2**; clamped 1–10.
- **Daily dedup**: at most one passive adjustment per word per day; a click may override an earlier same-day skip once. Retires the old `streak % N` auto-bump and the **SRS Auto-Bump Threshold** setting.
- **Manual selection** snaps to the bucket midpoint (easy 2 / medium 5 / hard 9) and always applies.
- **WordModal** shows the raw `N/10` next to the rank.

### Files
- `src/services/store.ts` — difficulty model, helpers (`bucketForDifficulty`, `difficultyForBucket`, `seedDifficulty`), `applyDifficultyEvent`, persist migration v3 (backfills local cache)
- `src/components/Reader.tsx` — end-of-article sweep + lookup events
- `src/components/WordModal.tsx` — `N/10` display
- `src/components/Settings.tsx` — removed the SRS Auto-Bump setting
- `src/services/api.ts` — round-trips the new `difficulty` column
- `database/11_difficulty.sql` — adds `difficulty smallint` (1..10 check) + backfill

## Database
Migration **already applied** to the live project. Backfill verified — easy→2 (3 rows), medium→5 (5), hard→9 (17), unseen→null (1).

## Testing
`npm run build` (tsc + vite) passes clean. Remaining `npm run lint` errors are pre-existing repo-wide `any`/`const` issues unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)