### PR TITLE
feat: track full-article vs snippet source fullness + FULL TEXT badge (#49)

### DIFF
--- a/database/20_source_fullness.sql
+++ b/database/20_source_fullness.sql
@@ -1,0 +1,54 @@
+-- ============================================================
+-- 20_source_fullness.sql
+-- Track how much real source material reached Gemini per article, so we can
+-- measure "what % of articles got full text vs a bare teaser snippet" and tune
+-- sourcing toward the full-text path (which produces markedly better articles).
+-- ============================================================
+-- APPLY MANUALLY in the Supabase SQL editor (migrations in this repo are not
+-- auto-deployed). Safe to run repeatedly — ADD COLUMN IF NOT EXISTS + a guarded
+-- CHECK constraint.
+--
+-- WHY: process-article upgrades thin teasers to full article text via Jina
+-- Reader, but the outcome was logged and then discarded. These columns persist
+-- it so the win/loss is queryable:
+--
+--   source_kind   full | partial | snippet
+--     full     — extraction succeeded and yielded a substantial body (≥1500 chars)
+--     partial  — richer than a bare teaser (e.g. a full-text RSS body), but thin
+--     snippet  — only the ~150-200 char NewsAPI/teaser fallback reached Gemini
+--   source_chars  the final char count of the source block sent to Gemini
+--
+-- Existing rows predate tracking; they stay NULL (unknown) rather than being
+-- mislabeled. Only newly produced articles populate these.
+
+-- ── Fullness columns ─────────────────────────────────────────────────────────
+ALTER TABLE public.processed_news
+  ADD COLUMN IF NOT EXISTS source_kind  text,
+  ADD COLUMN IF NOT EXISTS source_chars integer;
+
+-- Guarded CHECK (ALTER ... ADD CONSTRAINT is not itself idempotent). NULL passes
+-- the check, so legacy rows are unaffected.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'processed_news_source_kind_check'
+  ) THEN
+    ALTER TABLE public.processed_news
+      ADD CONSTRAINT processed_news_source_kind_check
+      CHECK (source_kind IS NULL OR source_kind IN ('full', 'partial', 'snippet'));
+  END IF;
+END $$;
+
+-- ── Reporting query (run ad hoc) ─────────────────────────────────────────────
+-- What % of articles produced in the last 7 days got full text vs a snippet:
+--
+--   SELECT
+--     source_kind,
+--     count(*)                                                  AS articles,
+--     round(100.0 * count(*) / sum(count(*)) OVER (), 1)        AS pct,
+--     round(avg(source_chars))                                  AS avg_chars
+--   FROM public.processed_news
+--   WHERE created_at > now() - interval '7 days'
+--     AND source_kind IS NOT NULL
+--   GROUP BY source_kind
+--   ORDER BY articles DESC;

--- a/src/components/Feed.tsx
+++ b/src/components/Feed.tsx
@@ -1,5 +1,5 @@
 import { motion, AnimatePresence, useMotionValue, useTransform, animate } from 'framer-motion';
-import { CheckCircle2, Trash2, Bookmark } from 'lucide-react';
+import { CheckCircle2, Trash2, Bookmark, FileText } from 'lucide-react';
 import { NewsArticle } from '../services/api';
 import { useState } from 'react';
 
@@ -193,6 +193,29 @@ function NewsCard({
             }}>
               {article.category.toUpperCase()}
             </span>
+
+            {/* Built from extracted full article text, not just a teaser snippet
+                — the strongest signal of article richness. */}
+            {article.sourceKind === 'full' && (
+              <span
+                title="Written from the full source article"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.3rem',
+                  fontSize: '0.6rem',
+                  fontWeight: 800,
+                  color: '#4a5d23',
+                  letterSpacing: '0.1em',
+                  backgroundColor: 'rgba(74, 93, 35, 0.08)',
+                  padding: '0.3rem 0.6rem',
+                  borderRadius: '8px',
+                }}
+              >
+                <FileText size={12} strokeWidth={2.5} />
+                FULL TEXT
+              </span>
+            )}
           </div>
           
           {isCached && (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -38,6 +38,11 @@ export interface NewsArticle {
   /** Clustered source articles — passed to process-article for full-text extraction. */
   sources?: ArticleSource[];
   sourceCount?: number;
+  /** How much real source material reached Gemini (set by process-article).
+   *  Drives the "Full text" badge; absent on legacy articles. */
+  sourceKind?: 'full' | 'partial' | 'snippet';
+  /** Char count of the source block sent to Gemini. */
+  sourceChars?: number;
 }
 
 import { supabase } from './supabase'

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -24,6 +24,27 @@ const TOTAL_SOURCE_CHAR_CAP = 7000;
 
 interface SourceRef { title?: string; url?: string; teaser?: string }
 
+// ── Source fullness classification ──────────────────────────────────────────
+// We track how much real source material Gemini actually received, because
+// article quality tracks it directly: a bare ~200-char teaser forces Gemini to
+// pad ("50% means half"), while an extracted body produces real news prose.
+// Stored on processed_news (source_kind / source_chars) for aggregate analytics
+// and echoed into content JSON so the Feed can badge full-text articles.
+//   full    — extraction succeeded and yielded a substantial body
+//   partial — more than a bare teaser (e.g. a full-text RSS body), but thin
+//   snippet — only the ~150-200 char NewsAPI/teaser fallback reached Gemini
+type SourceKind = 'full' | 'partial' | 'snippet';
+const FULL_SOURCE_CHARS = 1500;    // an extracted body Gemini can build a real article from
+const PARTIAL_SOURCE_CHARS = 600;  // richer than a bare teaser, but not a full body
+
+function classifySourceFullness(chars: number, extracted: boolean): SourceKind {
+  if (extracted && chars >= FULL_SOURCE_CHARS) return 'full';
+  if (chars >= PARTIAL_SOURCE_CHARS) return 'partial';
+  return 'snippet';
+}
+
+interface SourceBlock { text: string; chars: number; extracted: boolean; sourceCount: number }
+
 async function extractFullText(url: string, jinaKey: string | undefined): Promise<string> {
   const ctrl = new AbortController();
   const to = setTimeout(() => ctrl.abort(), EXTRACT_TIMEOUT_MS);
@@ -43,16 +64,21 @@ async function extractFullText(url: string, jinaKey: string | undefined): Promis
 }
 
 // Build the richest source block we can: extracted full text where a teaser is
-// thin and extraction succeeds, teaser otherwise. Returns '' if no sources.
-async function buildSourceBlock(sources: SourceRef[], jinaKey: string | undefined): Promise<string> {
+// thin and extraction succeeds, teaser otherwise. Reports whether any extraction
+// contributed and the final char count so the caller can classify fullness.
+async function buildSourceBlock(sources: SourceRef[], jinaKey: string | undefined): Promise<SourceBlock> {
   const picked = sources.filter((s) => s && (s.teaser || s.url)).slice(0, MAX_EXTRACT_SOURCES);
-  if (picked.length === 0) return '';
+  if (picked.length === 0) return { text: '', chars: 0, extracted: false, sourceCount: 0 };
 
+  let extracted = false;
   const parts = await Promise.all(picked.map(async (s, n) => {
     let body = (s.teaser || '').trim();
     if (s.url && body.length < EXTRACT_TEASER_THRESHOLD) {
       const full = await extractFullText(s.url, jinaKey);
-      if (full && full.length > body.length) body = full;
+      if (full && full.length > body.length) {
+        body = full;
+        extracted = true;
+      }
     }
     body = body.slice(0, PER_SOURCE_CHAR_CAP);
     return `${n + 1}. ${s.title || ''} — ${body}`.trim();
@@ -60,7 +86,8 @@ async function buildSourceBlock(sources: SourceRef[], jinaKey: string | undefine
 
   let block = parts.join('\n\n');
   if (block.length > TOTAL_SOURCE_CHAR_CAP) block = block.slice(0, TOTAL_SOURCE_CHAR_CAP);
-  return block.trim();
+  block = block.trim();
+  return { text: block, chars: block.length, extracted, sourceCount: picked.length };
 }
 
 // Approximate number of unique word tokens in a 3-paragraph article.
@@ -130,17 +157,23 @@ Deno.serve(async (req) => {
     // Opportunistically upgrade thin teasers to full article text. Falls back
     // to the merged teaser block (snippet) when no sources / extraction fails.
     let sourceText = snippet ?? '';
+    let sourceChars = sourceText.length;
+    let extracted = false;
     if (Array.isArray(sources) && sources.length > 0) {
       try {
         const built = await buildSourceBlock(sources as SourceRef[], jinaKey);
-        if (built) {
-          sourceText = built;
-          console.log(`[process-article] built source block from ${sources.length} source(s), ${built.length} chars`);
+        if (built.text) {
+          sourceText = built.text;
+          sourceChars = built.chars;
+          extracted = built.extracted;
+          console.log(`[process-article] built source block from ${sources.length} source(s), ${built.chars} chars`);
         }
       } catch (e) {
         console.warn('[process-article] source extraction failed, using teaser:', e instanceof Error ? e.message : e);
       }
     }
+    const sourceKind = classifySourceFullness(sourceChars, extracted);
+    console.log(`[process-article] source fullness: ${sourceKind} (${sourceChars} chars, extracted=${extracted})`);
 
     // 1. Fetch user preferences
     const { data: prefs } = await supabase
@@ -372,6 +405,10 @@ Output EXACTLY a JSON array:
         // `ready` (conflict target is the composite PK). On a fresh on-tap insert
         // it's `ready` from the start.
         status: 'ready',
+        // Queryable fullness columns — let us aggregate "what % of articles got
+        // full text vs a bare snippet" over time (see database/20_source_fullness.sql).
+        source_kind: sourceKind,
+        source_chars: sourceChars,
         content: {
           id: finalArticleId,
           title,
@@ -380,6 +417,10 @@ Output EXACTLY a JSON array:
           date: new Date().toISOString(),
           readTime: '5分で読める',
           category: 'Recent News',
+          // Echoed into content so the Feed can badge full-text articles without
+          // a second query (cache hydration only selects id + content).
+          sourceKind,
+          sourceChars,
         },
         metadata: { date: new Date().toISOString(), category: 'Recent News' },
       }, { onConflict: 'user_id,id' });


### PR DESCRIPTION
Closes #49.

Persists a per-article source-fullness metric and surfaces a **FULL TEXT** badge on Feed cards, so we can measure and tune toward the full-text sourcing path (which produces markedly better articles than bare ~200-char teasers).

## Changes
- **`process-article`**: `buildSourceBlock` now returns `{ text, chars, extracted, sourceCount }`; new `classifySourceFullness(chars, extracted)` buckets each article `full` / `partial` / `snippet`. Persisted as queryable `source_kind` / `source_chars` columns on `processed_news` **and** echoed into the `content` JSON so the Feed badge needs no extra query.
- **DB**: `database/20_source_fullness.sql` — idempotent `ADD COLUMN IF NOT EXISTS` + guarded CHECK; legacy rows stay `NULL` (unknown) rather than mislabeled.
- **Frontend**: small green `FULL TEXT` chip in `Feed.tsx` (shown only when `sourceKind === 'full'`); `sourceKind` / `sourceChars` added to the `NewsArticle` type, riding existing `content` JSON.

## Deploy (manual — repo migrations are not auto-deployed)
1. Apply `database/20_source_fullness.sql` in the Supabase SQL editor.
2. `supabase functions deploy process-article` (after step 1 — the upsert writes the new columns).
3. Merge this PR for the badge.

Until both the migration and function are deployed, `source_kind` stays empty and no badges appear.

## Verification
Run the reporting query in `database/20_source_fullness.sql` after a day of new articles to see the `source_kind` breakdown and `avg_chars`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)