### PR TITLE
fix: stop 'seen' sync from nulling graded difficulty

### DIFF
--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -291,6 +291,11 @@ export const useAppStore = create<AppState>()(
               import('./api').then(m => {
                 const syncData = {
                   mastery: updatedWord.mastery,
+                  // Preserve the word's graded difficulty. This is a full-row upsert,
+                  // so omitting `difficulty` writes null and wipes the SRS signal that
+                  // applyDifficultyEvent/setMastery wrote — and the seen path fires far
+                  // more often than grading, so it clobbered most words.
+                  difficulty: updatedWord.difficulty ?? null,
                   timesSeen: updatedWord.timesSeen,
                   streak: updatedWord.streak,
                   lastSeenTs: updatedWord.lastSeenTs


### PR DESCRIPTION
## Problem

~58% of tracked words had lost their SRS `difficulty` signal (484 / 1154 graded; the rest reset to `null`) even though the event log showed 1,146 words had been graded at some point.

**Root cause:** the seen/lookup path in `store.ts` built `syncData` without a `difficulty` field, and `upsertWordProgressToSupabase` does a **full-row upsert** with `difficulty: progress.difficulty ?? null`. Because "seen" events fire far more often than grading (5,191 vs 2,790), simply reading past a word overwrote its graded difficulty with `null`, clobbering whatever `applyDifficultyEvent` / `setWordMastery` had written.

## Fix

Carry the word's current `difficulty` through the seen-path upsert so reading past a word preserves its SRS value instead of wiping it. `tsc --noEmit` passes.

## Data backfill (already applied to prod)

A one-time backfill restored the lost words from the `study_history` `mastery_change` event log (each word's last-known difficulty, with `mastery_level` re-derived). Signal coverage went **42% → 99.8%** (484 → 1,152 graded; only 2 words remain null, and those never had any difficulty history). This was a live DB write and is **not** part of this diff.

## Notes

The tendency for new words to *start* hard is a separate, intentional mechanism (`seedDifficulty`, `store.ts`): a word one JLPT level above the user seeds at 8, and a word with no JLPT tag defaults to 9. This PR only stops the signal from being erased afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)