### PR TITLE
chore: pin & centralize LLM model versions across edge functions (#64)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Edge Functions live in `supabase/functions/` and run on Deno. They are deployed 
 
 ## Architecture
 
-**Stack**: React 18 + TypeScript + Vite (frontend), Supabase Postgres + Edge Functions (backend), Gemini 2.0-flash (article rewriting), Groq (dictionary fallback)
+**Stack**: React 18 + TypeScript + Vite (frontend), Supabase Postgres + Edge Functions (backend), Gemini 3.5-flash (article rewriting), Groq (dictionary fallback). Model identifiers are centralized in `supabase/functions/_shared/models.ts` (single bump point per model).
 
 ### Frontend (`src/`)
 

--- a/supabase/functions/_shared/models.ts
+++ b/supabase/functions/_shared/models.ts
@@ -1,0 +1,22 @@
+// Centralized LLM model identifiers — the single bump point per model (issue #64).
+//
+// Every edge function imports its model strings from here so there is exactly one
+// place to change when a model is bumped.
+//
+// Pinning notes:
+// - Groq IDs ARE the version identifier (Groq exposes no dated snapshots), so the
+//   strings below are as reproducible as the provider allows.
+// - GEMINI_FLASH was previously the floating `gemini-3-flash-preview` alias. The
+//   gemini-3-flash line never shipped a stable/dated build, so we moved to the
+//   stable `gemini-3.5-flash` — a reproducible, non-preview identifier. The
+//   flash-vs-pro / per-task comparison still belongs to the eval harness in
+//   issue #65; this is the single line to change when that lands.
+
+/** Gemini — article rewriting (process-article) + grammar insight (dictionary-lookup). */
+export const GEMINI_FLASH = 'gemini-3.5-flash';
+
+/** Groq — keyword extraction, heteronym readings, translation, definition fallback. */
+export const GROQ_GENERAL = 'openai/gpt-oss-20b';
+
+/** Groq — same-story news clustering/dedupe (fetch-raw-news). */
+export const GROQ_CLUSTER = 'llama-3.3-70b-versatile';

--- a/supabase/functions/dictionary-lookup/index.ts
+++ b/supabase/functions/dictionary-lookup/index.ts
@@ -1,12 +1,12 @@
 import { GoogleGenAI } from 'https://esm.sh/@google/genai';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { GEMINI_FLASH, GROQ_GENERAL as GROQ_MODEL } from '../_shared/models.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-const GROQ_MODEL = 'openai/gpt-oss-20b';
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
 
 // --- JMDict lookup helpers (server-side, mirrors client jmdict.ts) ---
@@ -212,7 +212,7 @@ Be extremely concise.`;
 
       const ai = new GoogleGenAI({ apiKey: geminiKey, httpOptions: { apiVersion: 'v1beta' } });
       const result = await ai.models.generateContent({
-        model: 'gemini-3-flash-preview',
+        model: GEMINI_FLASH,
         contents: prompt,
       });
       const insight = (result.text ?? '').trim();

--- a/supabase/functions/fetch-raw-news/index.ts
+++ b/supabase/functions/fetch-raw-news/index.ts
@@ -1,3 +1,5 @@
+import { GROQ_CLUSTER as CLUSTER_MODEL } from '../_shared/models.ts';
+
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -72,7 +74,6 @@ const EVERYTHING_URL = 'https://newsapi.org/v2/everything';
 // llama-3.3-70b is used over the smaller scout model, which produced a
 // catastrophic 91-item "misc" mega-bucket at real scale.
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
-const CLUSTER_MODEL = 'llama-3.3-70b-versatile';
 // Keep merges tight — over-merging suppresses unrelated articles and wastes
 // extraction calls. The lead article is always primary; extras are corroboration.
 const MAX_SOURCES_PER_CLUSTER = 3;

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -1,13 +1,13 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { GoogleGenAI } from 'https://esm.sh/@google/genai';
 import { rtkKanjiList } from '../_shared/rtkKanji.ts';
+import { GEMINI_FLASH, GROQ_GENERAL as GROQ_MODEL } from '../_shared/models.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
-const GROQ_MODEL = 'openai/gpt-oss-20b';
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
 
 // ── Opportunistic full-text extraction ──────────────────────────────────────
@@ -407,7 +407,7 @@ Output EXACTLY a JSON array:
 
     console.log(`[process-article] Pass 1 for user ${userId}`);
     const result1 = await ai.models.generateContent({
-      model: 'gemini-3-flash-preview',
+      model: GEMINI_FLASH,
       contents: prompt1,
       config: { responseMimeType: 'application/json' },
     });


### PR DESCRIPTION
Closes #64. First piece of the **Word Mastery Loop** plan (Phase C — `docs/word-mastery-loop-plan.md`).

## What
- **New `supabase/functions/_shared/models.ts`** — a single bump point per model. All three edge functions import from it; four inline model literals removed.
- **Upgraded Gemini** from the floating `gemini-3-flash-preview` alias → stable, non-preview **`gemini-3.5-flash`**. The gemini-3-flash line never shipped a dated/stable build, so this is the reproducible identifier. Eliminates the last floating `-preview` string (issue acceptance).
- **Groq** (`openai/gpt-oss-20b`, `llama-3.3-70b-versatile`): Groq exposes no dated snapshots, so the IDs themselves are the pinned versions — now centralized rather than duplicated across two functions.
- **Fixed stale `CLAUDE.md`** reference ("Gemini 2.0-flash" → "Gemini 3.5-flash").

## Verification
Made live API calls to `gemini-3.5-flash` (v1beta, matching the SDK config the functions use):

| Path | Result |
|------|--------|
| Plain `generateContent` (dictionary-lookup grammar) | ✅ `modelVersion: gemini-3.5-flash`, `finishReason: STOP` |
| JSON mode `responseMimeType: application/json` (process-article rewrite) | ✅ returned valid parseable JSON; `modelVersion: gemini-3.5-flash` |

API echoes back the exact model version — no silent fallback.

## Acceptance (#64)
- [x] No floating `-preview`/unpinned model strings in `supabase/functions/`
- [x] A single bump point per model
- [x] Stale `CLAUDE.md` "Gemini 2.0-flash" corrected

## Out of scope (flagged)
`src/services/jmdict.ts:254` keeps a client-side copy of `openai/gpt-oss-20b`. The issue scopes to edge functions and that's a separate browser/Vite module graph — small optional follow-up if we want frontend covered too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)