### PR TITLE
Fix articles stuck after interrupted processing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,8 +39,8 @@ function App() {
   const markArticleRead = useAppStore(state => state.markArticleRead);
   const [failedArticleIds, setFailedArticleIds] = useState<Set<string>>(new Set());
 
-  const handleProcessArticle = useCallback(async (article: NewsArticle) => {
-    if (!article.id || articlesCache[article.id] || (processingArticles || []).includes(article.id) || failedArticleIds.has(article.id)) return;
+  const handleProcessArticle = useCallback(async (article: NewsArticle): Promise<NewsArticle | null> => {
+    if (!article.id || articlesCache[article.id] || (processingArticles || []).includes(article.id) || failedArticleIds.has(article.id)) return null;
 
     setProcessing(article.id, true);
     try {
@@ -61,12 +61,16 @@ function App() {
         article.sources,
         () => {}
       );
-      saveProcessedArticle(article.id, { ...article, blocks: processedBlocks });
+      const processed = { ...article, blocks: processedBlocks };
+      saveProcessedArticle(article.id, processed);
+      setProcessing(article.id, false);
+      return processed;
     } catch (e) {
       console.error('[process] Failed for article:', article.id, article.title, e);
       setFailedArticleIds(prev => new Set(prev).add(article.id));
     }
     setProcessing(article.id, false);
+    return null;
   }, [articlesCache, processingArticles, setProcessing, saveProcessedArticle, failedArticleIds]);
 
   const replenishFeedAtBottom = useCallback(async () => {
@@ -203,17 +207,14 @@ function App() {
   }, []);
 
   const loadGlobalCache = async (userId: string) => {
-    // Skip if we already have cached articles from localStorage (Zustand persist)
-    const existingCache = useAppStore.getState().articlesCache;
-    if (Object.keys(existingCache).length > 0) {
-      console.log(`[App] Skipping Supabase cache fetch — ${Object.keys(existingCache).length} articles already in local state`);
-      return;
-    }
     const { fetchCachedArticlesFromSupabase } = await import('./services/api');
-    const cache = await fetchCachedArticlesFromSupabase(userId);
-    if (Object.keys(cache).length > 0) {
-      useAppStore.getState().setArticlesCache(cache);
-    }
+    const serverCache = await fetchCachedArticlesFromSupabase(userId);
+    if (Object.keys(serverCache).length === 0) return;
+    // Merge server-side completions (e.g. an article that finished processing
+    // after the app was closed) into the local cache. Local copies win on
+    // overlap so we don't clobber anything saved this session.
+    const existingCache = useAppStore.getState().articlesCache;
+    useAppStore.getState().setArticlesCache({ ...serverCache, ...existingCache });
   };
 
   const checkMidnightReset = useCallback(() => {
@@ -300,23 +301,46 @@ function App() {
 
   // Removed: syncPrefetchQueue useEffect - the daily-feed Edge Function handles background processing
 
-  const handleSelectArticle = (article: NewsArticle) => {
+  const openReader = useCallback((article: NewsArticle) => {
+    setActiveArticle(article);
+    setNewsView('reading');
+    setShowNav(true);
+    window.scrollTo(0, 0);
+    setTimeout(() => replenishFeedAtBottom(), 500);
+  }, [replenishFeedAtBottom]);
+
+  const handleSelectArticle = async (article: NewsArticle) => {
     if (!article.id) return;
     // Reading marks the article read (so it's never pulled back in as a fresh
     // suggestion) but does NOT remove it from the visible feed — the user
     // dismisses it manually when they're done with it.
     markArticleRead(article.id);
     useAppStore.getState().setCurrentArticle(null);
+
     if (articlesCache[article.id]) {
-      setActiveArticle(articlesCache[article.id]);
-      setNewsView('reading');
-      setShowNav(true);
-      window.scrollTo(0, 0);
-      setTimeout(() => replenishFeedAtBottom(), 500);
-    } else {
-      // Not yet cached — request on-demand server-side processing
-      handleProcessArticle(article);
+      openReader(articlesCache[article.id]);
+      return;
     }
+
+    // Not in the local cache. It may have finished processing on the server
+    // while the app was closed — pull it down before starting a fresh run.
+    let userId = 'dev-user';
+    if (!DEV_MODE) {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.user) return;
+      userId = session.user.id;
+    }
+    const { fetchProcessedArticleById } = await import('./services/api');
+    const fromServer = await fetchProcessedArticleById(article.id, userId);
+    if (fromServer) {
+      saveProcessedArticle(article.id, fromServer);
+      openReader(fromServer);
+      return;
+    }
+
+    // Genuinely not processed yet — process on demand, then open the Reader.
+    const processed = await handleProcessArticle(article);
+    if (processed) openReader(processed);
   };
 
   const handleDismissAndSync = (id: string) => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -103,6 +103,22 @@ export async function saveProcessedArticleToSupabase(article: NewsArticle, userI
   if (error) console.error("Error syncing to Supabase:", error);
 }
 
+/** Fetch a single processed article by id — used to recover articles that
+ *  finished processing server-side while the app was closed. */
+export async function fetchProcessedArticleById(articleId: string, userId: string): Promise<NewsArticle | null> {
+  const { data, error } = await supabase
+    .from('processed_news')
+    .select('content')
+    .eq('id', articleId)
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error) {
+    console.error('Error fetching processed article:', error);
+    return null;
+  }
+  return (data?.content as NewsArticle) ?? null;
+}
+
 export async function fetchCachedArticlesFromSupabase(userId: string): Promise<Record<string, NewsArticle>> {
   const { data, error } = await supabase
     .from('processed_news')

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -460,8 +460,13 @@ export const useAppStore = create<AppState>()(
         return state;
       },
       onRehydrateStorage: () => (state) => {
-        // Post-hydration cleanup
-        if (state && !Array.isArray(state.processingArticles)) state.processingArticles = [];
+        // Post-hydration cleanup.
+        // `processingArticles` tracks in-flight, in-memory processing calls that
+        // cannot survive a reload — any entry present at hydration time is stale
+        // (the app closed mid-processing). Always clear it, otherwise the stale
+        // flag makes handleProcessArticle() / the JIT pre-processor treat the
+        // article as "already processing" and silently refuse to retry it.
+        if (state) state.processingArticles = [];
         if (state && !Array.isArray(state.dismissedArticleIds)) state.dismissedArticleIds = [];
         if (state && !Array.isArray(state.readArticleIds)) state.readArticleIds = [];
       }


### PR DESCRIPTION
## Problem

Two related bugs around article processing when the app is closed mid-load:

1. **Interrupted articles became permanently stuck.** If processing was in flight when the app closed, clicking the article after reopening did nothing — it would never start processing again.
2. **Articles that finished server-side while the app was closed didn't show as loaded** on reopen.

## Root causes & fixes

- **Stale `processingArticles` flag (the "click does nothing" bug).** The Zustand store has no `partialize`, so `processingArticles` is persisted to localStorage. `onRehydrateStorage` only type-checked it and never cleared it, so an id left over from an interrupted run permanently tripped `handleProcessArticle`'s guard (and the JIT pre-processor), refusing to retry. → Always reset `processingArticles` to `[]` on rehydrate; in-flight processing is in-memory and cannot survive a reload, so any entry present at startup is stale by definition.

- **`loadGlobalCache` skipped the DB fetch.** It short-circuited whenever localStorage held any cached article, so an article that completed processing server-side after the app closed was never pulled into the local cache. → Always fetch and **merge** the Supabase cache (local copies win on overlap).

- **`handleSelectArticle` never navigated.** Clicking an uncached article fired background processing and stayed on the feed, so it looked like nothing happened. → Now it looks up a server-completed copy first (new `fetchProcessedArticleById`), then opens the Reader once the article is ready (`handleProcessArticle` now returns the processed article).

## Verification

Drove the running app in a browser:
- Injected a stale `processingArticles` entry (simulating a force-close mid-processing), reloaded → in-memory store cleared it to `[]`.
- Confirmed the previously-stuck article now passes the process guard, and `setProcessing` add/remove still works for normal in-session tracking.
- Zero console errors on load; `tsc --noEmit` clean.

Not verified end-to-end: the full live processing round-trip (real auth → Gemini → Reader), which needs `VITE_DEV_MODE`/credentials and was out of scope for this client-side state-machine fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)