### PR TITLE
fix: harden PWA against auth-lock stalls + popLayout ref warning

### DIFF
--- a/src/components/Feed.tsx
+++ b/src/components/Feed.tsx
@@ -1,7 +1,7 @@
 import { motion, AnimatePresence, useMotionValue, useTransform, animate } from 'framer-motion';
 import { CheckCircle2, Trash2, Bookmark } from 'lucide-react';
 import { NewsArticle } from '../services/api';
-import { useState } from 'react';
+import { useState, forwardRef } from 'react';
 
 interface Props {
   articles: NewsArticle[];
@@ -15,17 +15,21 @@ interface Props {
   isManualFetching?: boolean;
 }
 
-function NewsCard({ 
-  article, onSelect, onDismiss, isProcessing, isCached, isOpen, setOpenId 
-}: { 
-  article: NewsArticle; 
-  onSelect: (a: NewsArticle) => void; 
+// forwardRef is required by <AnimatePresence mode="popLayout">: Framer attaches a
+// ref to each child to measure it and absolutely-position it while it exits. A
+// plain function component drops that ref (React warns), leaving popLayout unable
+// to manage exiting cards correctly.
+const NewsCard = forwardRef<HTMLDivElement, {
+  article: NewsArticle;
+  onSelect: (a: NewsArticle) => void;
   onDismiss: (id: string) => void;
   isProcessing: boolean;
   isCached: boolean;
   isOpen: boolean;
   setOpenId: (id: string | null) => void;
-}) {
+}>(function NewsCard({
+  article, onSelect, onDismiss, isProcessing, isCached, isOpen, setOpenId
+}, ref) {
   const x = useMotionValue(0);
   // Transform x position: gradual linear fade from 0 to 1 over the full track
   const backdropOpacity = useTransform(x, [-160, 0], [1, 0]);
@@ -37,7 +41,8 @@ function NewsCard({
   };
 
   return (
-    <motion.div 
+    <motion.div
+      ref={ref}
       layout="position"
       variants={itemVariants}
       initial="hidden"
@@ -228,7 +233,7 @@ function NewsCard({
       </motion.div>
     </motion.div>
   );
-}
+});
 
 export function Feed({ articles, onSelect, onDismiss, isLoading, isReplenishing, processingIds, cachedIds, onManualFetch, isManualFetching }: Props) {
   const [openArticleId, setOpenArticleId] = useState<string | null>(null);

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, processLock } from '@supabase/supabase-js';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL?.replace(/['"]/g, '') || 'https://placeholder.supabase.co';
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.replace(/['"]/g, '') || 'placeholder';
@@ -12,6 +12,14 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     autoRefreshToken: true,
     detectSessionInUrl: true,
     flowType: 'pkce',
+    // Use the in-memory process lock instead of the default navigator.locks lock.
+    // In a long-lived iOS standalone PWA, a token auto-refresh that starts just as
+    // iOS suspends the WebView can leave the navigator.locks lock held and never
+    // released; every later getSession()/refresh then blocks on it, so all
+    // session-dependent actions (article open, word-lookup sync) stall while
+    // local-only UI keeps working. processLock serializes in-memory within this
+    // single window — correct for a one-window PWA — and cannot deadlock that way.
+    lock: processLock,
   },
 });
 


### PR DESCRIPTION
## Context

Investigating reports that the **installed iOS standalone PWA** stops responding to taps: opening an article does nothing (no error banner), word lookup works once then stops, and you can't open articles after navigating back — while the **Progress view and nav keep working**, it **degrades over a long session**, and a **reload clears it**.

## Diagnosis (what's established)

- **Not stale cache** (broke after a fresh reinstall; worked briefly first).
- **Not a global overlay** (Progress clicks work).
- **Not a deterministic logic bug** — the exact tap sequences were reproduced cleanly in **desktop Chromium (mouse)** *and* **WebKit + iPhone touch emulation (Playwright)**: taps fire, `popLayout` dismiss leaves zero ghost overlays, post-dismiss taps fire.
- **The split is along one line:** everything that breaks touches the **Supabase session / network**; everything that works is **local-only**.
- **Only reproduces on the real iOS standalone PWA over a long-lived session** — not in any fresh/emulated environment.

Root cause is **not yet confirmed on-device** (pending a Safari Web Inspector capture). These are two **low-risk hardening** changes that each remove a known iOS-PWA failure class consistent with the symptoms.

## Changes

1. **`src/services/supabase.ts` — use `processLock`.** The client used the default `navigator.locks` lock. In a long-lived iOS standalone PWA, a token auto-refresh that starts as iOS suspends the WebView can leave that lock held and never released; subsequent `getSession()`/refresh calls then block on it, stalling every session-dependent action while local-only UI keeps working. `processLock` (in `@supabase/supabase-js` 2.100.1) serializes in-memory within the single PWA window — correct for a one-window app — and cannot deadlock that way. This best fits the "only session-dependent actions break" discriminator.

2. **`src/components/Feed.tsx` — wrap `NewsCard` in `forwardRef`.** `<AnimatePresence mode="popLayout">` attaches a ref to each child to measure and absolutely-position exiting cards; `NewsCard` was a plain function component, so the ref was dropped (React warns), leaving `popLayout` unable to manage exits. The ref now forwards to the card's root motion element.

## Verification

- `tsc --noEmit` clean; `npm run build` succeeds.
- Could not reproduce the on-device failure locally (Chromium + WebKit/touch), so these are **not yet confirmed fixes** — labeling as hardening. Next step: Safari Web Inspector capture from the device to confirm the exact cause (hung request vs. wedged lock vs. frozen main thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)