### PR TITLE
Relabel end-of-article button to 完了 (delete on finish) + stop stale auto-open

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -391,6 +391,13 @@ function App() {
   // Do not restore it. (And this branch must not ship until JIT_ENABLED=true is
   // set in prod, else there is no pre-processing at all → spinner on every open.)
 
+  // Tracks the article the user most recently asked to open. On-demand processing
+  // takes ~10-20s; by the time it resolves the user may have tapped a different
+  // article, opened another, or gone back to browsing the list. A stale resolution
+  // must NOT yank them into an article they're no longer waiting for — it just
+  // lands in the cache (READY badge) for them to open on their own terms.
+  const pendingOpenIdRef = useRef<string | null>(null);
+
   const openReader = useCallback((article: NewsArticle) => {
     setActiveArticle(article);
     setNewsView('reading');
@@ -401,6 +408,9 @@ function App() {
 
   const handleSelectArticle = async (article: NewsArticle) => {
     if (!article.id) return;
+    // Mark this as the live open request. Any in-flight processing for a PREVIOUS
+    // tap will see a changed token when it resolves and decline to navigate.
+    pendingOpenIdRef.current = article.id;
     // Reading marks the article read (so it's never pulled back in as a fresh
     // suggestion) but does NOT remove it from the visible feed — the user
     // dismisses it manually when they're done with it.
@@ -432,14 +442,16 @@ function App() {
       const fromServer = await fetchProcessedArticleById(article.id, userId);
       if (fromServer) {
         saveProcessedArticle(article.id, fromServer);
-        openReader(fromServer);
+        // Cached now; only navigate if the user is still waiting on THIS article.
+        if (pendingOpenIdRef.current === article.id) openReader(fromServer);
         return;
       }
 
       // Genuinely not processed yet — process on demand, then open the Reader.
       const processed = await handleProcessArticle(article);
       if (processed) {
-        openReader(processed);
+        // Don't yank the user in if they moved on during the long processing wait.
+        if (pendingOpenIdRef.current === article.id) openReader(processed);
       } else {
         // handleProcessArticle swallows its error into failedArticleIds; surface
         // it here so the tap doesn't just silently do nothing.
@@ -461,6 +473,13 @@ function App() {
     setNewsView('hub');
     setShowNav(true);
     surfaceReadyBuffer(); // returning to the feed: pull in anything produced while reading
+  };
+
+  // Finish button at the end of the Reader: mark the article done AND remove it
+  // from the feed (handleDismissAndSync), then return to the hub.
+  const handleFinishArticle = () => {
+    if (activeArticle?.id) handleDismissAndSync(activeArticle.id);
+    handleBackToHub();
   };
 
   useEffect(() => {
@@ -624,7 +643,7 @@ function App() {
               isManualFetching={isLoadingFeed}
             />
           ) : (
-            <Reader key={activeArticle?.id} initialArticle={activeArticle} onComplete={handleBackToHub} />
+            <Reader key={activeArticle?.id} initialArticle={activeArticle} onComplete={handleFinishArticle} />
           )
         )}
         {activeTab === 'progress' && <Progress />}

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -553,21 +553,21 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
           return null;
         })}
 
-        {/* Restored Tsugihe Capsule Button */}
+        {/* Finish capsule: marks the article done and removes it from the feed. */}
         <div style={{ textAlign: 'center', marginTop: '4rem', marginBottom: 'calc(2rem + env(safe-area-inset-bottom))' }}>
            <button
              onClick={() => onComplete?.()}
-             style={{ 
-               backgroundColor: 'transparent', 
-               color: 'var(--text-muted)', 
-               padding: '0.75rem 2.5rem', 
-               borderRadius: '100px', 
-               fontWeight: 600, 
-               border: '1px solid var(--border-light)', 
+             style={{
+               backgroundColor: 'transparent',
+               color: 'var(--text-muted)',
+               padding: '0.75rem 2.5rem',
+               borderRadius: '100px',
+               fontWeight: 600,
+               border: '1px solid var(--border-light)',
                cursor: 'pointer'
              }}
            >
-             <span className="serif" style={{ fontSize: '1.25rem', verticalAlign: 'middle', marginRight: '0.2rem' }}>次へ</span> &rarr;
+             <span className="serif" style={{ fontSize: '1.25rem', verticalAlign: 'middle' }}>完了</span>
            </button>
         </div>
       </div>


### PR DESCRIPTION
## Changes

**1. End-of-article button: 次へ → 完了, and it now deletes the article**
- `Reader.tsx`: relabeled the end-of-article capsule from `次へ →` to `完了` (kanryō, "finish") and removed the forward arrow.
- `App.tsx`: new `handleFinishArticle` wired to the Reader's `onComplete`. It dismisses the active article (removes it from the feed, frees a buffer slot, triggers replenishment) and returns to the hub.

**2. Stop articles auto-opening when processing finishes**
Tapping an unprocessed article `await`s ~10-20s of on-demand processing and then unconditionally opened it — yanking you in even if you'd tapped another article, opened a different one, or gone back to browsing in the meantime.
- Added a `pendingOpenIdRef` request token set on each tap.
- The two post-`await` opens now only navigate if the token still matches the article you're actually waiting on. Otherwise the result just lands in the cache (READY badge).

Typecheck (`tsc --noEmit`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)