### PR TITLE
Frequency-rank words to prioritize common vocabulary for study

### DIFF
--- a/database/10_reading_intensity.sql
+++ b/database/10_reading_intensity.sql
@@ -44,13 +44,17 @@ RETURNS TABLE (
   jlpt_level  SMALLINT,
   kanji       TEXT,
   kana        TEXT,
-  is_common   BOOLEAN
+  is_common   BOOLEAN,
+  freq_rank   SMALLINT
 )
 LANGUAGE sql
 STABLE
 AS $$
+  -- Keep the most frequent matches when capping at max_results: order by
+  -- freq_rank (1 = most common, NULL = rare/unranked) BEFORE the LIMIT so common
+  -- candidates are never arbitrarily dropped before the app can prioritize them.
   WITH matched_entries AS (
-    SELECT DISTINCT e.id, e.jlpt_level, e.common
+    SELECT DISTINCT e.id, e.jlpt_level, e.common, e.freq_rank
     FROM public.jmdict_senses s
     JOIN public.jmdict_entries e ON e.id = s.entry_id
     WHERE e.jlpt_level IS NOT NULL
@@ -59,6 +63,7 @@ AS $$
         SELECT 1 FROM unnest(s.gloss) g
         WHERE g ILIKE ANY(keywords)
       )
+    ORDER BY e.common DESC, e.freq_rank ASC NULLS LAST
     LIMIT max_results
   )
   SELECT
@@ -70,7 +75,8 @@ AS $$
     (SELECT ka.text FROM public.jmdict_kana ka
        WHERE ka.entry_id = m.id
        ORDER BY ka.common DESC, ka.id ASC LIMIT 1) AS kana,
-    m.common                                 AS is_common
+    m.common                                 AS is_common,
+    m.freq_rank                              AS freq_rank
   FROM matched_entries m;
 $$;
 

--- a/database/10_reading_intensity.sql
+++ b/database/10_reading_intensity.sql
@@ -34,6 +34,10 @@ ALTER TABLE public.user_preferences
 --    and is excluded from the candidate pool (we don't suggest rare
 --    vocab to learners).
 
+-- DROP first: CREATE OR REPLACE cannot change a function's return columns, and
+-- this revision adds freq_rank to the RETURNS TABLE.
+DROP FUNCTION IF EXISTS public.jmdict_vocab_candidates(TEXT[], INT, INT);
+
 CREATE OR REPLACE FUNCTION public.jmdict_vocab_candidates(
   keywords     TEXT[],
   user_jlpt    INT,

--- a/database/12_word_frequency.sql
+++ b/database/12_word_frequency.sql
@@ -1,0 +1,28 @@
+-- 12. Word frequency rank for JMDict entries
+--
+-- jmdict-simplified (our import source) collapses JMDict's priority info into a
+-- single `common` boolean and discards the granular frequency bands. The original
+-- EDRDG JMdict_e.xml keeps them as `<ke_pri>/<re_pri>` codes, including the
+-- `nf01`..`nf48` frequency-of-use bands (groups of 500 words by descending
+-- newspaper frequency: nf01 = the 500 most frequent words, nf48 = ranks ~23.5k-24k).
+--
+-- `freq_rank` stores the best (lowest) nf band across an entry's kanji/kana forms:
+--   1   = most common (nf01)
+--   48  = least common ranked band (nf48)
+--   NULL = no nf band (long-tail / rarer word, or only ichi/spec/gai priority)
+--
+-- The entry's JMDict sequence number (`<ent_seq>`) equals our `jmdict_entries.id`,
+-- so this is backfilled by `scripts/import_word_frequency.cjs` via an exact-id
+-- UPDATE -- no re-import of kanji/kana/senses needed.
+--
+-- The existing `common` boolean is kept as a coarse fallback: words that are
+-- common but carry no nf band (some ichi/spec/gai entries) stay common=true with
+-- freq_rank=NULL, so consumers sort `common DESC, freq_rank ASC NULLS LAST`.
+
+alter table public.jmdict_entries
+  add column if not exists freq_rank smallint
+  check (freq_rank is null or (freq_rank between 1 and 48));
+
+-- Frequent words are pulled first for study; index supports ASC NULLS LAST ordering.
+create index if not exists idx_jmdict_entries_freq_rank
+  on public.jmdict_entries (freq_rank asc nulls last);

--- a/scripts/import_jmdict.cjs
+++ b/scripts/import_jmdict.cjs
@@ -49,7 +49,9 @@ if (!SUPABASE_URL || !SUPABASE_KEY) {
 }
 
 // ─── Config ──────────────────────────────────────────────────
-const DOWNLOAD_URL = 'https://github.com/scriptin/jmdict-simplified/releases/latest/download/jmdict-eng-3.6.2+20260406125001.json.tgz';
+// Asset filenames are version-stamped, so the /latest/download/ alias 404s once a
+// new release ships. Update this when bumping versions (see the project's releases).
+const DOWNLOAD_URL = 'https://github.com/scriptin/jmdict-simplified/releases/download/3.6.2%2B20260525143653/jmdict-eng-3.6.2%2B20260525143653.json.tgz';
 const TMP_DIR = path.resolve(__dirname, '..', 'tmp');
 const TGZ_PATH = path.join(TMP_DIR, 'jmdict-eng.json.tgz');
 const BATCH_SIZE = 500;

--- a/scripts/import_word_frequency.cjs
+++ b/scripts/import_word_frequency.cjs
@@ -1,0 +1,197 @@
+/**
+ * Word Frequency Backfill
+ *
+ * jmdict-simplified discards JMDict's frequency bands (it keeps only a `common`
+ * boolean). This script reads the granular `nf01`..`nf48` frequency-of-use bands
+ * from the ORIGINAL EDRDG JMdict_e.xml, computes the best (lowest) band per entry,
+ * and backfills `jmdict_entries.freq_rank` by an exact id match.
+ *
+ * The XML's <ent_seq> equals jmdict_entries.id, so this is a pure UPDATE -- it does
+ * NOT touch jmdict_kanji / jmdict_kana / jmdict_senses. Run the regular
+ * scripts/import_jmdict.cjs FIRST so the entries exist, and apply
+ * database/12_word_frequency.sql so the column exists.
+ *
+ * Requirements:
+ *   - SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in .env (service role bypasses RLS)
+ *
+ * Usage:
+ *   node scripts/import_word_frequency.cjs
+ */
+
+const https = require('https');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+
+// ─── Load .env ───────────────────────────────────────────────
+const envPath = path.resolve(__dirname, '..', '.env');
+if (fs.existsSync(envPath)) {
+  const envContent = fs.readFileSync(envPath, 'utf8');
+  envContent.split('\n').forEach(line => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) return;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) return;
+    const key = trimmed.slice(0, eqIdx).trim();
+    let val = trimmed.slice(eqIdx + 1).trim();
+    if ((val.startsWith("'") && val.endsWith("'")) || (val.startsWith('"') && val.endsWith('"'))) {
+      val = val.slice(1, -1);
+    }
+    process.env[key] = val;
+  });
+}
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('❌ Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env');
+  console.error('   The service role key is required to bypass RLS for the UPDATE.');
+  process.exit(1);
+}
+
+// ─── Config ──────────────────────────────────────────────────
+// EDRDG distributes the English-only gzipped XML over plain HTTP from its ftp mirror.
+const DOWNLOAD_URL = 'http://ftp.edrdg.org/pub/Nihongo/JMdict_e.gz';
+const TMP_DIR = path.resolve(__dirname, '..', 'tmp');
+const GZ_PATH = path.join(TMP_DIR, 'JMdict_e.gz');
+const BATCH_SIZE = 500;
+
+// ─── HTTP Helpers ────────────────────────────────────────────
+function download(url, dest) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    const doRequest = (reqUrl) => {
+      const lib = reqUrl.startsWith('https') ? https : http;
+      lib.get(reqUrl, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          doRequest(res.headers.location);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${res.statusCode} for ${reqUrl}`));
+          return;
+        }
+        res.pipe(file);
+        file.on('finish', () => file.close(resolve));
+      }).on('error', reject);
+    };
+    doRequest(url);
+  });
+}
+
+// Upsert with merge-duplicates: only `id` and `freq_rank` are sent, so PostgREST
+// updates freq_rank on conflict and leaves every other column (e.g. `common`) intact.
+function supabaseUpsert(rows) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify(rows);
+    const url = new URL('/rest/v1/jmdict_entries?on_conflict=id', SUPABASE_URL);
+    const options = {
+      method: 'POST',
+      hostname: url.hostname,
+      port: url.port || 443,
+      path: url.pathname + url.search,
+      headers: {
+        'Content-Type': 'application/json',
+        'apikey': SUPABASE_KEY,
+        'Authorization': `Bearer ${SUPABASE_KEY}`,
+        'Prefer': 'resolution=merge-duplicates,return=minimal',
+        'Content-Length': Buffer.byteLength(body)
+      }
+    };
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', c => data += c);
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) resolve(data);
+        else reject(new Error(`Supabase ${res.statusCode}: ${data}`));
+      });
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+async function batchUpsert(rows) {
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    const batch = rows.slice(i, i + BATCH_SIZE);
+    await supabaseUpsert(batch);
+    process.stdout.write(`\r   upserted ${Math.min(i + BATCH_SIZE, rows.length)}/${rows.length}`);
+  }
+  process.stdout.write('\n');
+}
+
+// ─── XML parsing ─────────────────────────────────────────────
+// Pull the lowest nf## band out of one <entry>...</entry> block.
+const SEQ_RE = /<ent_seq>(\d+)<\/ent_seq>/;
+const NF_RE = /<(?:ke|re)_pri>nf(\d{2})<\/(?:ke|re)_pri>/g;
+
+function parseEntry(block, out) {
+  const seqM = block.match(SEQ_RE);
+  if (!seqM) return;
+  let min = 99;
+  let m;
+  NF_RE.lastIndex = 0;
+  while ((m = NF_RE.exec(block)) !== null) {
+    const n = parseInt(m[1], 10);
+    if (n < min) min = n;
+  }
+  if (min === 99) return; // no nf band on this entry
+  out.push({ id: seqM[1], freq_rank: min });
+}
+
+// Stream the gunzipped XML and split on </entry> so we never hold the whole file.
+function parseFrequencies(gzPath) {
+  return new Promise((resolve, reject) => {
+    const out = [];
+    let buffer = '';
+    const stream = fs.createReadStream(gzPath).pipe(zlib.createGunzip());
+    stream.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+      let idx;
+      while ((idx = buffer.indexOf('</entry>')) !== -1) {
+        parseEntry(buffer.slice(0, idx), out);
+        buffer = buffer.slice(idx + '</entry>'.length);
+      }
+    });
+    stream.on('end', () => resolve(out));
+    stream.on('error', reject);
+  });
+}
+
+// ─── Main ────────────────────────────────────────────────────
+async function main() {
+  console.log('🔷 JMDict Word Frequency Backfill');
+  console.log('──────────────────────────────────');
+
+  if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR, { recursive: true });
+
+  if (fs.existsSync(GZ_PATH)) {
+    console.log('📦 Using cached download at', GZ_PATH);
+  } else {
+    console.log('⬇️  Downloading JMdict_e.xml.gz from EDRDG...');
+    await download(DOWNLOAD_URL, GZ_PATH);
+    console.log('✅ Downloaded to', GZ_PATH);
+  }
+
+  console.log('📄 Parsing frequency bands (streaming)...');
+  const updates = await parseFrequencies(GZ_PATH);
+  console.log(`📊 ${updates.length} entries carry an nf## frequency band`);
+
+  // Sanity: show the band distribution so a bad parse is obvious.
+  const byBand = {};
+  for (const u of updates) byBand[u.freq_rank] = (byBand[u.freq_rank] || 0) + 1;
+  console.log(`   nf01: ${byBand[1] || 0}, nf24: ${byBand[24] || 0}, nf48: ${byBand[48] || 0} (each band holds ≤500)`);
+
+  console.log('\n📤 Backfilling jmdict_entries.freq_rank...');
+  await batchUpsert(updates);
+
+  console.log('\n🎉 Done. Entries without an nf band keep freq_rank = NULL.');
+}
+
+main().catch(err => {
+  console.error('\n❌ Backfill failed:', err.message);
+  process.exit(1);
+});

--- a/scripts/import_word_frequency.cjs
+++ b/scripts/import_word_frequency.cjs
@@ -35,7 +35,13 @@ if (fs.existsSync(envPath)) {
     if (eqIdx === -1) return;
     const key = trimmed.slice(0, eqIdx).trim();
     let val = trimmed.slice(eqIdx + 1).trim();
-    if ((val.startsWith("'") && val.endsWith("'")) || (val.startsWith('"') && val.endsWith('"'))) {
+    // Strip surrounding quotes, repeatedly, to tolerate double-wrapped values
+    // like "'https://...'" (outer " then inner ').
+    while (
+      val.length >= 2 &&
+      ((val[0] === "'" && val[val.length - 1] === "'") ||
+        (val[0] === '"' && val[val.length - 1] === '"'))
+    ) {
       val = val.slice(1, -1);
     }
     process.env[key] = val;

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -188,9 +188,15 @@ Deno.serve(async (req) => {
           progressMap = new Map((progress ?? []).map((p: any) => [p.word_id, p.mastery_level]));
         }
 
-        // Sort candidates: common words first, then by jlpt_level (easier first).
+        // Sort candidates so the most useful words win the per-bucket slice below:
+        // common first, then by frequency rank (1 = most common, NULL = rare/unranked),
+        // then by jlpt_level (easier first). Feeds the known/review/new buckets alike,
+        // so frequent words are prioritized for study, not just for new introductions.
         const sorted = [...(candidates ?? [])].sort((a: any, b: any) => {
           if (a.is_common !== b.is_common) return a.is_common ? -1 : 1;
+          const fa = a.freq_rank ?? Infinity;
+          const fb = b.freq_rank ?? Infinity;
+          if (fa !== fb) return fa - fb;
           return (b.jlpt_level ?? 0) - (a.jlpt_level ?? 0);
         });
 
@@ -233,8 +239,17 @@ Deno.serve(async (req) => {
         .limit(30);
       const ids = (wordProgress as any[])?.map((r) => r.word_id) ?? [];
       if (ids.length > 0) {
-        const shuffled = [...ids].sort(() => 0.5 - Math.random()).slice(0, 5);
-        const { data: kanjiRes } = await supabase.from('jmdict_kanji').select('text').in('entry_id', shuffled);
+        // Pull the most common review words first (freq_rank 1 = most common,
+        // NULL = rare/unranked) instead of a random sample.
+        const { data: freqRows } = await supabase
+          .from('jmdict_entries')
+          .select('id, freq_rank')
+          .in('id', ids);
+        const rankMap = new Map((freqRows as any[] ?? []).map((r) => [r.id, r.freq_rank]));
+        const ranked = [...ids]
+          .sort((a, b) => (rankMap.get(a) ?? Infinity) - (rankMap.get(b) ?? Infinity))
+          .slice(0, 5);
+        const { data: kanjiRes } = await supabase.from('jmdict_kanji').select('text').in('entry_id', ranked);
         if (kanjiRes) vocabTargets = Array.from(new Set(kanjiRes.map((r: any) => r.text)));
       }
     }


### PR DESCRIPTION
## Why
Word-study prioritization previously had no sense of how *common* a word is. jmdict-simplified (our import source) collapses JMDict's priority info into a single `common` boolean and discards the granular frequency bands, so a top-500 word and a ~12,000th-ranked word looked identical to the selection logic.

## What
Adds a real frequency rank and uses it to order which words get pulled for study — both new introductions **and** reviews.

- **`database/12_word_frequency.sql`** — new `jmdict_entries.freq_rank` column (`nf01`..`nf48`, i.e. 1 = most common; `NULL` = rare/unranked) + index.
- **`scripts/import_word_frequency.cjs`** — backfills `freq_rank` from EDRDG's original `JMdict_e.gz`, which (unlike jmdict-simplified) keeps the `nf##` frequency bands. Joined to existing entries by exact `ent_seq` = `id`, so no re-import of kanji/kana/senses. Streaming parser validated against the live file: 22,434 ranked entries, every band ≤500.
- **`database/10_reading_intensity.sql`** — `jmdict_vocab_candidates` returns `freq_rank` and orders the candidate CTE by `common, freq_rank` **before** its `LIMIT`, so common words aren't arbitrarily dropped at the cap. (Includes a `DROP FUNCTION` since the return type changed.)
- **`process-article/index.ts`** — candidate sort and the topic-independent review fallback now order by `freq_rank` (the fallback was a random shuffle), prioritizing common words for study.
- **`scripts/import_jmdict.cjs`** — drive-by fix for the stale (404-ing) release URL.

Scope: data + selection ordering only. SRS `difficulty`/`seedDifficulty` deliberately untouched (commonness drives *what to study*, not *how hard* a word is).

## Deploy (already run against Supabase)
1. `database/12_word_frequency.sql`
2. `database/10_reading_intensity.sql`
3. `node scripts/import_word_frequency.cjs` (22,434 entries backfilled)
4. `supabase functions deploy process-article`

## Caveat
The `nf` bands cover the ~22k most frequent words and are newspaper-derived — well-matched to a news-reading app. Words outside that set get `freq_rank = NULL` and fall back to the existing `common` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)