### PR TITLE
feat: client-side morphological tokenization (kuromoji)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+public/kuromoji-dict/*.dat.gz filter=lfs diff=lfs merge=lfs -text

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,102 @@
+# Third-Party Licenses
+
+Yugen Study bundles the following third-party software and data. Their license
+notices are reproduced here as required.
+
+---
+
+## kuromoji.js (`@sglkc/kuromoji`)
+
+A JavaScript port of the kuromoji morphological analyzer, used client-side for
+Japanese tokenization, readings (furigana), and lemmatization.
+
+- Project: https://github.com/sglkc/kuromoji.js (fork of https://github.com/takuyaa/kuromoji.js)
+- Copyright 2014 Takuya Asano; Copyright 2010-2014 Atilika Inc. and contributors
+- Licensed under the **Apache License, Version 2.0** (http://www.apache.org/licenses/LICENSE-2.0)
+
+---
+
+## mecab-ipadic-2.7.0-20070801 (IPADIC dictionary)
+
+The dictionary data shipped under `public/kuromoji-dict/` (the `*.dat.gz` files)
+is derived from mecab-ipadic, obtainable from
+http://atilika.com/releases/mecab-ipadic/mecab-ipadic-2.7.0-20070801.tar.gz
+
+Copyright 2000, 2001, 2002, 2003 Nara Institute of Science
+and Technology.  All Rights Reserved.
+
+Use, reproduction, and distribution of this software is permitted.
+Any copy of this software, whether in its original form or modified,
+must include both the above copyright notice and the following
+paragraphs.
+
+Nara Institute of Science and Technology (NAIST),
+the copyright holders, disclaims all warranties with regard to this
+software, including all implied warranties of merchantability and
+fitness, in no event shall NAIST be liable for
+any special, indirect or consequential damages or any damages
+whatsoever resulting from loss of use, data or profits, whether in an
+action of contract, negligence or other tortuous action, arising out
+of or in connection with the use or performance of this software.
+
+A large portion of the dictionary entries
+originate from ICOT Free Software.  The following conditions for ICOT
+Free Software applies to the current dictionary as well.
+
+Each User may also freely distribute the Program, whether in its
+original form or modified, to any third party or parties, PROVIDED
+that the provisions of Section 3 ("NO WARRANTY") will ALWAYS appear
+on, or be attached to, the Program, which is distributed substantially
+in the same form as set out herein and that such intended
+distribution, if actually made, will neither violate or otherwise
+contravene any of the laws and regulations of the countries having
+jurisdiction over the User or the intended distribution itself.
+
+NO WARRANTY
+
+The program was produced on an experimental basis in the course of the
+research and development conducted during the project and is provided
+to users as so produced on an experimental basis.  Accordingly, the
+program is provided without any warranty whatsoever, whether express,
+implied, statutory or otherwise.  The term "warranty" used herein
+includes, but is not limited to, any warranty of the quality,
+performance, merchantability and fitness for a particular purpose of
+the program and the nonexistence of any infringement or violation of
+any right of any third party.
+
+Each user of the program will agree and understand, and be deemed to
+have agreed and understood, that there is no warranty whatsoever for
+the program and, accordingly, the entire risk arising from or
+otherwise connected with the program is assumed by the user.
+
+Therefore, neither ICOT, the copyright holder, or any other
+organization that participated in or was otherwise related to the
+development of the program and their respective officials, directors,
+officers and other employees shall be held liable for any and all
+damages, including, without limitation, general, special, incidental
+and consequential damages, arising out of or otherwise in connection
+with the use or inability to use the program or any product, material
+or result produced or otherwise obtained by using the program,
+regardless of whether they have been advised of, or otherwise had
+knowledge of, the possibility of such damages at any time during the
+project or thereafter.  Each user will be deemed to have agreed to the
+foregoing by his or her commencement of use of the program.  The term
+"use" as used herein includes, but is not limited to, the use,
+modification, copying and distribution of the program and the
+production of secondary products from the program.
+
+In the case where the program, whether in its original form or
+modified, was distributed or delivered to or received by a user from
+any person, organization or entity other than ICOT, unless it makes or
+grants independently of ICOT any specific warranty to the user in
+writing, such person, organization or entity, will also be exempted
+from and not be held liable to the user for any such damages as noted
+above as far as the program is concerned.
+
+---
+
+## kanji-data (kanji → JLPT mapping)
+
+The `kanji_jlpt` reference table is derived from
+https://github.com/davidluzgouveia/kanji-data (MIT License), itself derived from
+KANJIDIC and the Tanos JLPT lists.

--- a/docs/client-tokenizer-plan.md
+++ b/docs/client-tokenizer-plan.md
@@ -1,0 +1,123 @@
+# Implementation Plan — Client-Side Morphological Tokenization
+Replace the LLM-based tokenization/furigana/JMDict-linking with a real dictionary-based analyzer (kuromoji.js) running in the browser. Fixes wrong furigana, wrong dictionary meanings, and missing JLPT levels in one move, and _removes_ two server passes.
+## Licensing (cleared)
+- **kuromoji.js** (atilika original) and **@sglkc/kuromoji** fork: **Apache-2.0** — commercial use fine.
+  
+- **IPADIC dictionary** (mecab-ipadic 2.7.0, bundled in the package): permissive **BSD-style license**, commercial use allowed, with one obligation — **retain the copyright notice crediting the Nara Institute of Science and Technology (NAIST)**.
+  
+- **Action:** add both notices to a `THIRD_PARTY_LICENSES` / `NOTICE` file (or an "Acknowledgements" line in Settings/About). No copyleft, no per-seat terms. Verified via `npm view` — confirm the exact IPADIC notice text from the package's `dict/` or upstream `COPYING` before shipping.
+  
+## Architecture: before → after
+**Today** (all server-side, in `process-article`):
+
+```
+Gemini Pass 1 (rewrite → plain JP text)
+  → Gemini Pass 2 (tokenize + furigana)        ← buggy, DELETE
+  → Pass 3 (exact-surface JMDict link)         ← buggy, DELETE
+  → store enriched content[] in processed_news
+```
+
+**Proposed** (server simplified, client enriches):
+
+```
+SERVER  Gemini Pass 1 only → store plain paragraph text in processed_news
+CLIENT  on article open:
+          kuromoji.tokenize(text)              → segments + lemma + reading
+          merge inflections                    → display tokens (鎮めて, not 鎮)
+          align okurigana                      → furiganaMap (鎮→しず)
+          batch JMDict lookup by lemma         → jlptLevel + meaning + entryId
+          render; cache enriched blocks back
+USER    read / click / mastery → existing store sync → user_word_progress
+```
+
+Furigana (kana) comes **straight from kuromoji — no DB**. Only JLPT + meaning need the `jmdict` query the client already makes today.
+## Server changes — `supabase/functions/process-article/index.ts`
+1. **Delete Pass 2** (the `prompt2` "morphological analyzer" Gemini call, ~lines 354–374) and **Pass 3** (JMDict linking block, ~lines 376–417).
+  
+2. Change the stored shape so each paragraph keeps its **raw text** instead of a tokenized `content[]`:
+  
+  - `{ type: 'paragraph', text: '<full japanese string>' }`
+    
+  - yugen-box blocks unchanged (`keyword`/`reading`/`description` from Gemini stay — that path is reliable).
+    
+3. Net effect: one fewer Gemini call + no linking queries → faster, cheaper article prep. Keep the `responseMimeType: 'application/json'` Pass-1 contract.
+  
+
+> Old cached articles already have a Pass-2 `content[]`. The client auto-heals them (see Migration) by re-tokenizing from the joined text, so no backfill job is required.
+## New client module — `src/services/tokenizer.ts`
+Single responsibility: text → display tokens with furigana + lemma. No network except the one-time dict load.
+
+- **Loader / singleton.** `kuromoji.builder({ dicPath }).build(cb)` wrapped in a memoized `getTokenizer(): Promise<Tokenizer>` so the dictionary builds once per session. Browser uses kuromoji's XHR+pako loader (works out of the box — no Deno fs problem).
+  
+- **Dictionary hosting.** Self-host the 12 `*.dat.gz` files (~18 MB) under `public/kuromoji-dict/` and set `dicPath: '/kuromoji-dict/'`. Served as static assets, HTTP- and service-worker-cached (PWA → effectively one download per device, offline after). Avoids a hard runtime dependency on jsdelivr.
+  
+- `tokenizeToDisplay(text): DisplayToken[]` with three steps:
+  
+  1. `tokenizer.tokenize(text)` → raw tokens (`surface_form`, `basic_form`, `reading`, `pos`).
+    
+  2. **Inflection merge** — fold trailing `助動詞` (ます/た/ない/れる/られる/せる/させる…) and conjunctive `助詞 て/で` into the preceding `動詞`/`形容詞` head, keeping the head's `basic_form` as the lemma. (Optionally also merge a following auxiliary verb after て — いる/しまう/くる — into one unit; make this a tunable flag.) Produces `鎮めて` as one token with lemma `鎮める`.
+    
+  3. **Okurigana alignment** → `furiganaMap`. Split the surface into alternating kanji-runs / kana-runs; anchor each kana-run inside the reading; assign each kanji-run the reading span between anchors. (Robust generalization of the spike's leading/trailing-kana stripper — also handles internal kana like 入(い)り口(ぐち).) Replaces the broken even-split heuristic.
+    
+- **Unknown-word fallback.** When `basic_form === '*'` or `reading === '*'` (proper nouns like ヴァンス): emit the token with **no furigana** and no lemma link. Katakana needs none anyway; an unknown kanji name simply renders bare. No LLM call in the hot path.
+  
+- `DisplayToken` shape maps 1:1 onto the existing `ArticleBlock.content[]` item (`src/services/api.ts:4`): `{ text, furigana?, jmdict_entry_id?, details? }` — so Reader rendering barely changes.
+  
+## JMDict enrichment — extend `src/services/jmdict.ts`
+- Add `lookupLemmasBatch(lemmas: string[]): Promise<Map<string, JMDictResult>>`: one query over `jmdict_kanji`/`jmdict_kana` with `text IN (lemmas)`, then `fetchEntries` for the union. Reuses existing helpers; collapses N per-word lookups into one round-trip per article.
+  
+- **Disambiguation when a lemma has multiple entries:** rank by `common` desc → `freq_rank` asc → **POS match** against kuromoji's POS (verb/noun/adj), take the top. Reserve the existing `disambiguateWithLLM` (`jmdict.ts:112`, currently unused by the pipeline) for genuinely ambiguous high-value cases only.
+  
+- **JLPT fallback ladder** in `jmdictToWordDetails`: if the matched entry's `jlpt_level` is null, fall back to (a) max JLPT of its kanji via the existing `kanji_jlpt` table (`database/08_kanji_jlpt.sql`), else (b) a coarse bucket from `freq_rank`. Mark these as derived so the badge can read "≈N3" vs a tagged "N3" if you want the distinction.
+  
+- Keep the per-tap path (`fetchWordDefinitionQuick`, `api.ts:175`) but feed it the **lemma** the token already carries, not the surface string — so taps and the batch agree and conjugated forms stop falling through to Groq.
+  
+## Reader integration — `src/components/Reader.tsx`
+- In `loadArticle` (line 68), after obtaining the article, run an async `enrichArticle(blocks)`: for each paragraph block, `tokenizeToDisplay(rawText)` → batch `lookupLemmasBatch` over all unique lemmas → attach `details`/`jmdict_entry_id`/`furigana` to each token → set `block.content`.
+  
+- **Render unchanged.** `renderParagraph` (line 325) already maps `content[]` with `furigana`/`details`/`jmdict_entry_id`. The `Intl.Segmenter` fallback branch (line 365) can stay as a safety net for any block that failed tokenization.
+  
+- **First-load UX:** if the tokenizer isn't ready yet, render the raw paragraph text immediately (no furigana, sentence-tap still works), then swap in enriched tokens when ready — a sub-second flash on the very first session only. Add a tiny "preparing readings…" state reusing the existing `loadingStep` pattern if desired.
+  
+- **Cache enriched blocks** via the existing `saveProcessedArticle` (line 102) so re-opens skip tokenization and the dict isn't even needed on subsequent views.
+  
+## Read-but-not-clicked sweep — `Reader.tsx:135` (`handleFinishArticle`)
+Works as-is, and more accurately: because `enrichArticle` ran over the **whole** article, every token already carries a correct lemma + `jlptLevel`. The sweep keeps iterating all tokens with furigana, seeds never-seen words with their real entry, and applies the `'skip'` difficulty event with a correct JLPT level (it was frequently null before). No structural change — just better inputs.
+## Migration / backward compatibility
+- Articles cached before this change have a Pass-2 `content[]`. `enrichArticle` should **reconstruct raw text** as `block.text ?? block.content.map(t => t.text).join('')` and re-tokenize — auto-healing old articles with correct furigana/links on next open. No DB migration, no backfill (consistent with this repo's manual-migration norm).
+  
+- Gate with a `tokenizerVersion` stamp on the cached block so a future tokenizer/dict upgrade can invalidate and re-enrich.
+  
+## Rollout phases
+1. **Phase 1 — tokenizer module + dict hosting.** Add `tokenizer.ts`, vendor dict into `public/kuromoji-dict/`, unit-check segmentation/lemma/furigana on a fixture set (incl. the `鎮めて` case and a few conjugations). No UI wiring yet.
+  
+2. **Phase 2 — client enrichment + Reader wiring.** `lookupLemmasBatch`, `enrichArticle`, render swap, first-load fallback. Verify the screenshot article end-to-end.
+  
+3. **Phase 3 — server simplification.** Delete Pass 2/3, switch stored shape to raw paragraph text. (Client already handles both shapes from Phase 2, so this is safe to ship after.)
+  
+4. **Phase 4 — disambiguation + JLPT fallback ladder + licenses/NOTICE.**
+  
+## Risks & mitigations
+- **18 MB first-load.** Self-host + SW cache; render text-first, furigana-on-ready. One-time per device.
+  
+- **IPADIC proper-noun gaps.** Unknown kanji names render bare; acceptable, optional narrow LLM fallback later.
+  
+- **Inflection-merge edge cases** (compound auxiliaries, ～ておく/～ていく). Start with a conservative ruleset; tune against real articles. The `Intl.Segmenter` fallback covers any un-tokenized block.
+  
+- **Bundle weight of kuromoji JS** (the code, not the dict) — modest; lazy-import the module so it doesn't bloat initial app load.
+  
+## Decisions (resolved 2026-06-07)
+1. **Dict hosting → self-host** under `public/kuromoji-dict/` (reliable, offline, no third-party runtime dependency). *[chosen]*
+  
+2. **Enrichment caching → persist back to `processed_news`.** Heals the stored article for every device/session and makes re-opens instant (dict not needed on subsequent views). *[best judgment]*
+  
+3. **JLPT fallback → show derived levels, visibly marked** (`≈N3` from kanji `kanji_jlpt` / freq rank vs. a clean `N3` for a real JMDict tag). Better signal than blank, honest about the source. *[best judgment]*
+  
+4. **Inflection merge → inflectional suffixes + て-form only** (`鎮めて`); auxiliary verbs stay separate, so `鎮めている` = `鎮めて` + `いる` and the `〜ている` grammar stays independently tappable. Auxiliary-merge kept as a tunable flag, off by default. *[best judgment]*
+
+---
+comments:
+  c1:
+    body: Do self host. For all other decisions use your best judgement
+    by: user
+    at: 2026-06-07T17:48:39.256Z

--- a/docs/furigana-dictionary-review.md
+++ b/docs/furigana-dictionary-review.md
@@ -1,0 +1,107 @@
+# Furigana & Dictionary Accuracy — Process Review
+A detailed walkthrough of _why_ you see wrong furigana, wrong dictionary meanings, and missing JLPT levels — and how the pipeline could be fixed.
+## The bug you saw, decoded
+In the screenshot the text is `心を鎮めて` ("to calm one's heart"). The correct word is **鎮める (しずめる)** — and your yugen keyword box gets it exactly right.
+
+But the _tappable_ token in the running text was just the single kanji **鎮**, with furigana **ちん** on top, and tapping it returned _"a weight; temple supervisor; town (of China)"_ with the RTK keyword TRANQUILLIZE — and no JLPT badge.
+
+That is three separate failures stacking up on the same word:
+
+1. **Wrong segmentation** — `鎮める` was split into `鎮` + `めて`, so the tap target was a bare kanji, not the verb.
+  
+2. **Wrong furigana** — the isolated `鎮` got its dictionary _on'yomi_ `ちん`, not the contextual `しず`.
+  
+3. **Wrong dictionary entry + no JLPT** — looking up the surface string `鎮` matched the standalone-kanji noun entry (ちん = a Chinese town/weight), which carries no JLPT tag.
+  
+
+The keyword box is right and the inline tap is wrong **for the same word in the same sentence** — that contrast is the key clue. It tells us the failure is not in Gemini's understanding of the article; it's in the _tokenization layer_ that runs afterward.
+## How the pipeline actually works today
+The whole chain lives in `supabase/functions/process-article/index.ts` plus the live tap lookup in `supabase/functions/dictionary-lookup/index.ts` and `src/services/jmdict.ts`.
+### Article processing (3 passes, all at `process-article/index.ts`)
+- **Pass 1 — Rewrite** (`prompt1`, line 321): Gemini writes the Japanese article as plain text strings. It is explicitly told _"DO NOT tokenize the text yet"_ (line 336). This pass is reliable — Gemini writes natural prose, and when it emits a yugen-box keyword it writes the word, reading, and meaning together as one unit. **This is why your keyword boxes are correct.**
+  
+- **Pass 2 — Tokenize + furigana** (`prompt2`, line 355): Gemini is told _"You are a morphological analyzer"_ and asked to split every sentence into tokens and attach a `furigana` reading to each. **This is the root cause.** An LLM is being used to do dictionary-grounded morphological analysis from scratch, with:
+  
+  - no lexicon, so word boundaries are guessed (`鎮める` → `鎮` + `めて`);
+    
+  - no okurigana model, so a fragment like a bare `鎮` gets a plausible-in-isolation reading (`ちん`) rather than the contextual one (`しず`);
+    
+  - no lemmatization, so conjugated forms are never reduced to their dictionary form.
+    
+- **Pass 3 — JMDict linking** (line 377): for each token that has furigana, the code does an **exact surface-string match** against `jmdict_kanji.text` / `jmdict_kana.text` and stores _"the first entry_id found"_ (line 399–402). There is no context, no part-of-speech filter, and no "common entry wins" logic. So `鎮` resolves to whatever row comes back first.
+  
+### The tap lookup (`Reader.tsx` → `jmdict.ts` / `dictionary-lookup`)
+When you tap a token (`Reader.tsx:357`):
+
+- If Pass 3 attached a `jmdict_entry_id`, it's fetched directly (`fetchWordDefinitionQuick`, `api.ts:180`) — **propagating Pass 3's wrong link**.
+  
+- Otherwise it looks up the **surface string** via `lookupWord` (`jmdict.ts:41`): exact kanji match, else exact kana match. A conjugated `鎮めて` exact-matches nothing, so it falls through to the Groq LLM fallback in `dictionary-lookup` — which returns a free-form definition with **no** `jlptLevel` **field at all** (`dictionary-lookup/index.ts:210`).
+  
+
+So every path shares the same three weaknesses: **surface-only matching, first-entry-wins, and no lemmatization.**
+### Why JLPT is so often blank
+- `jmdict_entries.jlpt_level` (`database/07_jmdict_jlpt.sql`) is NULL for most entries — only the ~8k official JLPT-list words are tagged. Rare/auxiliary/kanji-as-noun entries (like `鎮`=ちん) are untagged by design.
+  
+- When the wrong entry is matched, it's frequently one of those untagged entries → no badge.
+  
+- Conjugated forms that miss JMDict entirely go to the Groq fallback, which never emits a JLPT level.
+  
+- `buildFuriganaMap` (`jmdict.ts:212`) splits multi-kanji blocks by an _even character count_ heuristic (line 258) — fine for `食べる`, wrong for compounds like `副大統領`, so even correctly-matched words can show mis-aligned furigana.
+  
+## The core problem in one sentence
+**An LLM is being asked to do the one job LLMs are worst at and dictionary-based tools are best at: deterministic morphological segmentation, reading assignment, and lemmatization.** Everything downstream (furigana, entry linking, JLPT) inherits Pass 2's guesses.
+## How to fix it
+### Recommendation: replace Pass 2 with a real morphological analyzer
+Drop the "Gemini as morphological analyzer" prompt and run a dictionary-based Japanese tokenizer over the Pass-1 text. The standard choice that runs in Deno/browser with no native deps is **kuromoji.js** (a MeCab + IPADIC port); Sudachi/MeCab-WASM are heavier alternatives. For every token a real analyzer gives you, deterministically:
+
+- **surface** (`鎮めて`) — what to display,
+  
+- **base form / lemma** (`鎮める`) — what to look up,
+  
+- **reading** (`しずめて`, katakana) — the _contextual_ reading, so furigana is correct,
+  
+- **part of speech** (verb, ichidan) — to disambiguate JMDict senses.
+  
+
+This single change fixes all three symptoms at once:
+
+1. **Segmentation** — `鎮める` stays whole; the tap target is the verb.
+  
+2. **Furigana** — the reading comes from the analyzer's contextual reading, not an isolated-kanji guess. Align it to the surface with a proper okurigana algorithm (match trailing/leading kana, assign the kanji span the remaining reading) instead of the even-split heuristic.
+  
+3. **Dictionary + JLPT** — look up by **lemma**, so `鎮める` matches its real entry with the right sense, reading, and JLPT tag. Conjugated forms now resolve instead of falling through to Groq.
+  
+### Supporting changes
+- **Disambiguate Pass 3 /** `lookupWord` **properly.** When a surface/lemma yields multiple entries, don't take "the first found." Rank by `common = true`, then `freq_rank`, then prefer the entry whose `pos` matches the analyzer's POS. Reserve the LLM (`disambiguateWithLLM`, already implemented at `jmdict.ts:112`) for genuinely ambiguous cases — it's currently bypassed in Pass 3 entirely.
+  
+- **Lemma-aware lookup in** `jmdict.ts`**.** Add a base-form parameter to `lookupWord` so the tap path can try lemma → surface → kana, instead of surface → kana only.
+  
+- **JLPT fallback ladder.** When the matched entry has no `jlpt_level`: (a) fall back to the max JLPT level of its kanji via the existing `kanji_jlpt` table (`database/08_kanji_jlpt.sql`), or (b) derive a coarse level from `freq_rank`. Surface "untagged" rather than silently blank.
+  
+- **Pre-bake everything in Pass 3.** Since the analyzer runs server-side once per article, store `surface`, `lemma`, `reading`, `furiganaMap`, `jmdict_entry_id`, and `jlpt_level` directly on each token in `processed_news`. The tap then needs no live lookup at all — eliminating the second place the surface-match bug can reappear and making taps instant.
+  
+- **Fix** `buildFuriganaMap` **okurigana alignment** (`jmdict.ts:212`, mirrored in `dictionary-lookup/index.ts:16`) regardless — replace the even-split with kana-anchored alignment, and dedupe the two copies into one shared helper.
+  
+### Effort vs. payoff
+| Change | Effort | Payoff |
+| --- | --- | --- |
+| Swap Pass 2 → kuromoji.js | Medium | Fixes segmentation + furigana + enables lemma lookup (the big one) |
+| Lemma-based JMDict lookup + POS-ranked disambiguation | Low–Medium | Fixes wrong meanings on conjugated/ambiguous words |
+| JLPT fallback ladder (kanji_jlpt / freq_rank) | Low | Fills in most missing badges |
+| Pre-bake token metadata in Pass 3 | Low | Instant taps, removes a whole class of live-lookup bugs |
+| Fix `buildFuriganaMap` alignment | Low | Correct furigana on multi-kanji words |
+
+The first row is the linchpin: once tokens carry a real lemma and reading, the rest are small, well-scoped follow-ups.
+## Open questions for you
+1. Is adding a JS morphological analyzer (kuromoji-class) into the `process-article` edge function acceptable, given its dictionary adds bundle/cold-start weight to the Deno function?
+  
+2. Do you want furigana/linking computed **once at processing time** (pre-baked, my recommendation) or kept **live at tap time**?
+  
+3. How important is full JLPT coverage vs. just "don't show a wrong level" — do you want the kanji-level / frequency fallback, or is blank acceptable when untagged?
+
+---
+comments:
+  c1:
+    body: tell me more about kuromoji.js
+    by: user
+    at: 2026-06-07T17:07:22.496Z

--- a/docs/task.md
+++ b/docs/task.md
@@ -46,3 +46,20 @@
   - [ ] Only if spikes recur under real concurrent load: revisit `jmdict_vocab_candidates`
         (full jmdict_senses scan w/ ILIKE ANY on gloss, runs per process-article) or
         bump compute. Not needed as of resolution.
+- [x] Client-side morphological tokenization (kuromoji) — 2026-06-07
+  - Replaces buggy LLM tokenization (Gemini Pass 2 + exact-surface Pass 3) that
+    split words at arbitrary boundaries (鎮める → 鎮 read ちん, wrong meaning, no JLPT).
+  - [x] Phase 1: `src/services/tokenizer.ts` (kuromoji singleton, inflection merge,
+        okurigana alignment, content-word classification) + dict self-hosted under
+        `public/kuromoji-dict/` (~17 MB, SW/HTTP cached). Shared kana helpers in
+        `src/services/furigana.ts`. kuromoji lazy-imported → its own 29 KB-gz chunk.
+        Verified: 鎮めて→lemma 鎮める/furi しず; した→する; 〜ている stays split.
+  - [x] Phase 2: `src/services/enrich.ts` (`enrichArticle`) — tokenize → batch
+        `lookupLemmasBatch` by lemma → attach reading/meaning/JLPT/furigana. Reader
+        renders raw text first, swaps in enriched blocks, caches them. Lemma-keyed
+        SRS so conjugations collapse and the end-of-article sweep agrees.
+  - [x] Phase 3: process-article stores raw `{type, text}` paragraphs; Pass 2/3 deleted
+        (one fewer Gemini call, no linking queries). Old content[] articles auto-heal.
+  - [x] Phase 4: POS-ranked disambiguation (replaces first-entry-wins), JLPT fallback
+        ladder (kanji_jlpt → freq_rank, shown as `≈Nx`), THIRD_PARTY_LICENSES (NAIST
+        IPADIC + Apache-2.0) + Settings acknowledgement.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
+        "@sglkc/kuromoji": "^1.1.0",
         "@supabase/supabase-js": "^2.100.1",
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.6.0",
@@ -1239,6 +1240,17 @@
         "win32"
       ]
     },
+    "node_modules/@sglkc/kuromoji": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@sglkc/kuromoji/-/kuromoji-1.1.0.tgz",
+      "integrity": "sha512-uKxXYUM5XNjZw0ia0yMYTI3jHSh/c1gEMNvcvS6J49B4mI+PAq8iRYPTxh2ma0RWm45LyWWrILxCJAIXpi/pww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^2.0.1",
+        "doublearray": "0.0.2",
+        "fflate": "^0.8.0"
+      }
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.100.1",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.100.1.tgz",
@@ -1769,6 +1781,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1947,6 +1968,12 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/doublearray": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
+      "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.322",
@@ -2214,6 +2241,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2508,6 +2541,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
+    "@sglkc/kuromoji": "^1.1.0",
     "@supabase/supabase-js": "^2.100.1",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.6.0",

--- a/public/kuromoji-dict/base.dat.gz
+++ b/public/kuromoji-dict/base.dat.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0803327762e1c93ca731e4319ab8343340f2806bb84941207782cde9d2d5a8eb
+size 3956825

--- a/public/kuromoji-dict/cc.dat.gz
+++ b/public/kuromoji-dict/cc.dat.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02b7631be0d4de3a1a75cd9f9cc51536e4f94c9e6b389b813e06ba0f6e7de765
+size 1692067

--- a/public/kuromoji-dict/check.dat.gz
+++ b/public/kuromoji-dict/check.dat.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:193ae0035fff6fe812b58d9ee730e7a7d7ee601d918481ce51075c58114f6cc9
+size 3111633

--- a/public/kuromoji-dict/tid.dat.gz
+++ b/public/kuromoji-dict/tid.dat.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d43d831cb6fb0f0a411739cd287a6d5e998e121a8daca614df14a81a0dcac586
+size 1605820

--- a/public/kuromoji-dict/tid_map.dat.gz
+++ b/public/kuromoji-dict/tid_map.dat.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33efd5ffd87a70f669add093fa39dee44341d58f940844ef107c8fd98bb795b2
+size 1485576

--- a/public/kuromoji-dict/tid_pos.dat.gz
+++ b/public/kuromoji-dict/tid_pos.dat.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60dbfc99a6ab993f30c5dab648bec6ad7f9aaefa5c14e1843837d95e509f8895
+size 5916009

--- a/public/kuromoji-dict/unk.dat.gz
+++ b/public/kuromoji-dict/unk.dat.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7f991cdeb9bfd3e9c0e4577cc50ee0815a11c508cccd444a9d3ab3c81521100
+size 10512

--- a/public/kuromoji-dict/unk_char.dat.gz
+++ b/public/kuromoji-dict/unk_char.dat.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a8e86fd9aff32d323fbb59f5a7006f05927a11f8173c90712cc56293aeb3225
+size 306

--- a/public/kuromoji-dict/unk_compat.dat.gz
+++ b/public/kuromoji-dict/unk_compat.dat.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50f60aa29bc2e86c2903ab8c825bb6fa604d2b294d96941c1d3924259791899d
+size 338

--- a/public/kuromoji-dict/unk_invoke.dat.gz
+++ b/public/kuromoji-dict/unk_invoke.dat.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b210889548457c3006913afd12c8b525562255f2709e404604be9614a25e94c
+size 1140

--- a/public/kuromoji-dict/unk_map.dat.gz
+++ b/public/kuromoji-dict/unk_map.dat.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6df12460e5477230bb6fd9641def918b699fc0a8868016b6c9f794488630509b
+size 1190

--- a/public/kuromoji-dict/unk_pos.dat.gz
+++ b/public/kuromoji-dict/unk_pos.dat.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b183a29f281acc7e0542beca47b83f7985047c0a2d27e78a66f32276be5ad11
+size 10540

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -3,12 +3,13 @@ import { FuriganaText, HitWeight } from './FuriganaText';
 import type { MasteryLevel } from '../services/store';
 import { YugenBox } from './YugenBox';
 import { WordModal, WordDetails } from './WordModal';
-import { 
-  rewriteArticleWithGemini, 
-  fetchWordDefinitionQuick, 
-  fetchWordGrammarInsight, 
+import {
+  rewriteArticleWithGemini,
+  fetchWordDefinitionQuick,
+  fetchWordGrammarInsight,
   fetchSentenceTranslation
 } from '../services/api';
+import { enrichArticle, isEnriched } from '../services/enrich';
 import { useAppStore } from '../services/store';
 import { touchLock } from '../services/touchLock';
 import { } from 'lucide-react'; // Empty block to show we're using icons elsewhere if needed, or just clear it.
@@ -65,11 +66,35 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     readerFontSize, readerFontWeight
   } = useAppStore();
 
+  // Tracks the article currently being loaded so a slow background enrichment
+  // from a previous article can't clobber a newer one the reader switched to.
+  const loadIdRef = React.useRef<string | null>(null);
+
+  // Tokenize + dictionary-link the article on the client, then swap in the
+  // enriched blocks and cache them. Runs in the background so the raw text shows
+  // immediately (sub-second flash on the very first session, then dict-cached).
+  const enrichInBackground = (article: any) => {
+    if (!article || isEnriched(article.blocks)) return;
+    const loadId = article.id ?? null;
+    enrichArticle(article.blocks)
+      .then((blocks) => {
+        if (loadIdRef.current !== loadId) return; // reader moved on
+        const enriched = { ...article, blocks };
+        setCurrentArticle(enriched);
+        if (article.id) saveProcessedArticle(article.id, enriched);
+      })
+      .catch((e) => console.warn('[Reader] enrichment failed:', e));
+  };
+
   const loadArticle = async () => {
+    loadIdRef.current = initialArticle?.id ?? null;
+
     // 1. Check Cache first for instant return
     if (initialArticle?.id && articlesCache[initialArticle.id]) {
-      setCurrentArticle(articlesCache[initialArticle.id]);
+      const cached = articlesCache[initialArticle.id];
+      setCurrentArticle(cached);
       setLoading(false);
+      enrichInBackground(cached);
       return;
     }
 
@@ -100,6 +125,8 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
       setCurrentArticle(processed);
       // 3. Save to cache for next time
       if (selectedRaw.id) saveProcessedArticle(selectedRaw.id, processed);
+      // 4. Tokenize + dictionary-link on the client, then swap in enriched blocks.
+      enrichInBackground(processed);
     } else {
       // Emergency Fallback
       setLoading(false);
@@ -140,10 +167,12 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     const articleWords = new Map<string, any>();
     currentArticle?.blocks.forEach(b => {
       if (b.content) b.content.forEach(w => {
-        if (!w.furigana) return;
-        const existing = articleWords.get(w.text);
+        if (!w.isInteractive && !w.furigana) return;
+        // Key by lemma so conjugations collapse and the key matches clickedWords.
+        const key = w.lemma ?? w.details?.word ?? w.text;
+        const existing = articleWords.get(key);
         if (!existing || (!existing.details && (w.details || w.jmdict_entry_id))) {
-          articleWords.set(w.text, w);
+          articleWords.set(key, w);
         }
       });
     });
@@ -155,7 +184,7 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
       // Make sure a never-seen word exists before grading it.
       if (!wordDatabase[word]) {
         saveWordDefinition(word, details
-          ? { reading: details.reading, meaning: details.meaning, jlptLevel: details.jlptLevel, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id }
+          ? { reading: details.reading, meaning: details.meaning, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id }
           : { reading: '...', meaning: 'Implicitly parsed context', jmdictEntryId: token.jmdict_entry_id });
       }
       recordWordSeen(word, true);
@@ -323,10 +352,14 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
   };
 
   const renderParagraph = (block: any, blockIdx: number) => {
+    // Before client enrichment finishes, a block may carry only raw text — render
+    // it as one segment so the text (and sentence-tap) work during the brief flash.
+    const content: any[] = block.content ?? (block.text ? [{ text: block.text }] : []);
+
     // 1. Group tokens into sentences
     const sentences: any[][] = [];
     let currentSent: any[] = [];
-    block.content.forEach((seg: any) => {
+    content.forEach((seg: any) => {
       currentSent.push(seg);
       if (seg.text.match(/[。！？\n]/)) {
         sentences.push(currentSent);
@@ -357,7 +390,8 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
                   onClick={(e) => {
                     const tid = `${sentenceId}-${j}`;
                     if (segment.details) handleWordClick(segment.details as WordDetails, sentText, e, tid);
-                    else handleDictionaryLookup(segment.text, sentText, e, tid, segment.jmdict_entry_id);
+                    // Look up by lemma (鎮める) when we have it, not the surface form (鎮めて).
+                    else handleDictionaryLookup(segment.lemma ?? segment.text, sentText, e, tid, segment.jmdict_entry_id);
                   }}
                 />
               );

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -374,9 +374,16 @@ export function Settings() {
               Reset All Progress
             </button>
           </div>
+
+          {/* Acknowledgements — required attribution for the bundled dictionary. */}
+          <p style={{ fontSize: '0.7rem', color: 'var(--text-muted)', lineHeight: 1.6, marginTop: '2rem', opacity: 0.7 }}>
+            Japanese analysis by kuromoji.js (Apache-2.0). Dictionary data from
+            mecab-ipadic, © Nara Institute of Science and Technology (NAIST). See
+            THIRD_PARTY_LICENSES for full notices.
+          </p>
         </div>
       </details>
-      
+
     </div>
   );
 }

--- a/src/components/WordModal.tsx
+++ b/src/components/WordModal.tsx
@@ -13,6 +13,8 @@ export interface WordDetails {
   jmdictEntryId?: string;
   pos?: string[];
   jlptLevel?: number | null;
+  /** True when jlptLevel was inferred (kanji/frequency) rather than an official tag. */
+  jlptDerived?: boolean;
 }
 
 interface Props {
@@ -202,11 +204,12 @@ export function WordModal({
                 style={{ fontSize: '1.25rem', color: 'var(--text-main)', lineHeight: 1.5 }}
               >
                 {wordData.jlptLevel && (
-                  <span className="sans" style={{ 
-                    fontSize: '0.85rem', fontWeight: 800, color: '#4a5d23', 
+                  <span className="sans" style={{
+                    fontSize: '0.85rem', fontWeight: 800, color: '#4a5d23',
                     marginRight: '0.6rem', opacity: 0.8, verticalAlign: 'middle'
-                  }}>
-                    N{wordData.jlptLevel}
+                  }}
+                  title={wordData.jlptDerived ? 'Approximate level (inferred from kanji / frequency)' : undefined}>
+                    {wordData.jlptDerived ? '≈' : ''}N{wordData.jlptLevel}
                   </span>
                 )}
                 {wordData.meaning}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,13 +3,19 @@ import { lookupWord, disambiguateWithLLM, jmdictToWordDetails, fetchEntries } fr
 
 export interface ArticleBlock {
   type: 'paragraph' | 'yugen-box';
-  content?: { 
-    text: string; 
-    furigana?: string; 
-    isInteractive?: boolean; 
+  /** Raw paragraph text (server-stored shape). Tokenized into `content` client-side. */
+  text?: string;
+  content?: {
+    text: string;
+    furigana?: string;
+    isInteractive?: boolean;
+    /** Dictionary/base form, used for lookup and SRS keying (conjugations collapse here). */
+    lemma?: string;
     details?: WordDetails;
     jmdict_entry_id?: string;
   }[];
+  /** Tokenizer version that produced `content`; gates client re-enrichment. */
+  tokenizerVersion?: number;
   keyword?: string;
   reading?: string;
   description?: string;

--- a/src/services/enrich.ts
+++ b/src/services/enrich.ts
@@ -1,0 +1,106 @@
+/**
+ * Client-side article enrichment.
+ *
+ * Turns raw Japanese paragraph text into interactive, dictionary-linked tokens:
+ *   tokenize (kuromoji) → batch JMDict lookup by lemma → attach reading/meaning/JLPT.
+ *
+ * This replaces the old server passes (Gemini "tokenizer" + exact-surface JMDict
+ * linking). It also auto-heals articles cached in the old content[] shape by
+ * reconstructing their raw text and re-tokenizing.
+ */
+
+import type { ArticleBlock } from './api';
+import type { WordDetails } from '../components/WordModal';
+import { tokenizeToDisplay, TOKENIZER_VERSION, type CoarsePos, type DisplayToken } from './tokenizer';
+import { lookupLemmasBatch, jmdictToWordDetails, type JMDictResult } from './jmdict';
+
+/** Raw text of a block, reconstructed from the old content[] shape when needed. */
+function rawTextOf(block: ArticleBlock): string {
+  if (block.text) return block.text;
+  if (block.content) return block.content.map(t => t.text).join('');
+  return '';
+}
+
+/** True when every paragraph block already carries current-version enrichment. */
+export function isEnriched(blocks: ArticleBlock[]): boolean {
+  return blocks.every(
+    b => b.type !== 'paragraph' || (b.tokenizerVersion === TOKENIZER_VERSION && !!b.content),
+  );
+}
+
+/**
+ * Enrich an article's paragraphs in place-of (returns a new array). yugen-box
+ * blocks pass through untouched. Falls back to the raw block on any failure so a
+ * tokenizer hiccup never blanks the article.
+ */
+export async function enrichArticle(blocks: ArticleBlock[]): Promise<ArticleBlock[]> {
+  // 1. Tokenize every paragraph from its raw text.
+  const perBlock: (DisplayToken[] | null)[] = await Promise.all(
+    blocks.map(async (block) => {
+      if (block.type !== 'paragraph') return null;
+      const raw = rawTextOf(block);
+      if (!raw) return null;
+      try {
+        return await tokenizeToDisplay(raw);
+      } catch (e) {
+        console.warn('[enrich] tokenize failed for a block:', e);
+        return null;
+      }
+    }),
+  );
+
+  // 2. Gather unique lemmas + their coarse POS for a single batched lookup.
+  const posByLemma = new Map<string, CoarsePos>();
+  for (const tokens of perBlock) {
+    if (!tokens) continue;
+    for (const t of tokens) {
+      if (t.lemma && !posByLemma.has(t.lemma)) posByLemma.set(t.lemma, t.pos ?? 'other');
+    }
+  }
+
+  let byLemma = new Map<string, JMDictResult>();
+  try {
+    byLemma = await lookupLemmasBatch([...posByLemma.keys()], posByLemma);
+  } catch (e) {
+    console.warn('[enrich] JMDict batch lookup failed; rendering without links:', e);
+  }
+
+  // 3. Build enriched content[] per paragraph.
+  return blocks.map((block, i) => {
+    const tokens = perBlock[i];
+    if (!tokens) return block; // yugen-box or un-tokenizable: leave as-is
+
+    const content = tokens.map((tk) => {
+      const item: NonNullable<ArticleBlock['content']>[number] = { text: tk.text };
+      if (tk.furigana) item.furigana = tk.furigana;
+      if (!tk.isInteractive) return item;
+
+      item.isInteractive = true;
+      if (tk.lemma) item.lemma = tk.lemma;
+
+      const entry = tk.lemma ? byLemma.get(tk.lemma) : undefined;
+      if (entry && tk.lemma) {
+        const d = jmdictToWordDetails(tk.lemma, entry);
+        item.jmdict_entry_id = d.jmdictEntryId;
+        const details: WordDetails = {
+          word: tk.lemma,
+          reading: d.reading,
+          meaning: d.meaning,
+          furiganaMap: d.furiganaMap,
+          jlptLevel: d.jlptLevel,
+          jlptDerived: d.jlptDerived,
+          pos: d.pos,
+          jmdictEntryId: d.jmdictEntryId,
+        };
+        item.details = details;
+      } else if (tk.furiganaMap) {
+        // No JMDict entry (e.g. proper noun): keep the tokenizer's reading map so
+        // the modal can still show furigana; tap falls back to dictionary-lookup.
+        item.details = { word: tk.lemma ?? tk.text, reading: tk.furigana ?? '', meaning: '', furiganaMap: tk.furiganaMap };
+      }
+      return item;
+    });
+
+    return { ...block, text: rawTextOf(block), content, tokenizerVersion: TOKENIZER_VERSION };
+  });
+}

--- a/src/services/furigana.ts
+++ b/src/services/furigana.ts
@@ -1,0 +1,79 @@
+/**
+ * Furigana / kana utilities — pure functions, no dictionary or network deps.
+ *
+ * Shared by the client tokenizer and JMDict lookup so okurigana alignment is
+ * computed one way everywhere (the old even-split heuristic mis-aligned
+ * compounds like 副大統領).
+ */
+
+export const isKana = (c: string) => /[぀-ゟ゠-ヿ]/.test(c);
+export const hasKanji = (s: string) => /[一-龯㐀-䶿]/.test(s);
+
+/** Convert katakana to hiragana (kuromoji readings are katakana). */
+export function kataToHira(s: string): string {
+  return s.replace(/[ァ-ヶ]/g, (c) => String.fromCharCode(c.charCodeAt(0) - 0x60));
+}
+
+/**
+ * Align a surface form to its kana reading, kanji-run by kanji-run.
+ *
+ * Splits the surface into alternating kanji/kana runs, anchors each kana run
+ * inside the reading, and assigns each kanji run the reading span up to the
+ * next anchor. Handles leading, trailing, and internal kana (入(い)り口(ぐち)).
+ *
+ * Example: 食べる + たべる → [{食:た},{べ:べ},{る:る}]
+ *
+ * A multi-kanji run with no internal kana (大統領) is genuinely ambiguous per
+ * character; we attach the whole span to the first kanji and blank the rest
+ * rather than guess wrong readings.
+ */
+export function alignOkurigana(
+  surface: string,
+  reading: string,
+): { kanji: string; kana: string }[] {
+  const chars = Array.from(surface);
+  if (chars.every((c) => isKana(c)) || !reading) {
+    return chars.map((c) => ({ kanji: c, kana: c }));
+  }
+
+  const segments: { kanji: string; kana: string }[] = [];
+  let rIdx = 0;
+  let i = 0;
+
+  while (i < chars.length) {
+    if (isKana(chars[i])) {
+      let j = i;
+      while (j < chars.length && isKana(chars[j])) j++;
+      const kanaRun = chars.slice(i, j).join('');
+      for (const c of kanaRun) segments.push({ kanji: c, kana: c });
+      const pos = reading.indexOf(kanaRun, rIdx);
+      rIdx = pos !== -1 ? pos + kanaRun.length : rIdx + kanaRun.length;
+      i = j;
+    } else {
+      let j = i;
+      while (j < chars.length && !isKana(chars[j])) j++;
+      const kanjiRun = chars.slice(i, j);
+
+      let readingEnd: number;
+      if (j < chars.length) {
+        let k = j;
+        while (k < chars.length && isKana(chars[k])) k++;
+        const nextKana = chars.slice(j, k).join('');
+        const anchor = reading.indexOf(nextKana, rIdx);
+        readingEnd = anchor !== -1 ? anchor : reading.length;
+      } else {
+        readingEnd = reading.length;
+      }
+
+      const blockReading = reading.slice(rIdx, readingEnd);
+      segments.push({ kanji: kanjiRun[0], kana: blockReading });
+      for (let k = 1; k < kanjiRun.length; k++) {
+        segments.push({ kanji: kanjiRun[k], kana: '' });
+      }
+      rIdx = readingEnd;
+      i = j;
+    }
+  }
+
+  return segments;
+}

--- a/src/services/jmdict.ts
+++ b/src/services/jmdict.ts
@@ -7,6 +7,8 @@
  */
 
 import { supabase } from './supabase';
+import { alignOkurigana, hasKanji } from './furigana';
+import type { CoarsePos } from './tokenizer';
 
 export interface JMDictResult {
   entryId: string;
@@ -19,7 +21,11 @@ export interface JMDictResult {
     misc: string[];
   }[];
   jlptLevel: number | null;
+  /** Best (lowest) frequency band across the entry's forms; null = rare/unranked. */
+  freqRank: number | null;
   isCommon: boolean;
+  /** JLPT level inferred from kanji/frequency when jlptLevel is null (Phase 4). */
+  derivedJlpt?: number | null;
 }
 
 const LOOKUP_TIMEOUT_MS = 6000;
@@ -76,7 +82,7 @@ async function lookupByKana(text: string): Promise<JMDictResult[]> {
 export async function fetchEntries(entryIds: string[]): Promise<JMDictResult[]> {
   // Fetch entries, kanji forms, kana forms, and senses in parallel
   const [entriesRes, kanjiRes, kanaRes, sensesRes] = await withTimeout(Promise.all([
-    supabase.from('jmdict_entries').select('id, common, jlpt_level').in('id', entryIds),
+    supabase.from('jmdict_entries').select('id, common, jlpt_level, freq_rank').in('id', entryIds),
     supabase.from('jmdict_kanji').select('entry_id, text').in('entry_id', entryIds),
     supabase.from('jmdict_kana').select('entry_id, text').in('entry_id', entryIds),
     supabase.from('jmdict_senses').select('entry_id, pos, gloss, field, misc').in('entry_id', entryIds),
@@ -100,9 +106,139 @@ export async function fetchEntries(entryIds: string[]): Promise<JMDictResult[]> 
       readings,
       senses,
       jlptLevel: entry.jlpt_level,
+      freqRank: entry.freq_rank ?? null,
       isCommon: entry.common || false,
     };
   });
+}
+
+// ── Lemma batch lookup + disambiguation ──────────────────────────────────────
+// kuromoji gives us a lemma (鎮める) and coarse POS per content word; one query
+// per article collapses N per-word lookups into a single round-trip.
+
+/** Does any sense of this entry match the analyzer's coarse POS? */
+function posMatches(result: JMDictResult, pos: CoarsePos | undefined): boolean {
+  if (!pos) return false;
+  const codes = result.senses.flatMap(s => s.pos);
+  if (pos === 'verb') return codes.some(c => /^v/.test(c));
+  if (pos === 'noun') return codes.some(c => /^n/.test(c));
+  if (pos === 'adjective') return codes.some(c => /^adj/.test(c));
+  if (pos === 'adverb') return codes.some(c => /^adv/.test(c) || c === 'n-adv');
+  return false;
+}
+
+/**
+ * Pick the best entry for a lemma: prefer a POS match, then common words, then
+ * the most frequent (lowest freq_rank). Replaces the old "first entry wins".
+ */
+export function pickBestEntry(candidates: JMDictResult[], pos?: CoarsePos): JMDictResult {
+  return [...candidates].sort((a, b) => {
+    const pa = posMatches(a, pos) ? 0 : 1;
+    const pb = posMatches(b, pos) ? 0 : 1;
+    if (pa !== pb) return pa - pb;
+    if (a.isCommon !== b.isCommon) return a.isCommon ? -1 : 1;
+    return (a.freqRank ?? Infinity) - (b.freqRank ?? Infinity);
+  })[0];
+}
+
+/**
+ * Look up many lemmas at once. Returns lemma → best JMDict entry.
+ * Kanji surface matches win over kana matches for the same lemma.
+ * Entries with no JLPT tag get a derived level (kanji_jlpt, else freq_rank).
+ */
+export async function lookupLemmasBatch(
+  lemmas: string[],
+  posByLemma?: Map<string, CoarsePos>,
+): Promise<Map<string, JMDictResult>> {
+  const unique = [...new Set(lemmas.filter(Boolean))];
+  if (unique.length === 0) return new Map();
+
+  const [kanjiRes, kanaRes] = await withTimeout(Promise.all([
+    supabase.from('jmdict_kanji').select('entry_id, text').in('text', unique),
+    supabase.from('jmdict_kana').select('entry_id, text').in('text', unique),
+  ]), LOOKUP_TIMEOUT_MS, 'lemma batch surface lookup');
+
+  // lemma → candidate entry ids, kanji matches kept separate so they take priority.
+  const kanjiIds = new Map<string, Set<string>>();
+  const kanaIds = new Map<string, Set<string>>();
+  const collect = (rows: { entry_id: string; text: string }[] | null, into: Map<string, Set<string>>) => {
+    (rows || []).forEach(r => {
+      if (!into.has(r.text)) into.set(r.text, new Set());
+      into.get(r.text)!.add(r.entry_id);
+    });
+  };
+  collect(kanjiRes.data, kanjiIds);
+  collect(kanaRes.data, kanaIds);
+
+  const allIds = new Set<string>();
+  [kanjiIds, kanaIds].forEach(m => m.forEach(set => set.forEach(id => allIds.add(id))));
+  if (allIds.size === 0) return new Map();
+
+  const entries = await fetchEntries([...allIds]);
+  const byId = new Map(entries.map(e => [e.entryId, e]));
+
+  const result = new Map<string, JMDictResult>();
+  for (const lemma of unique) {
+    const ids = (kanjiIds.get(lemma)?.size ? kanjiIds.get(lemma) : kanaIds.get(lemma)) ?? new Set();
+    const cands = [...ids].map(id => byId.get(id)).filter((e): e is JMDictResult => !!e);
+    if (cands.length > 0) result.set(lemma, pickBestEntry(cands, posByLemma?.get(lemma)));
+  }
+
+  await applyJlptFallback(result);
+  return result;
+}
+
+/**
+ * Fill in a derived JLPT level for matched entries that carry no official tag:
+ *   (a) the hardest (lowest-numbered) JLPT level among the lemma's kanji, else
+ *   (b) a coarse bucket from frequency rank.
+ * Stored on `derivedJlpt` so the UI can mark it as approximate.
+ */
+async function applyJlptFallback(byLemma: Map<string, JMDictResult>): Promise<void> {
+  const needKanji = new Set<string>();
+  byLemma.forEach((entry, lemma) => {
+    if (entry.jlptLevel == null) {
+      for (const ch of lemma) if (hasKanji(ch)) needKanji.add(ch);
+    }
+  });
+
+  let kanjiLevels = new Map<string, number>();
+  if (needKanji.size > 0) {
+    try {
+      const { data } = await withTimeout(
+        supabase.from('kanji_jlpt').select('kanji, jlpt_level').in('kanji', [...needKanji]),
+        LOOKUP_TIMEOUT_MS,
+        'kanji_jlpt fallback',
+      );
+      kanjiLevels = new Map(
+        ((data || []) as { kanji: string; jlpt_level: number }[]).map(r => [r.kanji, r.jlpt_level]),
+      );
+    } catch (e) {
+      console.warn('kanji_jlpt fallback failed:', e);
+    }
+  }
+
+  byLemma.forEach((entry, lemma) => {
+    if (entry.jlptLevel != null) return;
+    // Hardest kanji = lowest JLPT number (N1 hardest = 1).
+    let derived: number | null = null;
+    for (const ch of lemma) {
+      const lv = kanjiLevels.get(ch);
+      if (lv != null) derived = derived == null ? lv : Math.min(derived, lv);
+    }
+    if (derived == null) derived = freqRankToJlpt(entry.freqRank);
+    entry.derivedJlpt = derived;
+  });
+}
+
+/** Coarse JLPT bucket from a frequency band (1 = most common … 48 = rare). */
+function freqRankToJlpt(rank: number | null): number | null {
+  if (rank == null) return null;
+  if (rank <= 4) return 5;
+  if (rank <= 8) return 4;
+  if (rank <= 16) return 3;
+  if (rank <= 24) return 2;
+  return 1;
 }
 
 /**
@@ -181,101 +317,28 @@ Answer (just the number):`;
 export function jmdictToWordDetails(
   word: string,
   result: JMDictResult
-): { reading: string; meaning: string; jmdictEntryId: string; pos: string[]; jlptLevel: number | null; furiganaMap: { kanji: string; kana: string }[] } {
+): { reading: string; meaning: string; jmdictEntryId: string; pos: string[]; jlptLevel: number | null; jlptDerived: boolean; furiganaMap: { kanji: string; kana: string }[] } {
   const reading = result.readings[0] || '';
   const allGlosses = result.senses.flatMap(s => s.gloss);
   const meaning = allGlosses.slice(0, 3).join('; ') || '';
   const pos = [...new Set(result.senses.flatMap(s => s.pos))];
 
-  // Build furiganaMap from the word and its kana reading
-  const furiganaMap = buildFuriganaMap(word, reading);
+  // Prefer the official JLPT tag; fall back to the derived level when untagged.
+  const jlptLevel = result.jlptLevel ?? result.derivedJlpt ?? null;
+  const jlptDerived = result.jlptLevel == null && jlptLevel != null;
+
+  // Kana-anchored okurigana alignment (shared with the tokenizer).
+  const furiganaMap = alignOkurigana(word, reading);
 
   return {
     reading,
     meaning,
     jmdictEntryId: result.entryId,
     pos,
-    jlptLevel: result.jlptLevel,
+    jlptLevel,
+    jlptDerived,
     furiganaMap,
   };
-}
-
-const isKana = (c: string) => /[\u3040-\u309f\u30a0-\u30ff]/.test(c);
-
-/**
- * Build a furigana map from a word and its reading.
- * Splits the word into segments: kana chars map to themselves,
- * kanji groups get the remaining reading portion.
- * 
- * Example: "食べる" + "たべる" → [{kanji:"食", kana:"た"}, {kanji:"べ", kana:"べ"}, {kanji:"る", kana:"る"}]
- */
-function buildFuriganaMap(word: string, reading: string): { kanji: string; kana: string }[] {
-  const chars = Array.from(word);
-  
-  // If the word is entirely kana, each char maps to itself
-  if (chars.every(isKana)) {
-    return chars.map(c => ({ kanji: c, kana: c }));
-  }
-
-  const segments: { kanji: string; kana: string }[] = [];
-  let readingIdx = 0;
-
-  for (let i = 0; i < chars.length; i++) {
-    const char = chars[i];
-    if (isKana(char)) {
-      segments.push({ kanji: char, kana: char });
-      const kanaPos = reading.indexOf(char, readingIdx);
-      if (kanaPos !== -1) {
-        readingIdx = kanaPos + 1;
-      } else {
-        readingIdx++;
-      }
-    } else {
-      // Kanji character or consecutive kanjis
-      let kanjiEnd = i + 1;
-      while (kanjiEnd < chars.length && !isKana(chars[kanjiEnd])) {
-        kanjiEnd++;
-      }
-      
-      // Determine the reading for this block of kanji
-      let readingEnd = readingIdx;
-      if (kanjiEnd < chars.length) {
-        const nextKana = chars[kanjiEnd];
-        const nextAnchorPos = reading.indexOf(nextKana, readingIdx);
-        readingEnd = nextAnchorPos !== -1 ? nextAnchorPos : readingIdx + (kanjiEnd - i);
-      } else {
-        readingEnd = reading.length;
-      }
-
-      const kanjiBlock = chars.slice(i, kanjiEnd);
-      const blockReading = reading.slice(readingIdx, readingEnd);
-
-      // MANDATORY: Split the block into individual kanji characters
-      // so each gets its own spacing and RTK meaning in the UI.
-      if (kanjiBlock.length === 1) {
-        segments.push({ kanji: kanjiBlock[0], kana: blockReading });
-      } else {
-        // Balanced heuristic for multi-kanji blocks (e.g., 2 kanji + 4 kana -> 2:2)
-        const readingPerKanji = Math.floor(blockReading.length / kanjiBlock.length);
-        const remainder = blockReading.length % kanjiBlock.length;
-
-        let rIdx = 0;
-        for (let k = 0; k < kanjiBlock.length; k++) {
-          const count = readingPerKanji + (k < remainder ? 1 : 0);
-          segments.push({
-            kanji: kanjiBlock[k],
-            kana: blockReading.slice(rIdx, rIdx + count)
-          });
-          rIdx += count;
-        }
-      }
-
-      readingIdx = readingEnd;
-      i = kanjiEnd - 1;
-    }
-  }
-
-  return segments.length > 0 ? segments : [{ kanji: word, kana: reading }];
 }
 
 // ── JLPT corpus coverage ────────────────────────────────────────────────────

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -58,6 +58,7 @@ export interface WordData {
   grammarNote?: string;
   furiganaMap?: { kanji: string; kana: string }[];
   jlptLevel?: number | null;
+  jlptDerived?: boolean;
   pos?: string[];
   jmdictEntryId?: string;
   mastery: MasteryLevel;          // derived bucket, kept in sync with `difficulty`

--- a/src/services/tokenizer.ts
+++ b/src/services/tokenizer.ts
@@ -1,0 +1,193 @@
+/**
+ * Client-side morphological tokenizer (kuromoji.js + IPADIC).
+ *
+ * Replaces the old LLM "morphological analyzer" pass. A real dictionary-based
+ * analyzer gives us, deterministically, for every token:
+ *   - surface form  (鎮めて)        — what to display
+ *   - basic form    (鎮める)        — the lemma to look up in JMDict
+ *   - reading       (しずめて)       — the *contextual* reading, so furigana is right
+ *   - part of speech (動詞/名詞…)    — to disambiguate JMDict senses
+ *
+ * The dictionary (~17 MB of *.dat.gz) is self-hosted under public/kuromoji-dict/
+ * and loaded once per session. In the browser, @sglkc/kuromoji's `browser` field
+ * swaps in a fetch + fflate loader automatically (see its package.json), so no
+ * Node fs dependency leaks into the bundle.
+ */
+
+import type { IpadicFeatures, Tokenizer } from '@sglkc/kuromoji';
+import { isKana, hasKanji, kataToHira, alignOkurigana } from './furigana';
+
+/** Bump when the tokenizer/dict or the enrichment shape changes, so cached
+ *  articles stamped with an older version get re-enriched on next open. */
+export const TOKENIZER_VERSION = 1;
+
+/** Coarse part of speech, mapped from kuromoji's Japanese POS labels. */
+export type CoarsePos = 'verb' | 'noun' | 'adjective' | 'adverb' | 'other';
+
+export interface DisplayToken {
+  /** Surface form, exactly as it appears in the text — what we render. */
+  text: string;
+  /** Hiragana reading of the surface. Present only when the surface has kanji. */
+  furigana?: string;
+  /** Dictionary/base form, used for JMDict lookup and SRS keying. */
+  lemma?: string;
+  /** Coarse POS, used to disambiguate JMDict candidates. */
+  pos?: CoarsePos;
+  /** Tappable content word (verb/noun/adjective/adverb). */
+  isInteractive?: boolean;
+  /** Per-kanji okurigana alignment for the modal furigana breakdown. */
+  furiganaMap?: { kanji: string; kana: string }[];
+}
+
+const DIC_PATH = '/kuromoji-dict/';
+
+let tokenizerPromise: Promise<Tokenizer<IpadicFeatures>> | null = null;
+
+/**
+ * Build (or reuse) the kuromoji tokenizer. Memoized for the session. kuromoji
+ * (~380 KB) is dynamically imported so it stays out of the initial app bundle
+ * and only loads when the reader first enriches an article.
+ */
+export function getTokenizer(): Promise<Tokenizer<IpadicFeatures>> {
+  if (!tokenizerPromise) {
+    tokenizerPromise = import('@sglkc/kuromoji').then(
+      (mod) =>
+        new Promise<Tokenizer<IpadicFeatures>>((resolve, reject) => {
+          mod.default.builder({ dicPath: DIC_PATH }).build((err, tokenizer) => {
+            if (err) reject(err);
+            else resolve(tokenizer);
+          });
+        }),
+    );
+    // Allow a retry on the next call if the load/build fails.
+    tokenizerPromise.catch(() => { tokenizerPromise = null; });
+  }
+  return tokenizerPromise;
+}
+
+// ── POS mapping ──────────────────────────────────────────────────────────────
+
+function coarsePos(pos: string): CoarsePos {
+  if (pos === '動詞') return 'verb';
+  if (pos === '名詞') return 'noun';
+  if (pos === '形容詞') return 'adjective';
+  if (pos === '副詞') return 'adverb';
+  return 'other';
+}
+
+// ── Inflection merge ─────────────────────────────────────────────────────────
+// Fold conjugational tail onto its verb/adjective head so the tappable token is
+// the whole inflected word (鎮めて), not a bare stem (鎮). We keep the head's
+// basic_form as the lemma. Auxiliary *verbs* (いる/しまう/くる) are intentionally
+// left separate (off by default) so 〜ている stays independently tappable.
+
+/** A 助動詞 (auxiliary) always continues the preceding head. */
+function isAuxiliary(t: IpadicFeatures): boolean {
+  return t.pos === '助動詞';
+}
+
+/** The conjunctive 助詞 て/で binds the verb to what follows; merge it onto the head. */
+function isConnectiveParticle(t: IpadicFeatures): boolean {
+  return (
+    t.pos === '助詞' &&
+    t.pos_detail_1 === '接続助詞' &&
+    (t.surface_form === 'て' || t.surface_form === 'で')
+  );
+}
+
+/** A 動詞 in 連用接続/連用形 with no base of its own is part of the inflection (e.g. ない stems). */
+function isInflectionSuffix(t: IpadicFeatures): boolean {
+  // 接尾 verbs/adjectives and non-independent (非自立) suffixes that carry conjugation.
+  return (
+    (t.pos === '動詞' || t.pos === '形容詞') && t.pos_detail_1 === '接尾'
+  );
+}
+
+interface MergedToken {
+  surface: string;
+  reading: string; // katakana, concatenated across the merged span
+  lemma: string;
+  pos: CoarsePos;
+  isContent: boolean;
+}
+
+function mergeInflections(tokens: IpadicFeatures[]): MergedToken[] {
+  const out: MergedToken[] = [];
+
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    const isHead = t.pos === '動詞' || t.pos === '形容詞';
+
+    let surface = t.surface_form;
+    let reading = t.reading && t.reading !== '*' ? t.reading : t.surface_form;
+    const lemma = t.basic_form && t.basic_form !== '*' ? t.basic_form : t.surface_form;
+
+    if (isHead) {
+      // Consume the conjugational tail.
+      while (i + 1 < tokens.length) {
+        const next = tokens[i + 1];
+        if (isAuxiliary(next) || isConnectiveParticle(next) || isInflectionSuffix(next)) {
+          surface += next.surface_form;
+          reading += next.reading && next.reading !== '*' ? next.reading : next.surface_form;
+          i++;
+        } else {
+          break;
+        }
+      }
+    }
+
+    const cpos = coarsePos(t.pos);
+    const isContent =
+      (cpos === 'verb' || cpos === 'noun' || cpos === 'adjective' || cpos === 'adverb') &&
+      t.pos_detail_1 !== '非自立' &&
+      t.pos_detail_1 !== '接尾' &&
+      t.pos_detail_1 !== '数'; // bare numbers aren't worth a dictionary tap
+
+    out.push({ surface, reading, lemma, pos: cpos, isContent });
+  }
+
+  return out;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Tokenize Japanese text into display tokens with furigana + lemma.
+ * Pure transform over the kuromoji output — no network beyond the dict load.
+ */
+export async function tokenizeToDisplay(text: string): Promise<DisplayToken[]> {
+  const tokenizer = await getTokenizer();
+  return displayFromRaw(tokenizer.tokenize(text));
+}
+
+/**
+ * Pure transform from raw kuromoji tokens to display tokens (merge inflections,
+ * align okurigana, classify content words). Separated out so it can be tested
+ * without loading the dictionary.
+ */
+export function displayFromRaw(raw: IpadicFeatures[]): DisplayToken[] {
+  const merged = mergeInflections(raw);
+
+  return merged.map((m) => {
+    const surfaceHasKanji = hasKanji(m.surface);
+    const readingHira = kataToHira(m.reading);
+
+    const token: DisplayToken = { text: m.surface };
+
+    if (surfaceHasKanji) {
+      token.furigana = readingHira;
+      token.furiganaMap = alignOkurigana(m.surface, readingHira);
+    }
+
+    if (m.isContent) {
+      token.isInteractive = true;
+      // Unknown words (proper nouns kuromoji can't analyze) have no usable lemma.
+      if (hasKanji(m.lemma) || isKana(m.lemma[0] ?? '')) {
+        token.lemma = m.lemma;
+      }
+      token.pos = m.pos;
+    }
+
+    return token;
+  });
+}

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -348,73 +348,16 @@ Output EXACTLY a JSON array:
       contents: prompt1,
       config: { responseMimeType: 'application/json' },
     });
-    let rawText1 = (result1.text ?? '').replace(/^```(json)?[\s\n]*/i, '').replace(/[\s\n]*```$/i, '').trim();
+    const rawText1 = (result1.text ?? '').replace(/^```(json)?[\s\n]*/i, '').replace(/[\s\n]*```$/i, '').trim();
     const rawBlocks = JSON.parse(rawText1);
 
-    // Pass 2: Tokenize + furigana
-    const prompt2 = `
-You are a morphological analyzer. For every "text" field in this JSON, replace it with a "content" array of individual Japanese tokens.
-CRITICAL: For EVERY word token containing Kanji, provide a "furigana" field showing its reading.
-CRITICAL: Strip all brackets [], special markup from text.
-
-Input:
-${JSON.stringify(rawBlocks, null, 2)}
-
-Output EXACTLY a JSON array:
-[{"type":"paragraph"|"yugen-box","content":[{"text":"...","furigana":"..."}],"keyword":"...","reading":"...","description":"..."}]
-`;
-
-    console.log(`[process-article] Pass 2 (tokenize) for user ${userId}`);
-    const result2 = await ai.models.generateContent({
-      model: 'gemini-3-flash-preview',
-      contents: prompt2,
-      config: { responseMimeType: 'application/json' },
-    });
-    let rawText2 = (result2.text ?? '').replace(/^```(json)?[\s\n]*/i, '').replace(/[\s\n]*```$/i, '').trim();
-    const processedBlocks = JSON.parse(rawText2);
-
-    // ─────────────────────────────────────────────────────────────────────────
-    // Pass 3: Server-Side JMDict Linking
-    // ─────────────────────────────────────────────────────────────────────────
-    try {
-      console.log(`[process-article] Pass 3 (JMDict linking) for user ${userId}`);
-      
-      const tokensToLink = new Set<string>();
-      processedBlocks.forEach((block: any) => {
-        block.content?.forEach((token: any) => {
-          if (token.furigana) tokensToLink.add(token.text);
-        });
-      });
-
-      const uniqueWords = Array.from(tokensToLink);
-      if (uniqueWords.length > 0) {
-        // Batch query Kanji and Kana matches
-        const [kanjiRes, kanaRes] = await Promise.all([
-          supabase.from('jmdict_kanji').select('entry_id, text').in('text', uniqueWords),
-          supabase.from('jmdict_kana').select('entry_id, text').in('text', uniqueWords),
-        ]);
-
-        const resolvedMap = new Map<string, string>(); // word -> entry_id
-
-        // Simple mapping: Store the first entry_id found for each word
-        // (In a more advanced version, we could check for 'common' flags or disambiguate)
-        kanjiRes.data?.forEach((r: any) => { if (!resolvedMap.has(r.text)) resolvedMap.set(r.text, r.entry_id); });
-        kanaRes.data?.forEach((r: any) => { if (!resolvedMap.has(r.text)) resolvedMap.set(r.text, r.entry_id); });
-
-        // Update blocks with entry IDs
-        processedBlocks.forEach((block: any) => {
-          block.content?.forEach((token: any) => {
-            if (resolvedMap.has(token.text)) {
-              token.jmdict_entry_id = resolvedMap.get(token.text);
-            }
-          });
-        });
-        console.log(`[process-article] Successfully linked ${resolvedMap.size} unique tokens.`);
-      }
-    } catch (linkErr) {
-      console.error('[process-article] JMDict linking error (skipping):', linkErr);
-      // We don't fail the whole request if linking fails; just return unlinked article
-    }
+    // Store paragraphs as raw text ({type, text}); the client tokenizes, adds
+    // furigana, and links JMDict entries with a real morphological analyzer
+    // (kuromoji). Tokenization/furigana/linking used to be Gemini Pass 2 + a
+    // server-side exact-surface Pass 3 — both removed: an LLM with no lexicon
+    // split words at arbitrary boundaries (鎮める → 鎮 read ちん). yugen-box
+    // blocks keep Gemini's keyword/reading/description (that path is reliable).
+    const processedBlocks = rawBlocks;
 
     // 4. Save to processed_news
     const finalArticleId = articleId || `${Date.now()}-${userId.slice(0, 8)}`;


### PR DESCRIPTION
## Why

The reader showed wrong furigana, wrong dictionary meanings, and missing JLPT badges. Root cause: the pipeline asked an **LLM to do morphological analysis with no lexicon** (Gemini Pass 2 "morphological analyzer" + an exact-surface Pass 3 JMDict link). With no dictionary, words split at arbitrary boundaries — e.g. `心を鎮めて` → tap target `鎮`, read `ちん`, linked to a standalone-kanji noun ("a weight; temple supervisor"), no JLPT — while the yugen keyword box (written by Pass 1) got the same word right.

## What

Replace that with a real dictionary-based analyzer (**kuromoji.js + IPADIC**) running client-side. For every token it gives, deterministically: surface, base form (lemma), contextual reading, and POS — fixing segmentation, furigana, and lemma-based lookup in one move, and removing two server passes.

### Phase 1 — tokenizer + dict
- `src/services/tokenizer.ts`: memoized kuromoji singleton, inflection merge (folds 助動詞 / て-form onto verb/adjective heads, keeps the lemma), content-word classification. kuromoji is **lazy-imported** → its own ~29 KB-gz chunk, kept out of the initial bundle.
- `src/services/furigana.ts`: shared kana helpers + **kana-anchored okurigana alignment** (replaces the broken even-split heuristic), reused by `jmdict.ts`.
- Dictionary **self-hosted** under `public/kuromoji-dict/` (~17 MB, HTTP/service-worker cacheable → one download per device, offline after).

### Phase 2 — client enrichment + Reader wiring
- `src/services/enrich.ts` (`enrichArticle`): tokenize → one batched `lookupLemmasBatch` by lemma → attach reading/meaning/JLPT/furigana. Reader renders raw text first, swaps in enriched blocks when ready (guarded against stale background swaps), and caches them. **Lemma-keyed SRS** so conjugations collapse and the end-of-article sweep agrees with clicks.

### Phase 3 — server simplification
- `process-article` now stores raw `{type, text}` paragraphs; **Pass 2/3 deleted** (one fewer Gemini call, no linking queries). Articles cached in the old `content[]` shape **auto-heal** by re-tokenizing on next open — no DB migration / backfill.

### Phase 4 — disambiguation + JLPT fallback + licenses
- **POS-ranked disambiguation** in `jmdict.ts` (replaces first-entry-wins): POS match → common → frequency.
- **JLPT fallback ladder** (`kanji_jlpt` → `freq_rank`), surfaced as `≈Nx` in the modal so derived levels are honest.
- `THIRD_PARTY_LICENSES.md` (NAIST IPADIC notice + Apache-2.0) + Settings acknowledgement.

## Verification

- `npm run build` and `tsc` pass; new files are lint-clean.
- Integration test of the transform against kuromoji confirms:
  - `鎮めて` → lemma `鎮める`, furigana `鎮(しず)め` ✅ (the reported bug)
  - `発表した` → `した` merges, lemma `する` ✅
  - `食べている` → `食べて` + `いる` stay separate (〜ている independently tappable) ✅
  - `入り口` → `入(い)り口(くち)` internal okurigana aligns ✅

## Notes

- The 17 MB dictionary under `public/kuromoji-dict/` is committed (the self-hosting deliverable).
- No DB migration required, consistent with the repo's manual-migration norm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)