### PR TITLE
Tap sentence-ending punctuation (。！？) to translate the sentence

### DIFF
--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -453,6 +453,25 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
       const sentText = sentTokens.map(t => t.text).join('');
       const sentenceId = `${blockIdx}-${sIdx}`;
 
+      // Render a run of non-interactive text, turning sentence-ending marks
+      // (。！？) into tap targets that translate the whole sentence. Single-tap on
+      // a word stays word-lookup; tapping the period is the non-conflicting way to
+      // pull up the sentence (the double-tap gesture loses to the word's onClick).
+      const renderText = (text: string, keyBase: string) =>
+        text.split(/([。！？])/).filter(s => s !== '').map((part, idx) =>
+          /[。！？]/.test(part) ? (
+            <span
+              key={`${keyBase}-p${idx}`}
+              onClick={(e) => handleSentenceTranslate(sentText, sentenceId, e)}
+              style={{ cursor: 'pointer', padding: '0 0.25em', margin: '0 -0.1em' }}
+            >
+              {part}
+            </span>
+          ) : (
+            <span key={`${keyBase}-t${idx}`}>{part}</span>
+          ),
+        );
+
       return (
         <span 
           key={sentenceId} 
@@ -485,7 +504,7 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
             if (segmenter) {
               const words = Array.from((segmenter as any).segment(segment.text));
               return words.map((w: any, index: number) => {
-                if (!w.isWordLike) return <span key={`${sentenceId}-${j}-${index}`}>{w.segment}</span>;
+                if (!w.isWordLike) return <span key={`${sentenceId}-${j}-${index}`}>{renderText(w.segment, `${sentenceId}-${j}-${index}`)}</span>;
                 const isWide = [...w.segment].length > 2;
                 return (
                   <span
@@ -505,7 +524,7 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
                 );
               });
             }
-            return <span key={`${sentenceId}-${j}`}>{segment.text}</span>;
+            return <span key={`${sentenceId}-${j}`}>{renderText(segment.text, `${sentenceId}-${j}`)}</span>;
           })}
         </span>
       );


### PR DESCRIPTION
## Problem

Single tap = word lookup, double tap = sentence lookup — but the word's single-tap `onClick` fires first, so the sentence double-tap is effectively unreachable on a word. Delaying the single tap to detect a double would add latency to every word lookup.

## Change

Make the sentence-ending marks (。！？) tap targets that translate the whole sentence. Single tap on a word stays instant word lookup; tapping the period pulls up the sentence — a non-conflicting gesture.

- New `renderText` helper in `renderParagraph` splits non-interactive text on `。！？` and wraps each mark in a tappable span calling the existing `handleSentenceTranslate`.
- Wired into both non-interactive render paths (segmenter non-word output + plain-text fallback), so it works on enriched articles and during the brief pre-enrichment raw-text flash.
- Small tap pad on the mark for easier hits; the original `onDoubleClick` on the sentence span is kept intact (still works in gaps / on desktop).

Reuses the shared `WordModal` (`mode="sentence"`), so outside-tap, swipe-to-dismiss, and same-mark toggle dismissal behave identically to word lookup. Typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)