### PR TITLE
feat: source-fullness-driven article length, configurable in Settings

### DIFF
--- a/database/21_target_paragraphs.sql
+++ b/database/21_target_paragraphs.sql
@@ -1,0 +1,33 @@
+-- ============================================================
+-- 21_target_paragraphs.sql
+-- Per-user article-length targets, keyed by how much real source material the
+-- article was built from (source_kind: full | partial | snippet — see
+-- 20_source_fullness.sql). Length follows source fullness, not JLPT level: a
+-- full-text source supports a longer article, while a thin teaser should stay
+-- short to avoid padding ("50% means half"). JLPT level still drives complexity.
+-- ============================================================
+-- APPLY MANUALLY in the Supabase SQL editor (migrations in this repo are not
+-- auto-deployed). Safe to run repeatedly — ADD COLUMN IF NOT EXISTS + guarded
+-- CHECKs. Existing rows get the defaults below; process-article also falls back
+-- to the same defaults when a column is NULL.
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS target_paragraphs_full    smallint NOT NULL DEFAULT 5,
+  ADD COLUMN IF NOT EXISTS target_paragraphs_partial smallint NOT NULL DEFAULT 4,
+  ADD COLUMN IF NOT EXISTS target_paragraphs_snippet smallint NOT NULL DEFAULT 3;
+
+-- Keep targets in a sane range (1–10 paragraphs). Guarded so re-running is a no-op.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'user_preferences_target_paragraphs_check'
+  ) THEN
+    ALTER TABLE public.user_preferences
+      ADD CONSTRAINT user_preferences_target_paragraphs_check
+      CHECK (
+        target_paragraphs_full    BETWEEN 1 AND 10 AND
+        target_paragraphs_partial BETWEEN 1 AND 10 AND
+        target_paragraphs_snippet BETWEEN 1 AND 10
+      );
+  END IF;
+END $$;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -3,12 +3,36 @@ import { ChevronDown } from 'lucide-react';
 import { useAppStore } from '../services/store';
 import { rtkKanjiList } from '../data/rtkKanji';
 
+const stepperBtnStyle = (disabled: boolean): React.CSSProperties => ({
+  width: '34px',
+  height: '34px',
+  borderRadius: '100px',
+  border: 'none',
+  backgroundColor: 'var(--border-light)',
+  color: disabled ? 'var(--text-muted)' : 'var(--text-main)',
+  fontSize: '1.2rem',
+  fontWeight: 700,
+  lineHeight: 1,
+  cursor: disabled ? 'default' : 'pointer',
+  opacity: disabled ? 0.4 : 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+const lengthRows = [
+  { kind: 'full', label: 'Full text', hint: 'Whole article body (badged FULL TEXT)' },
+  { kind: 'partial', label: 'Partial', hint: 'A richer-than-teaser excerpt' },
+  { kind: 'snippet', label: 'Snippet', hint: 'Only a short headline teaser' },
+] as const;
+
 export function Settings() {
   const {
     jlptLevel, setJlptLevel,
     rtkLevel, setRtkLevel,
     studyMode, setStudyMode,
     readingIntensity, setReadingIntensity,
+    targetParagraphs, setTargetParagraphs,
     readerFontSize, setReaderFontSize,
     readerFontWeight, setReaderFontWeight
   } = useAppStore();
@@ -140,6 +164,42 @@ export function Settings() {
           {readingIntensity === 'balanced' && 'Comfortable learning — ~95% known, with a handful of review words and 1–2 new words per article.'}
           {readingIntensity === 'intensive' && 'Study-heavy — ~90% known, with more review and new vocabulary packed in. Slower but faster growth.'}
         </p>
+      </div>
+
+      {/* 3. Article Length */}
+      <div style={{ backgroundColor: 'var(--bg-card)', padding: '1.5rem', borderRadius: '16px', marginBottom: '1.5rem' }}>
+        <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-muted)', letterSpacing: '0.1em', marginBottom: '0.5rem', textTransform: 'uppercase' }}>
+          Article Length
+        </label>
+        <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: '1.4rem' }}>
+          Target paragraphs by how much real source text each article was built from. Full-text sources support longer reads; thin snippets stay short to avoid padding. Your JLPT level still sets the difficulty.
+        </p>
+
+        {lengthRows.map(({ kind, label, hint }) => (
+          <div key={kind} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: kind === 'snippet' ? 0 : '1.1rem' }}>
+            <div style={{ marginRight: '1rem' }}>
+              <div style={{ fontSize: '0.95rem', fontWeight: 600, color: 'var(--text-main)' }}>{label}</div>
+              <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)', lineHeight: 1.4 }}>{hint}</div>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexShrink: 0 }}>
+              <button
+                onClick={() => setTargetParagraphs(kind, targetParagraphs[kind] - 1)}
+                disabled={targetParagraphs[kind] <= 1}
+                aria-label={`Decrease ${label} length`}
+                style={stepperBtnStyle(targetParagraphs[kind] <= 1)}
+              >−</button>
+              <span style={{ minWidth: '1.5rem', textAlign: 'center', fontSize: '1.05rem', fontWeight: 700, color: 'var(--text-main)', fontVariantNumeric: 'tabular-nums' }}>
+                {targetParagraphs[kind]}
+              </span>
+              <button
+                onClick={() => setTargetParagraphs(kind, targetParagraphs[kind] + 1)}
+                disabled={targetParagraphs[kind] >= 10}
+                aria-label={`Increase ${label} length`}
+                style={stepperBtnStyle(targetParagraphs[kind] >= 10)}
+              >+</button>
+            </div>
+          </div>
+        ))}
       </div>
 
       {/* 3. Vocab Use */}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -531,6 +531,9 @@ export async function upsertUserPreferences(
     vocab_mode?: string;
     furigana_mode?: string;
     reading_intensity?: string;
+    target_paragraphs_full?: number;
+    target_paragraphs_partial?: number;
+    target_paragraphs_snippet?: number;
   }
 ) {
   const { error } = await supabase

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -94,7 +94,10 @@ interface AppState {
   vocabMode: 'natural' | 'balanced' | 'study';
   furiganaMode: 'always' | 'never' | 'dynamic';
   readingIntensity: 'leisure' | 'balanced' | 'intensive';
-  
+  // Target article length (paragraphs) by source fullness. Length follows how
+  // much real source material the article was built from; JLPT drives complexity.
+  targetParagraphs: { full: number; partial: number; snippet: number };
+
   wordDatabase: Record<string, WordData>;
   studyKanji: string[];
   lastRtkUpdateTs: number | null;
@@ -114,6 +117,7 @@ interface AppState {
   setVocabMode: (mode: 'natural' | 'balanced' | 'study') => void;
   setFuriganaMode: (mode: 'always' | 'never' | 'dynamic') => void;
   setReadingIntensity: (intensity: 'leisure' | 'balanced' | 'intensive') => void;
+  setTargetParagraphs: (kind: 'full' | 'partial' | 'snippet', value: number) => void;
   setCurrentArticle: (article: NewsArticle | null) => void;
   saveProcessedArticle: (id: string, article: NewsArticle) => void;
   setArticlesCache: (cache: Record<string, NewsArticle>) => void;
@@ -143,6 +147,7 @@ export const useAppStore = create<AppState>()(
       vocabMode: 'balanced',
       furiganaMode: 'dynamic',
       readingIntensity: 'balanced',
+      targetParagraphs: { full: 5, partial: 4, snippet: 3 },
       wordDatabase: {},
       studyKanji: [],
       lastRtkUpdateTs: null,
@@ -185,6 +190,18 @@ export const useAppStore = create<AppState>()(
         set({ readingIntensity: intensity });
         currentUserId().then((uid) => {
           if (uid) import('./api').then(m => m.upsertUserPreferences(uid, { reading_intensity: intensity }));
+        });
+      },
+      setTargetParagraphs: (kind, value) => {
+        const v = Math.max(1, Math.min(10, Math.round(value)));
+        set((state) => ({ targetParagraphs: { ...state.targetParagraphs, [kind]: v } }));
+        const column = ({
+          full: 'target_paragraphs_full',
+          partial: 'target_paragraphs_partial',
+          snippet: 'target_paragraphs_snippet',
+        } as const)[kind];
+        currentUserId().then((uid) => {
+          if (uid) import('./api').then(m => m.upsertUserPreferences(uid, { [column]: v }));
         });
       },
 
@@ -430,6 +447,11 @@ export const useAppStore = create<AppState>()(
             vocabMode: remotePrefs.vocab_mode ?? state.vocabMode,
             furiganaMode: remotePrefs.furigana_mode ?? state.furiganaMode,
             readingIntensity: remotePrefs.reading_intensity ?? state.readingIntensity,
+            targetParagraphs: {
+              full: remotePrefs.target_paragraphs_full ?? state.targetParagraphs.full,
+              partial: remotePrefs.target_paragraphs_partial ?? state.targetParagraphs.partial,
+              snippet: remotePrefs.target_paragraphs_snippet ?? state.targetParagraphs.snippet,
+            },
           }));
         }
 
@@ -509,6 +531,7 @@ export const useAppStore = create<AppState>()(
         vocabMode: state.vocabMode,
         furiganaMode: state.furiganaMode,
         readingIntensity: state.readingIntensity,
+        targetParagraphs: state.targetParagraphs,
         wordDatabase: state.wordDatabase,
         studyKanji: state.studyKanji,
         lastRtkUpdateTs: state.lastRtkUpdateTs,

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -96,9 +96,24 @@ async function buildSourceBlock(sources: SourceRef[], jinaKey: string | undefine
   return { text: block, chars: block.length, fullBody, sourceCount: picked.length };
 }
 
-// Approximate number of unique word tokens in a 3-paragraph article.
-// Used to translate intensity ratios into concrete palette counts.
-const WORDS_PER_ARTICLE = 200;
+// Article LENGTH is driven by source fullness (full text supports a longer
+// article; a thin snippet should stay short to avoid padding), and is
+// user-configurable. JLPT level drives COMPLEXITY (grammar/vocab difficulty), not
+// length. These are the fallbacks when the user hasn't overridden them in Settings.
+const DEFAULT_TARGET_PARAGRAPHS: Record<SourceKind, number> = {
+  full: 5,
+  partial: 4,
+  snippet: 3,
+};
+
+// Unique-token budget per paragraph (~200 tokens over a 3-paragraph article was
+// the original fixed basis). The vocab palette scales with paragraph count so a
+// longer full-text article gets proportionally more review/new words — keeping
+// the known/review/new density constant instead of diluting it across more text.
+const WORDS_PER_PARAGRAPH = 67;
+// Backbone (KNOWN) pool size per paragraph — a draw-from pool, not a quota — so a
+// longer article has a richer known palette to build its spine from.
+const KNOWN_WORDS_PER_PARAGRAPH = 10;
 
 // reading_intensity preset -> target distribution of known/review/new vocab.
 // See database/10_reading_intensity.sql for the column definition.
@@ -194,8 +209,20 @@ Deno.serve(async (req) => {
     const vocabMode = prefs?.vocab_mode ?? 'balanced';
     const readingIntensity: string = prefs?.reading_intensity ?? 'balanced';
     const ratios = INTENSITY_RATIOS[readingIntensity] ?? INTENSITY_RATIOS.balanced;
-    const targetReview = Math.max(1, Math.round(ratios.review * WORDS_PER_ARTICLE));
-    const targetNew = Math.max(1, Math.round(ratios.new * WORDS_PER_ARTICLE));
+
+    // Length follows source fullness (user-configurable), not JLPT level.
+    const paragraphPref: Record<SourceKind, number> = {
+      full: prefs?.target_paragraphs_full ?? DEFAULT_TARGET_PARAGRAPHS.full,
+      partial: prefs?.target_paragraphs_partial ?? DEFAULT_TARGET_PARAGRAPHS.partial,
+      snippet: prefs?.target_paragraphs_snippet ?? DEFAULT_TARGET_PARAGRAPHS.snippet,
+    };
+    const targetParagraphs = Math.max(1, Math.round(paragraphPref[sourceKind]));
+
+    // Scale the vocab budget with length so review/new density stays constant.
+    const wordsBudget = WORDS_PER_PARAGRAPH * targetParagraphs;
+    const targetReview = Math.max(1, Math.round(ratios.review * wordsBudget));
+    const targetNew = Math.max(1, Math.round(ratios.new * wordsBudget));
+    console.log(`[process-article] length: ${targetParagraphs} paragraphs (sourceKind=${sourceKind}), vocab budget ${wordsBudget} -> ${targetReview} review / ${targetNew} new`);
 
     // 2. Vocabulary palette pipeline
     //    a) Extract topic keywords from the English source (Groq)
@@ -255,7 +282,7 @@ Deno.serve(async (req) => {
           }
         }
         // De-dupe while preserving order
-        knownPalette = Array.from(new Set(knownPalette)).slice(0, 30);
+        knownPalette = Array.from(new Set(knownPalette)).slice(0, KNOWN_WORDS_PER_PARAGRAPH * targetParagraphs);
         reviewPalette = Array.from(new Set(reviewPalette)).slice(0, Math.max(5, targetReview + 2));
         newPalette = Array.from(new Set(newPalette)).slice(0, Math.max(3, targetNew + 2));
       }
@@ -296,26 +323,23 @@ Deno.serve(async (req) => {
     // 3. Build Gemini prompts (same logic as client-side rewriteArticleWithGemini)
     const jlptStr = `N${jlptLevel}`;
 
-    const JLPT_LEVEL_CONFIG: Record<number, { description: string; paragraphs: string }> = {
+    // JLPT level controls COMPLEXITY only (grammar/vocab difficulty). Article
+    // LENGTH comes from targetParagraphs (source fullness, user-configurable) above.
+    const JLPT_LEVEL_CONFIG: Record<number, { description: string }> = {
       5: {
         description: 'N5: The reader understands some basic Japanese. Write simple sentences using hiragana, katakana, and basic kanji. Basic vocabulary and elementary grammar only.',
-        paragraphs: '3',
       },
       4: {
         description: 'N4: The reader understands basic Japanese. Write about familiar daily topics using basic vocabulary and kanji. Simple compound sentences are acceptable.',
-        paragraphs: '3-4',
       },
       3: {
         description: 'N3: The reader understands everyday Japanese. Write like a real newspaper article — use compound sentences, natural news phrasing, and intermediate grammar. The reader can handle newspaper headlines and slightly difficult text with context. Do NOT over-simplify to basic sentence patterns.',
-        paragraphs: '4-5',
       },
       2: {
         description: 'N2: The reader understands Japanese used in everyday situations and a variety of circumstances. Write like a real newspaper article or commentary — clear, natural prose on general topics at near-natural complexity.',
-        paragraphs: '5-6',
       },
       1: {
         description: 'N1: The reader understands Japanese used in a variety of circumstances. Write with full natural complexity — abstract reasoning, editorials, and nuanced prose are appropriate.',
-        paragraphs: '5-6',
       },
     };
     const levelConfig = JLPT_LEVEL_CONFIG[jlptLevel] ?? JLPT_LEVEL_CONFIG[3];
@@ -358,7 +382,7 @@ Treat this palette as a GUIDE, not a quota. Never distort the facts or insert un
 
     // Pass 1: Rewrite article
     const prompt1 = `
-You are a factual Japanese news reporter writing a ${levelConfig.paragraphs} paragraph news article for a JLPT ${jlptStr} learner.
+You are a factual Japanese news reporter writing a ${targetParagraphs}-paragraph news article for a JLPT ${jlptStr} learner.
 LEVEL GUIDANCE: ${levelConfig.description}
 Topic: ${title}
 Sources (real English news text; the FIRST source is the primary story):


### PR DESCRIPTION
Lets articles be **longer when built from full text** and stay short on thin snippets, with the targets **user-configurable in Settings**. Builds on the source-fullness tracking from #49/#57.

## Design (per product decisions)
- **Source fullness drives length; JLPT drives complexity.** Paragraph count comes from a per-user, per-fullness setting; JLPT level keeps controlling grammar/vocab difficulty only. (`JLPT_LEVEL_CONFIG` is now complexity-only.)
- **Defaults:** `full = 5`, `partial = 4`, `snippet = 3` paragraphs.
- **Vocab budget scales with length.** `WORDS_PER_PARAGRAPH` replaces the fixed `WORDS_PER_ARTICLE = 200`, so a 5-paragraph full-text article gets proportionally more review/new target words — keeping the known/review/new *density* constant instead of diluting it across more text. The KNOWN backbone pool scales the same way. (Snippet at 3 paragraphs ≈ the old 200-word basis, so short articles are unchanged.)

## Changes
- **`process-article`**: `targetParagraphs` chosen by `sourceKind` from new prefs (with code defaults as fallback); `wordsBudget = WORDS_PER_PARAGRAPH * targetParagraphs` drives `targetReview`/`targetNew`; KNOWN cap = `KNOWN_WORDS_PER_PARAGRAPH * targetParagraphs`; prompt uses `${targetParagraphs}`.
- **DB**: `database/21_target_paragraphs.sql` — adds `target_paragraphs_{full,partial,snippet}` to `user_preferences` (`smallint NOT NULL`, defaults 5/4/3, `BETWEEN 1 AND 10` CHECK). Idempotent. **Manual apply.**
- **Frontend**: new **Article Length** Settings card (a stepper per fullness tier); store field `targetParagraphs` + `setTargetParagraphs` (clamped 1–10, synced to Supabase), added to `partialize` and remote rehydrate; `upsertUserPreferences` type extended.

`tsc -b` + `vite build` pass.

## Deploy (manual — repo migrations are not auto-deployed)
1. Apply `database/21_target_paragraphs.sql` in the Supabase SQL editor.
2. `supabase functions deploy process-article` (after the migration).
3. Merge this PR for the Settings UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)