### PR TITLE
fix: lookup-grades-everything-hard bug + hydrate article cache once per user

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import { Progress } from './components/Progress'
 import { LandingPage } from './components/LandingPage'
 import { useAppStore } from './services/store'
 import { supabase } from './services/supabase'
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { fetchNewsFeed, NewsArticle, requestArticleProcessing } from './services/api'
 import { MoreVertical, ChevronLeft } from 'lucide-react'
 
@@ -239,11 +239,20 @@ function App() {
   }, [loadHub]);
 
   // One-time init: runs when user is onboarded + authenticated
+  const loadedCacheForUser = useRef<string | null>(null);
   useEffect(() => {
     if (isOnboarded && session) {
       checkDailyKanji();
       checkMidnightReset();
-      loadGlobalCache(session.user.id);
+      // This effect re-runs on every `session` change (token refresh / tab
+      // refocus produce a new session object with the same user id). Only the
+      // first run per user should hydrate the processed-article cache — re-pulling
+      // the recent-articles `content` JSONB on each refocus was the repeated
+      // multi-MB network/Disk-IOPS burst seen in Observability.
+      if (loadedCacheForUser.current !== session.user.id) {
+        loadedCacheForUser.current = session.user.id;
+        loadGlobalCache(session.user.id);
+      }
       useAppStore.getState().syncSrsWithSupabase(session.user.id);
     }
   }, [isOnboarded, session, checkDailyKanji, checkMidnightReset]);

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -305,8 +305,17 @@ export const useAppStore = create<AppState>()(
             if (!overrides) return {};
           }
 
-          const base = current.difficulty ?? seedDifficulty(jlptLevel ?? current.jlptLevel, state.jlptLevel);
-          const difficulty = clampDifficulty(base + (event === 'click' ? 2 : -1));
+          // The seed already encodes the word's JLPT level relative to the user, so
+          // on the FIRST event (no prior numeric difficulty) use it directly. Applying
+          // the click(+2)/skip(-1) nudge on the seeding event too double-counts and
+          // shoves an at-level word straight to 'hard' on a single lookup — the bug
+          // where every lookup defaulted to 'hard' regardless of JLPT level. The nudge
+          // only kicks in once a baseline exists (repeat-day lookups harden, clean
+          // reads ease).
+          const prior = current.difficulty;
+          const difficulty = prior == null
+            ? clampDifficulty(seedDifficulty(jlptLevel ?? current.jlptLevel, state.jlptLevel))
+            : clampDifficulty(prior + (event === 'click' ? 2 : -1));
           const mastery = bucketForDifficulty(difficulty);
 
           const updatedWord: WordData = {


### PR DESCRIPTION
Two follow-ups after the IOPS-saturation fix (PR #29).

## 1. Lookups defaulted every word to `hard` regardless of JLPT level

`applyDifficultyEvent` seeded difficulty from the word's JLPT level relative to the user (`seedDifficulty`: 6 at-level, 8 one harder) **and then** added the `click` nudge (+2) on the same first event. With `bucketForDifficulty` treating `>7` as `hard`, an at-level word (`6+2=8`) hit `hard` on a single lookup — and since articles introduce words at/above the user's level, that was essentially every lookup, hiding the JLPT signal.

**Fix:** on the seeding event (no prior numeric difficulty) use the JLPT-relative seed directly; only apply the `click(+2)`/`skip(-1)` nudge once a baseline exists. Result: at-level → `medium`, harder/untagged → `hard`, easier → `easy`/`medium`. Repeat-day lookups still harden; clean reads still ease.

## 2. Article cache re-hydrated on every session change

The onboarded+authenticated init effect depends on `session`, which gets a fresh object on every token refresh / tab refocus — so `loadGlobalCache` re-pulled the recent-articles `content` JSONB each time (the repeated multi-MB network / Disk-IOPS humps in Observability). Gated behind a ref so it hydrates **once per user id**.

Build verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)