### PR TITLE
fix: stop the Reader flashing to a spinner when you open another article (#42)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -406,7 +406,10 @@ function App() {
     // dismisses it manually when they're done with it.
     markArticleRead(article.id);
     watchForFreshReady(); // reading a buffer article frees a slot → server refills
-    useAppStore.getState().setCurrentArticle(null);
+    // NOTE: do NOT null currentArticle here. The Reader loads its own article by id on
+    // mount (keyed by activeArticle.id), so blanking the shared currentArticle only
+    // served to flash the article you're currently reading down to a spinner the moment
+    // you tapped a different one — before the new article had even finished loading.
 
     if (articlesCache[article.id]) {
       openReader(articlesCache[article.id]);

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -196,9 +196,15 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     window.scrollTo(0, 0);
   }, []);
 
+  // Each Reader instance is keyed to one article (App keys <Reader> by id), so load
+  // THIS article on mount. Keying the load off `initialArticle.id` — rather than the
+  // global `currentArticle` being null — means the feed no longer has to blank the
+  // shared currentArticle to trigger a load, which used to flash the article you were
+  // reading down to a spinner the instant you tapped a different one.
   useEffect(() => {
-    if (!currentArticle && !loading) loadArticle();
-  }, [initialArticle]);
+    if (currentArticle?.id !== initialArticle?.id) loadArticle();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialArticle?.id]);
 
   // Build the gradeable-word payload map for the article: the richest token per
   // lemma (details/jmdict id win), so a word can be stored and JLPT-seeded on grade.
@@ -506,7 +512,11 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     });
   };
 
-  if (loading || !currentArticle) {
+  // Render content only when the loaded article IS this Reader's article. On mount the
+  // shared `currentArticle` may still hold the PREVIOUS article for a frame (until the
+  // load effect runs) — gating on identity shows this article's loading state instead
+  // of briefly flashing the old article's text under the new one.
+  if (loading || !currentArticle || currentArticle.id !== initialArticle?.id) {
     return (
       <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', minHeight: '60vh', textAlign: 'center', padding: '0 2rem' }}>
         <div className="lucide-spin" style={{ color: 'var(--text-main)', marginBottom: '1.5rem', width: '32px', height: '32px', border: '3px solid var(--border-light)', borderTopColor: 'var(--text-main)', borderRadius: '50%' }} />


### PR DESCRIPTION
Follow-up to #47, which did **not** fix the flash. Re #42.

## Why #47 missed
#47 narrowed the Reader's store subscription on the theory that a background `articlesCache` write re-rendered it. I reproduced the scenario locally (dev server + browser automation) and **disproved** that path: scrolling an open Reader to 1200px and firing a background `saveProcessedArticle` for a *different* article left scroll at 1200 with no remount. Background processing is not the trigger.

## The real cause (reproduced)
It's the **on-tap path**. When you tap a second article, `handleSelectArticle` ran `setCurrentArticle(null)` **synchronously** — before the 10–20s of processing. Because the open Reader renders entirely off the shared global `currentArticle`, that instantly blanked the article you were reading down to the loading spinner (`読書家 / Initializing feed…`). Then when the tapped article finished, `openReader` remounted the Reader (`key={activeArticle.id}`) → `scrollTo(0,0)` + `fade-in` = "resets to the top."

The `setCurrentArticle(null)` was only there to satisfy the Reader's load trigger, which was gated on the global being null:
```js
useEffect(() => { if (!currentArticle && !loading) loadArticle(); }, [initialArticle])
```

## The fix
- **Reader loads by identity, not by global-null.** Each `<Reader>` is already keyed by article id, so load when the instance's `initialArticle.id` changes — the feed no longer has to blank shared state to trigger a load.
- **Render gated on identity** (`currentArticle.id === initialArticle.id`) so a Reader shows its own loading state instead of briefly flashing the previous article's text.
- **Removed the premature `setCurrentArticle(null)`** from the feed tap handler.

## Verification (local, instrumented)
- Tapping an article: **no** `setCurrentArticle(null)` fires; open is a single clean `MOUNT` + one `scrollTo`; content renders correctly (no stale/blank frame).
- Background article finishing while reading: scroll position **unchanged**, no remount.
- `npm run build` passes; no new lint issues (pre-existing `any`/deps only).

## Note
The `key={currentArticle.id}` belt-and-suspenders from #47 is already in `main` and is retained — it's harmless and still correct for the enrichment swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)