### PR TITLE
fix: unwedge JIT buffer deadlock + Step 5 overnight cron

### DIFF
--- a/database/19_overnight_cron.sql
+++ b/database/19_overnight_cron.sql
@@ -1,0 +1,155 @@
+-- ============================================================
+-- 19_overnight_cron.sql
+-- Server-side JIT buffer, part 3 / Step 5 (issue #31): the overnight refill.
+-- pg_cron fires nightly → jit_refill_active_users() → one pg_net POST to the
+-- ensure-buffer Edge Function per ACTIVE user. ensure-buffer stays the single
+-- entrypoint that enforces the buffer invariant (kill switch, N, daily cap M,
+-- advisory-lock claim) — this migration only *triggers* it on a schedule, so
+-- a user who never opens the app still wakes up to a ready article, and a user
+-- whose buffer drained overnight is topped up before morning.
+-- ============================================================
+-- APPLY MANUALLY in the Supabase SQL editor, AFTER database/16/17/18 and after
+-- ensure-buffer is deployed with JIT_ENABLED=true. Idempotent: guarded extension
+-- creates, CREATE OR REPLACE FUNCTION, and a defensive unschedule+reschedule.
+--
+-- ── ONE PREREQUISITE: store the anon key in Vault (run ONCE, by hand) ─────────
+-- ensure-buffer requires a valid JWT at the gateway. The cron sends your PUBLIC
+-- anon key (the same one already shipped in the web bundle — not the service-role
+-- key) as the bearer; ensure-buffer ignores it for identity and uses the body
+-- userId, so the anon key is purely the gateway pass. Set it ONCE in the SQL
+-- editor, then run this whole file (the function reads it from Vault by name, so
+-- re-running this migration never needs the key again, and it never lands in git):
+--
+--     select vault.create_secret(
+--       'YOUR_ANON_KEY', 'jit_anon_key',
+--       'Public anon key the JIT overnight cron uses to pass the ensure-buffer gateway');
+--
+-- The only other embedded value is the PUBLIC project URL (also in the web bundle).
+-- jit_refill_active_users() raises loudly if the secret is missing.
+-- ------------------------------------------------------------
+
+-- ── Extensions ───────────────────────────────────────────────────────────────
+-- pg_cron schedules jobs (schema `cron`); pg_net issues async, non-blocking HTTP
+-- (schema `net`). Both ship with Supabase; if `create extension` is blocked for
+-- your role, enable them once via Dashboard → Database → Extensions, then re-run.
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+-- ── jit_refill_active_users: fan out ensure-buffer over active users ──────────
+-- "Active" = anyone with a study_history event in the last p_active_days. Each
+-- user gets ONE fire-and-forget POST; ensure-buffer does the per-user accounting
+-- and the slow Gemini work. pg_net queues the requests and returns immediately,
+-- so this function never blocks on article production.
+--
+-- Guardrails: p_max_users caps the fan-out (runaway backstop — the per-user cost
+-- ceiling still lives in ensure-buffer's N/M/kill-switch). p_timeout_ms is set
+-- generous because ensure-buffer produces up to N articles synchronously; even
+-- if pg_net stops waiting, the run is idempotent, so the next trigger finishes
+-- any half-filled buffer. We don't care about the response — only the trigger.
+create or replace function public.jit_refill_active_users(
+  p_active_days int default 14,
+  p_max_users   int default 500,
+  p_timeout_ms  int default 60000  -- covers ~N sequential Gemini rewrites in ensure-buffer
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  -- PUBLIC base URL (same value as VITE_SUPABASE_URL in the web bundle — not a secret).
+  v_url   text := 'https://mfehycyixslnedyffito.supabase.co';
+  v_key   text;
+  v_count int := 0;
+  r       record;
+begin
+  select decrypted_secret into v_key
+    from vault.decrypted_secrets where name = 'jit_anon_key';
+  if v_key is null then
+    raise exception
+      'jit_refill_active_users: missing Vault secret jit_anon_key (see database/19_overnight_cron.sql header)';
+  end if;
+
+  for r in
+    select distinct sh.user_id
+      from public.study_history sh
+     where sh.created_at > now() - make_interval(days => p_active_days)
+     limit p_max_users
+  loop
+    perform net.http_post(
+      url     := v_url || '/functions/v1/ensure-buffer',
+      headers := jsonb_build_object(
+                   'Content-Type',  'application/json',
+                   'Authorization', 'Bearer ' || v_key
+                 ),
+      body    := jsonb_build_object('userId', r.user_id),
+      timeout_milliseconds := p_timeout_ms
+    );
+    v_count := v_count + 1;
+  end loop;
+
+  raise log 'jit_refill_active_users: queued % active user(s) (active_days=%, cap=%)',
+    v_count, p_active_days, p_max_users;
+  return jsonb_build_object('queued', v_count, 'active_days', p_active_days);
+end;
+$$;
+
+-- Only the cron scheduler (postgres) runs this; keep it off every client role.
+revoke all on function public.jit_refill_active_users(int, int, int) from public;
+
+-- ── Schedule: nightly overnight refill ───────────────────────────────────────
+-- 09:00 UTC ≈ 1–4 AM across US time zones — articles are ready before morning.
+-- Adjust the cron expression to your users' overnight. Idempotent reschedule:
+-- drop the old job first so re-running this file doesn't error or duplicate.
+do $$
+declare
+  j bigint;
+begin
+  for j in select jobid from cron.job where jobname = 'jit-overnight-refill' loop
+    perform cron.unschedule(j);
+  end loop;
+end $$;
+
+select cron.schedule(
+  'jit-overnight-refill',
+  '0 9 * * *',
+  $cron$ select public.jit_refill_active_users(); $cron$
+);
+
+-- ── Retire daily-feed ────────────────────────────────────────────────────────
+-- ensure-buffer + this cron fully supersede the old broadcast daily-feed job
+-- (which pushed the SAME 2 headlines to every user, ignoring the buffer). Remove
+-- any pg_cron schedule that points at it. NOTE: if daily-feed was scheduled via
+-- Dashboard → Edge Functions → Schedules (not pg_cron), disable it THERE too —
+-- this DO block only reaches pg_cron jobs. The Edge Function source is left
+-- deployed but marked deprecated; delete it once this cron is verified live.
+do $$
+declare
+  j bigint;
+begin
+  for j in
+    select jobid from cron.job
+     where jobname = 'daily-feed'
+        or jobname ilike '%daily-feed%'
+        or command ilike '%daily-feed%'
+  loop
+    perform cron.unschedule(j);
+  end loop;
+end $$;
+
+-- ── Verify (run after applying) ──────────────────────────────────────────────
+--   -- the anon-key secret is present:
+--   select name from vault.secrets where name = 'jit_anon_key';
+--
+--   -- the job is scheduled and daily-feed is gone:
+--   select jobid, jobname, schedule, active from cron.job order by jobid;
+--
+--   -- manual smoke test (fires the real POST(s) now; watch ensure-buffer logs):
+--   select public.jit_refill_active_users();   -- → {"queued": N, "active_days": 14}
+--
+--   -- inspect the most recent pg_net responses (200 = ensure-buffer reached):
+--   select id, status_code, content from net._http_response order by id desc limit 5;
+--
+--   -- inspect cron run history:
+--   select jobid, status, return_message, start_time
+--     from cron.job_run_details order by start_time desc limit 10;

--- a/docs/task.md
+++ b/docs/task.md
@@ -112,8 +112,10 @@
         - [x] ISOLATED GATE PASSED (2026-06-13, JIT_ENABLED=true, cap bumped to 30):
               empty buffer → produced exactly 2; repeat calls → reason:full, produced:0
               (idempotent, no runaway). Guardrails #1/#2/#3/#7 + idempotency proven live.
-        - [ ] In-app open test (READY card, open → read → 1 replacement). Then reset
-              JIT_DAILY_CAP to 15 (bumped to 30 for the same-day test).
+        - [x] Verified on Vercel preview, then SHIPPED to prod (PR #44 → main 0213b73,
+              deploy success). JIT_ENABLED=true confirmed live before merge.
+        - [ ] Post-ship: clear stale client localStorage for the true fresh experience;
+              consider JIT_DAILY_CAP 30 → 15.
   - [x] Step 3: server-owned read/dismiss — api.markArticleConsumed (direct RLS
         update, .in('status',['ready','pending']) so only a live buffer row moves,
         exactly once; raw cards & already-consumed no-op = guardrail #6) + api.ensureBuffer.
@@ -124,5 +126,29 @@
         leftovers); client JIT effect REMOVED; redundant saveProcessedArticle Supabase
         mirror REMOVED; on-tap fallback kept. build + lint clean (no new errors).
         ⚠️ MUTUALLY EXCLUSIVE with server JIT — do not merge until JIT_ENABLED=true in prod.
-  - [ ] Step 5: overnight cron — pg_cron + pg_net → ensure-buffer for active users
+  - [x] HOTFIX (2026-06-13): buffer-wedge deadlock. Server had 2 `ready` articles
+        (healthy, under cap) but the feed showed nothing new. Cause: loadHub
+        re-filtered server `ready` rows through the LOCAL seen set; swiping a raw
+        headline before it's processed only wrote localStorage (no DB row), so the
+        buffer re-produced that story → it landed `ready` but was hidden as "seen"
+        → buffer stuck full at N → server stopped producing. Fix: (1) App.tsx
+        loadHub trusts server `ready` status, no longer seen-filters the buffer;
+        (2) api.markArticleConsumed writes a dismissed/read TOMBSTONE when no live
+        buffer row matched, so ensure_buffer_claim's ON CONFLICT never re-produces
+        a swiped raw headline. Self-heals existing stuck buffers on next open.
+  - [/] Step 5: overnight cron — pg_cron + pg_net → ensure-buffer for active users
         (study_history in last 14 days), service-role key via Vault. Retire daily-feed.
+        Cron adds overnight/daily-fresh seeding + bootstrap for non-opening users
+        (event-driven app-open/read/dismiss refill already shipped in Steps 3/4).
+        - [x] database/19_overnight_cron.sql (manual-apply): enables pg_cron+pg_net;
+              jit_refill_active_users(active_days,max_users,timeout) reads the PUBLIC
+              anon key from Vault (jit_anon_key) + hardcoded public URL, fans out ONE
+              pg_net POST/active user to ensure-buffer (idempotent, fire-and-forget);
+              nightly cron 'jit-overnight-refill' @ 09:00 UTC; defensively unschedules
+              any daily-feed pg_cron job. ensure-buffer keeps verify_jwt=true; anon key
+              is just the gateway pass (body userId is authoritative).
+        - [x] daily-feed/index.ts marked DEPRECATED (banner); pg_cron schedule removed
+              by 19. Dashboard-scheduled daily-feed (if any) must be disabled by hand.
+        - [ ] APPLY (your steps): (1) select vault.create_secret('<ANON_KEY>','jit_anon_key');
+              (2) run database/19 in SQL editor; (3) smoke-test select jit_refill_active_users().
+        - [ ] After cron verified live: delete the daily-feed Edge Function deployment.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,7 +159,17 @@ function App() {
       // Server-produced ready articles go FIRST — they're fresh and instantly
       // openable. They surface even when not in today's raw NewsAPI fetch, fixing
       // the original "processed-but-unread article never appears on open" bug.
-      const readyFresh = readyBuffer.filter(a => a && a.id && !seen.has(a.id));
+      //
+      // Do NOT re-filter these through the local `seen` set: the server's `ready`
+      // status is authoritative. ensure_buffer_claim only produces a story the
+      // user has no row for, and markArticleConsumed flips a row OUT of `ready`
+      // the instant it's read/dismissed — so a row that is STILL `ready` is
+      // genuinely unread. A ready id CAN sit in the local seen set when a raw
+      // headline was swiped before it was ever processed (that dismiss only
+      // touched localStorage, leaving no DB row, so the buffer later re-produced
+      // it). Filtering it here hid the article AND wedged the buffer full of
+      // invisible rows so nothing new ever loaded (issue #31 deadlock).
+      const readyFresh = readyBuffer.filter(a => a && a.id);
       const readyIds = new Set(readyFresh.map(a => a.id));
 
       const uniqueFeed = Array.from(new Map(feed.map(a => [a.id, a])).values());

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -107,9 +107,10 @@ export async function markArticleConsumed(
   userId: string,
   kind: 'read' | 'dismissed',
 ): Promise<boolean> {
+  const now = new Date().toISOString();
   const patch = kind === 'read'
-    ? { status: 'read', read_at: new Date().toISOString() }
-    : { status: 'dismissed', dismissed_at: new Date().toISOString() };
+    ? { status: 'read', read_at: now }
+    : { status: 'dismissed', dismissed_at: now };
   const { data, error } = await supabase
     .from('processed_news')
     .update(patch)
@@ -121,7 +122,23 @@ export async function markArticleConsumed(
     console.error(`[api] markArticleConsumed(${kind}) failed:`, error);
     return false;
   }
-  return (data?.length ?? 0) > 0;
+  if ((data?.length ?? 0) > 0) return true; // a live buffer row moved → caller refills
+
+  // No live buffer row matched: this was a RAW feed card swiped/read before it was
+  // ever processed, so the only record of it was in localStorage. Write a tombstone
+  // so ensure_buffer_claim's ON CONFLICT never (re)produces this story into the
+  // buffer — where it would land `ready` but, being in the client's local seen set,
+  // get hidden and wedge the buffer (the issue #31 deadlock). A no-content row is
+  // valid (title/content are nullable). This is NOT a buffer move, so it returns
+  // false and never triggers production (guardrail #6: only real buffer rows refill).
+  const tombstone = kind === 'read'
+    ? { id: articleId, user_id: userId, status: 'read', read_at: now }
+    : { id: articleId, user_id: userId, status: 'dismissed', dismissed_at: now };
+  const { error: tombErr } = await supabase
+    .from('processed_news')
+    .upsert(tombstone, { onConflict: 'user_id,id', ignoreDuplicates: true });
+  if (tombErr) console.warn(`[api] markArticleConsumed(${kind}) tombstone failed:`, tombErr.message);
+  return false;
 }
 
 /** Ask the server to top up this user's ready-article buffer. Idempotent and

--- a/supabase/functions/daily-feed/index.ts
+++ b/supabase/functions/daily-feed/index.ts
@@ -1,3 +1,10 @@
+// ⚠️ DEPRECATED (issue #31, Step 5) — superseded by the server-side JIT buffer.
+// This job broadcast the SAME 2 headlines to every user, ignoring per-user read/
+// dismiss state and the buffer invariant. The overnight refill is now pg_cron →
+// jit_refill_active_users() → ensure-buffer (per user, idempotent, capped). Its
+// pg_cron schedule is removed by database/19_overnight_cron.sql. Left deployed
+// only as a fallback; delete this function once the new cron is verified live.
+
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 const corsHeaders = {


### PR DESCRIPTION
## The bug (urgent)
Testing in prod: read everything, **nothing new loads**, feed stuck on raw cards — while the server held **2 healthy `ready` articles** (0 failed, under daily cap).

### Root cause
`loadHub` re-filtered the server's `ready` buffer through the client's **local seen set**. Swiping a raw headline before it's processed writes *only* localStorage (no DB row), so the buffer **re-produced that story** — it landed `ready` but was hidden as "already seen" → buffer wedged full at N → `ensure_buffer_claim` saw no deficit → server stopped producing. Deadlock.

### Fix
1. **`App.tsx` `loadHub`** — trust the server `ready` status as authoritative; stop seen-filtering the buffer. A row that's still `ready` is genuinely unread (read/dismiss flips it out of `ready` server-side). The raw feed still respects the seen set.
2. **`api.markArticleConsumed`** — when no live `ready`/`pending` row matches (i.e. a raw card swiped before processing), write a `read`/`dismissed` **tombstone** so `ensure_buffer_claim`'s `ON CONFLICT` never re-produces it. Not counted as a buffer move (guardrail #6 intact).
3. **Self-heals** existing stuck buffers on next open.

## Also: Step 5 (issue #31 overnight cron)
- `database/19_overnight_cron.sql` (manual-apply, **already applied + verified live** by @kdevoe): `pg_cron` + `pg_net` nightly → `jit_refill_active_users()` → one `ensure-buffer` POST per active user (anon key from Vault, hardcoded public URL); retires any `daily-feed` pg_cron job.
- `daily-feed/index.ts` — DEPRECATED banner.

## Verification
- `npm run build` clean (tsc + vite).
- Cron smoke-tested live: `jit_refill_active_users()` → `net._http_response` 200.
- Buffer fix is the frontend deploy that resolves the "nothing loads" report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)