### PR TITLE
fix: stop processed_news select('*') from saturating IOPS and timing out lookups

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -20,10 +20,20 @@
 - [/] Polish & Testing
   - [/] Ensure "Zen-like" aesthetics (animations, typography)
   - [ ] Final visual QA against reference images
-- [/] DB performance: Progress "discover" query overload (2026-05-31)
+- [x] DB incident: app-wide lookup/processing timeouts (2026-05-31, resolved)
+  - Root cause (two compounding afternoon changes, fine in the morning):
+    1. PR #26 Progress `get_unseen_common_words` — full-corpus query that
+       refetch-stormed and ran unbounded (acute trigger).
+    2. PR #24 `freq_rank` backfill left ~31.5k dead tuples in `jmdict_entries`,
+       sitting just under autovacuum's 20% trigger so it never cleaned —
+       bloating every corpus read on the cache-starved free-tier instance (drag).
+    - NOT the plan tier: it ran fine before either change shipped.
   - [x] Optimize get_unseen_common_words RPC (order+limit before per-row LATERAL lookups) — database/14
   - [x] Frontend: send only active-level seen words; stop refetch-on-every-word; add RPC timeout
   - [x] Surface silent failures (article tap banner, lookup timeout message)
-  - [ ] Monitor DB IOwait/memory post-fix (was ~74% IOwait, ~1% free RAM on small tier);
-        upgrade compute one tier if spikes persist when visiting Progress
-  - [ ] Confirm FK indexes from database/06 exist in prod (verification query in database/14)
+  - [x] Confirmed FK indexes from database/06 exist in prod (all present)
+  - [x] Reclaimed jmdict_entries bloat: VACUUM (FULL, ANALYZE) → 0 dead tuples
+  - [x] import_word_frequency.cjs now prints a VACUUM reminder after backfill
+  - [ ] Only if spikes recur under real concurrent load: revisit `jmdict_vocab_candidates`
+        (full jmdict_senses scan w/ ILIKE ANY on gloss, runs per process-article) or
+        bump compute. Not needed as of resolution.

--- a/docs/task.md
+++ b/docs/task.md
@@ -34,6 +34,15 @@
   - [x] Confirmed FK indexes from database/06 exist in prod (all present)
   - [x] Reclaimed jmdict_entries bloat: VACUUM (FULL, ANALYZE) → 0 dead tuples
   - [x] import_word_frequency.cjs now prints a VACUUM reminder after backfill
+  - Recurrence (same day): lookups kept timing out after the above. 24h Observability
+    showed an idle DB that spiked Disk IOPS into the instance ceiling + 13MB/s network
+    only on app use. Cause: PR #23 removed the skip-if-cached guard in `loadGlobalCache`,
+    so `fetchCachedArticlesFromSupabase` ran `select('*')` over the user's ENTIRE
+    `processed_news` history (full `content` JSONB) on every session change. The cold
+    read pegged IOPS and starved concurrent word lookups into statement timeouts.
+  - [x] Bound it: fetch only `id, content` for the 30 most recent articles
+    (order by created_at desc). Older articles still open on demand via
+    fetchProcessedArticleById. Keeps PR #23's server-completion behavior.
   - [ ] Only if spikes recur under real concurrent load: revisit `jmdict_vocab_candidates`
         (full jmdict_senses scan w/ ILIKE ANY on gloss, runs per process-article) or
         bump compute. Not needed as of resolution.

--- a/scripts/import_word_frequency.cjs
+++ b/scripts/import_word_frequency.cjs
@@ -195,6 +195,16 @@ async function main() {
   await batchUpsert(updates);
 
   console.log('\n🎉 Done. Entries without an nf band keep freq_rank = NULL.');
+
+  // This backfill is a bulk UPDATE, which leaves ~one dead tuple per updated row
+  // in jmdict_entries. autovacuum only fires at ~20% dead tuples, so a backfill
+  // of ~22k rows on a ~216k-row table stays UNDER the trigger and never gets
+  // cleaned automatically — the bloat then drags every corpus query (it caused an
+  // app-wide IOwait/timeout incident on 2026-05-31). Reclaim it by hand:
+  console.log('\n⚠️  IMPORTANT: this bulk UPDATE leaves dead tuples that autovacuum');
+  console.log('   will NOT clear (under its 20% threshold). Run this in the Supabase');
+  console.log('   SQL editor to reclaim the bloat and refresh stats:');
+  console.log('\n     VACUUM (FULL, ANALYZE) public.jmdict_entries;\n');
 }
 
 main().catch(err => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -119,12 +119,23 @@ export async function fetchProcessedArticleById(articleId: string, userId: strin
   return (data?.content as NewsArticle) ?? null;
 }
 
+// Hydrate the local cache with the user's RECENT processed articles only.
+// Pulling the full history's `content` JSONB on every load (this runs on each
+// auth/session change) cold-reads megabytes off disk, spikes Disk IOPS into the
+// instance ceiling, and starves concurrent word lookups into statement timeouts.
+// Bounding to the most recent N keeps the "show articles that finished server-side
+// while the app was closed" behavior — any older article still opens on demand via
+// fetchProcessedArticleById() in handleSelectArticle.
+const RECENT_CACHE_LIMIT = 30;
+
 export async function fetchCachedArticlesFromSupabase(userId: string): Promise<Record<string, NewsArticle>> {
   const { data, error } = await supabase
     .from('processed_news')
-    .select('*')
-    .eq('user_id', userId);
-    
+    .select('id, content')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(RECENT_CACHE_LIMIT);
+
   if (error) {
     console.error("Error fetching cache from Supabase:", error);
     return {};


### PR DESCRIPTION
## Problem

Word lookups kept timing out app-wide (SQLSTATE 57014, "Lookup timed out") even after the Progress-query-storm and `freq_rank`-bloat fixes from PR #28. The 24h Supabase Observability told the real story: the DB was **flat-idle for 24h**, then spiked **only on app use** — Disk IOPS slammed into the instance's 3K Max ceiling, network to 13.7 MB/s, CPU ~90%. With IOPS pinned at the cap, concurrent word lookups (cold dictionary pages) queued behind the storm and blew past the statement timeout.

## Root cause

**PR #23** removed the skip-if-cached guard in `loadGlobalCache`, so `fetchCachedArticlesFromSupabase` ran `select('*')` over the user's **entire `processed_news` history** (full `content` JSONB) on **every session change** — and that init effect re-fires on token refresh / tab refocus. Each firing cold-read megabytes of JSONB off disk, pegging Read IOPS. "Fine this morning" fit exactly: PR #23 shipped at 2:08pm.

## Fix

Fetch only `id, content` for the **30 most recent** articles (`order by created_at desc`) instead of the whole history. Preserves PR #23's goal of surfacing articles that finished server-side while the app was closed — the recent ones are what the user opens; any older article still loads on demand via `fetchProcessedArticleById` in `handleSelectArticle`. Pure read-volume reduction, no DB migration. Build verified clean.

Also folds in `14cd250` (freq_rank backfill VACUUM reminder + incident root-cause correction in docs/task.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)