### PR TITLE
fix: stop Reader flashing when a background article finishes (#42)

### DIFF
--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -74,11 +74,23 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     } catch { return null; }
   }, []);
   
-  const {
-    wordDatabase, saveWordDefinition, recordWordSeen, setWordMastery, applyDifficultyEvent,
-    currentArticle, setCurrentArticle, articlesCache, saveProcessedArticle,
-    readerFontSize, readerFontWeight
-  } = useAppStore();
+  // Narrow, per-field subscriptions so the Reader re-renders ONLY when something it
+  // actually renders changes. The old selector-less `useAppStore()` subscribed to the
+  // whole store, so any background `articlesCache` write (the server buffer surfacing a
+  // freshly-produced article mid-session) re-rendered the open Reader for nothing.
+  // `articlesCache` is read imperatively in `loadArticle` (once, at open) — it needs no
+  // reactive subscription. Actions are stable references in Zustand, so subscribing to
+  // them never triggers a re-render.
+  const currentArticle = useAppStore(s => s.currentArticle);
+  const wordDatabase = useAppStore(s => s.wordDatabase);
+  const readerFontSize = useAppStore(s => s.readerFontSize);
+  const readerFontWeight = useAppStore(s => s.readerFontWeight);
+  const saveWordDefinition = useAppStore(s => s.saveWordDefinition);
+  const recordWordSeen = useAppStore(s => s.recordWordSeen);
+  const setWordMastery = useAppStore(s => s.setWordMastery);
+  const applyDifficultyEvent = useAppStore(s => s.applyDifficultyEvent);
+  const setCurrentArticle = useAppStore(s => s.setCurrentArticle);
+  const saveProcessedArticle = useAppStore(s => s.saveProcessedArticle);
 
   // Keep the observer's view of mutable state fresh without re-creating it.
   clickedWordsRef.current = clickedWords;
@@ -133,7 +145,9 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
   const loadArticle = async () => {
     loadIdRef.current = initialArticle?.id ?? null;
 
-    // 1. Check Cache first for instant return
+    // 1. Check Cache first for instant return. Read imperatively — the Reader has no
+    // reactive subscription to articlesCache (see the store hooks above).
+    const articlesCache = useAppStore.getState().articlesCache;
     if (initialArticle?.id && articlesCache[initialArticle.id]) {
       const cached = articlesCache[initialArticle.id];
       setCurrentArticle(cached);
@@ -506,7 +520,12 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
 
   return (
     <>
-      <div ref={contentRef} className="reading-content fade-in" style={{ paddingBottom: 0, fontSize: `${readerFontSize || 18}px`, fontWeight: readerFontWeight || 500 }}>
+      {/* key pins the fade-in to the article identity: `enrichInBackground` swaps in a
+          NEW currentArticle object (same id) once readings are linked, mid-read. Keying
+          by id lets React reconcile in place across that swap — the furigana appears
+          without remounting, so the `fade-in` animation never replays as a flash. The
+          animation plays only on a genuine open (the loading → loaded branch flip). */}
+      <div key={currentArticle.id} ref={contentRef} className="reading-content fade-in" style={{ paddingBottom: 0, fontSize: `${readerFontSize || 18}px`, fontWeight: readerFontWeight || 500 }}>
         <div style={{ marginBottom: '3rem' }}>
           <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)', marginBottom: '1rem', display: 'flex', gap: '1rem' }}>
             <span style={{ backgroundColor: 'var(--bg-card)', padding: '0.2rem 0.6rem', borderRadius: '4px' }}>{currentArticle.category}</span>


### PR DESCRIPTION
Closes #42.

## What was happening
The open Reader subscribed to the **entire** store via a selector-less `useAppStore()`, so *any* background `articlesCache` write re-rendered it. With the client JIT pre-processor retired in #44, the current background writer is #46's `surfaceReadyBuffer` — an 8s poll after read/dismiss that calls `setArticlesCache(...)` to surface freshly-produced buffer articles mid-session.

## The trace (the issue's stated cause didn't hold)
A background cache write changes neither `currentArticle` nor `loading`, so the Reader's render output is identical and React performs **zero DOM mutation** — and a CSS `fade-in` only replays on *remount*, which requires the loading↔loaded branch to flip. So the over-subscription alone can't produce the flash.

The real suspect is **`enrichInBackground`**: on open it calls `setCurrentArticle(enriched)` — a *new* article object (same id) with readings linked, swapped in mid-read. Its timing (sub-second to seconds after open) is easy to mis-attribute to "a second article finishing."

## The fix
1. **Narrow the subscription** — per-field selectors instead of the whole store; `articlesCache` is read imperatively in `loadArticle` (only needed once, at open). Reader no longer re-renders on background buffer writes.
2. **Pin `fade-in` to `currentArticle.id`** — React reconciles the `enrichInBackground` swap in place (furigana appears, no remount, no animation replay). The fade now plays only on a genuine open.

## Caveat
Reasoned from the code, not observed live — reproducing needs non-DEV auth + the server buffer's 8s poll. Fix #2 targets the most likely real cause; if the flash survives in prod we'd want a runtime repro to pin the exact path.

## Testing
- `npm run build` — passes
- `npm run lint` — no new issues in `Reader.tsx` (pre-existing `any`/exhaustive-deps only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)