### PR TITLE
feat: keep full-text RSS bodies so they reach source_kind=full (#57)

### DIFF
--- a/supabase/functions/fetch-raw-news/index.ts
+++ b/supabase/functions/fetch-raw-news/index.ts
@@ -25,6 +25,20 @@ const ITEMS_PER_FEED = 12;
 const FEED_TIMEOUT_MS = 8000;
 const MAX_CARDS = 40;
 
+// Source-material caps. A full-text feed (e.g. Ars) ships the whole article body
+// in content:encoded; keep enough of it that process-article classifies the
+// article as `full` (its FULL_SOURCE_CHARS = 1500 bar) instead of truncating to a
+// teaser — the old flat 800-char cap landed full-text feeds as `partial` and also
+// tripped process-article's Jina skip. A bare `description` is just a teaser, so
+// keep it short (Jina backfills the body from the URL). process-article re-caps
+// each source at PER_SOURCE_CHAR_CAP = 2500, so matching that here is the ceiling.
+const FULLTEXT_BODY_CAP = 2500;  // content:encoded / Atom content — a real body
+const TEASER_CAP = 800;          // description-only — Jina fills the rest
+// The card preview (shown in the Feed and used only as a fallback snippet) never
+// needs the whole body; the full text rides in each card's `sources[].teaser`.
+// Keeping the preview small bounds the persisted articlesCache blob (see #54).
+const PREVIEW_CHARS = 400;
+
 // Article IDs MUST be deterministic and stable across fetches. The client tracks
 // dismissed/read articles by id; if the same story comes back with a new id on a
 // later fetch, the dismiss filter no longer matches and it reappears in the feed.
@@ -115,10 +129,14 @@ function parseFeed(xml: string, source: string, category: string): PoolItem[] {
   for (const b of blocks) {
     const title = stripHtml(extractTag(b, 'title'));
     const desc = stripHtml(extractTag(b, 'description') || extractTag(b, 'summary'));
-    // content:encoded (RSS) / content (Atom) is often the full body — keep the
-    // longer of the two so feeds that ship full text (e.g. Ars) skip extraction.
+    // content:encoded (RSS) / content (Atom) is often the full body. When the
+    // feed ships one, keep it under the generous full-text cap so it survives to
+    // process-article as a real body; otherwise the bare description is a teaser
+    // and gets the short cap (Jina backfills it downstream).
     const content = stripHtml(extractTag(b, 'content:encoded') || extractTag(b, 'content'));
-    const teaser = (content.length > desc.length ? content : desc).slice(0, 800);
+    const teaser = content.length > desc.length
+      ? content.slice(0, FULLTEXT_BODY_CAP)
+      : desc.slice(0, TEASER_CAP);
     const url = extractLink(b);
     const date = stripHtml(extractTag(b, 'pubDate') || extractTag(b, 'published') || extractTag(b, 'updated'));
     out.push({ title, teaser, url, date, source, category });
@@ -336,8 +354,11 @@ Deno.serve(async (req) => {
       // The card title is the lead article's real headline — concrete and
       // trustworthy even when clustering is imperfect — not a model-generated
       // topic label (which can mislabel a loose merge).
+      // Preview only — trim each member so a full-text body doesn't bloat the
+      // persisted card. The untrimmed body rides in `sources[].teaser` below and
+      // is what process-article actually builds the article from.
       const mergedSnippet = members
-        .map((m, n) => `${n + 1}. ${m.title} — ${m.teaser || m.title}`)
+        .map((m, n) => `${n + 1}. ${m.title} — ${(m.teaser || m.title).slice(0, PREVIEW_CHARS)}`)
         .join('\n');
       const when = lead.date ? new Date(lead.date) : new Date();
 

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -30,20 +30,21 @@ interface SourceRef { title?: string; url?: string; teaser?: string }
 // pad ("50% means half"), while an extracted body produces real news prose.
 // Stored on processed_news (source_kind / source_chars) for aggregate analytics
 // and echoed into content JSON so the Feed can badge full-text articles.
-//   full    — extraction succeeded and yielded a substantial body
-//   partial — more than a bare teaser (e.g. a full-text RSS body), but thin
+//   full    — a real article body reached Gemini, whether Jina-extracted or
+//             shipped whole by a full-text feed (e.g. Ars via content:encoded)
+//   partial — more than a bare teaser (e.g. a short full-text RSS body), but thin
 //   snippet — only the ~150-200 char NewsAPI/teaser fallback reached Gemini
 type SourceKind = 'full' | 'partial' | 'snippet';
-const FULL_SOURCE_CHARS = 1500;    // an extracted body Gemini can build a real article from
+const FULL_SOURCE_CHARS = 1500;    // a body Gemini can build a real article from
 const PARTIAL_SOURCE_CHARS = 600;  // richer than a bare teaser, but not a full body
 
-function classifySourceFullness(chars: number, extracted: boolean): SourceKind {
-  if (extracted && chars >= FULL_SOURCE_CHARS) return 'full';
+function classifySourceFullness(chars: number, fullBody: boolean): SourceKind {
+  if (fullBody && chars >= FULL_SOURCE_CHARS) return 'full';
   if (chars >= PARTIAL_SOURCE_CHARS) return 'partial';
   return 'snippet';
 }
 
-interface SourceBlock { text: string; chars: number; extracted: boolean; sourceCount: number }
+interface SourceBlock { text: string; chars: number; fullBody: boolean; sourceCount: number }
 
 async function extractFullText(url: string, jinaKey: string | undefined): Promise<string> {
   const ctrl = new AbortController();
@@ -68,17 +69,22 @@ async function extractFullText(url: string, jinaKey: string | undefined): Promis
 // contributed and the final char count so the caller can classify fullness.
 async function buildSourceBlock(sources: SourceRef[], jinaKey: string | undefined): Promise<SourceBlock> {
   const picked = sources.filter((s) => s && (s.teaser || s.url)).slice(0, MAX_EXTRACT_SOURCES);
-  if (picked.length === 0) return { text: '', chars: 0, extracted: false, sourceCount: 0 };
+  if (picked.length === 0) return { text: '', chars: 0, fullBody: false, sourceCount: 0 };
 
-  let extracted = false;
+  // Whether a real article body — not just a teaser — reached Gemini. True when
+  // Jina extracts one, OR when a full-text feed already shipped one (its teaser
+  // is itself a full body). Either way the article can be classified `full`.
+  let fullBody = false;
   const parts = await Promise.all(picked.map(async (s, n) => {
     let body = (s.teaser || '').trim();
     if (s.url && body.length < EXTRACT_TEASER_THRESHOLD) {
       const full = await extractFullText(s.url, jinaKey);
       if (full && full.length > body.length) {
         body = full;
-        extracted = true;
+        fullBody = true;               // Jina supplied the body
       }
+    } else if (body.length >= FULL_SOURCE_CHARS) {
+      fullBody = true;                 // full-text feed shipped a real body — no Jina needed
     }
     body = body.slice(0, PER_SOURCE_CHAR_CAP);
     return `${n + 1}. ${s.title || ''} — ${body}`.trim();
@@ -87,7 +93,7 @@ async function buildSourceBlock(sources: SourceRef[], jinaKey: string | undefine
   let block = parts.join('\n\n');
   if (block.length > TOTAL_SOURCE_CHAR_CAP) block = block.slice(0, TOTAL_SOURCE_CHAR_CAP);
   block = block.trim();
-  return { text: block, chars: block.length, extracted, sourceCount: picked.length };
+  return { text: block, chars: block.length, fullBody, sourceCount: picked.length };
 }
 
 // Approximate number of unique word tokens in a 3-paragraph article.
@@ -158,22 +164,22 @@ Deno.serve(async (req) => {
     // to the merged teaser block (snippet) when no sources / extraction fails.
     let sourceText = snippet ?? '';
     let sourceChars = sourceText.length;
-    let extracted = false;
+    let fullBody = false;
     if (Array.isArray(sources) && sources.length > 0) {
       try {
         const built = await buildSourceBlock(sources as SourceRef[], jinaKey);
         if (built.text) {
           sourceText = built.text;
           sourceChars = built.chars;
-          extracted = built.extracted;
+          fullBody = built.fullBody;
           console.log(`[process-article] built source block from ${sources.length} source(s), ${built.chars} chars`);
         }
       } catch (e) {
         console.warn('[process-article] source extraction failed, using teaser:', e instanceof Error ? e.message : e);
       }
     }
-    const sourceKind = classifySourceFullness(sourceChars, extracted);
-    console.log(`[process-article] source fullness: ${sourceKind} (${sourceChars} chars, extracted=${extracted})`);
+    const sourceKind = classifySourceFullness(sourceChars, fullBody);
+    console.log(`[process-article] source fullness: ${sourceKind} (${sourceChars} chars, fullBody=${fullBody})`);
 
     // 1. Fetch user preferences
     const { data: prefs } = await supabase


### PR DESCRIPTION
Closes #57.

The flat 800-char teaser cap in `fetch-raw-news` truncated feeds that ship the whole article body in `content:encoded` (e.g. **Ars Technica**), so those high-value sources reached Gemini as a thin teaser **and** were misclassified `partial`. The 800-char teaser also exceeded `process-article`'s `EXTRACT_TEASER_THRESHOLD = 600`, so the Jina pass was skipped and couldn't recover the body either. Net: full-text feeds were degraded *and* could never reach `source_kind='full'`.

## Changes

**`fetch-raw-news`** — split the cap by path:
- `content:encoded` / Atom `content` (a real body) → `FULLTEXT_BODY_CAP = 2500` (matches `process-article`'s `PER_SOURCE_CHAR_CAP`).
- `description`-only teasers → `TEASER_CAP = 800` (unchanged; Jina backfills from the URL downstream).
- Card preview trimmed to `PREVIEW_CHARS = 400` so a full body doesn't bloat the persisted `articlesCache` blob (interacts with #54). The untrimmed body rides in `sources[].teaser`, which is what `process-article` actually builds from — Feed.tsx doesn't render this preview, so no UI impact.

**`process-article`** — classify `full` for full-text feeds, not just Jina:
- `buildSourceBlock` now tracks `fullBody` (Jina extraction **or** a source whose teaser is itself ≥ `FULL_SOURCE_CHARS`) instead of only Jina success. So a full-text RSS body reaches `source_kind='full'` with **no Jina call** — no extra latency, no paywall/extraction-failure risk. The ≥1500-char gate still applies, so thin merges don't false-positive.

## No migration
Columns already exist from #49.

## Verification
After deploying both functions, watch the #49 reporting query over a day of new articles — Ars (and other full-text feeds) should move `partial → full` and `avg_chars` should rise. Short-description feeds (BBC/NPR/NewsAPI) are unchanged.

## Deploy
- `supabase functions deploy fetch-raw-news`
- `supabase functions deploy process-article`

🤖 Generated with [Claude Code](https://claude.com/claude-code)