### PR TITLE
refactor: extract Word Priority Metric into shared scoring module (#69)

### DIFF
--- a/supabase/functions/_shared/wordPriority.ts
+++ b/supabase/functions/_shared/wordPriority.ts
@@ -1,0 +1,96 @@
+// Word Priority Metric — the single shared scorer for "which word matters" (#69).
+//
+// Three signals decide a word's priority: SRS state, JLPT level, and natural
+// frequency. They combine into TWO distinct orderings for two moments in a word's
+// life. This module is the one place that logic lives, so the LLM article palette
+// (process-article), the intake-promotion job (#68), and the flashcard deck (#70/#72)
+// never drift into separate copies.
+//
+//   1. Intake (pre-SRS)   — which queued words enter active study, and in what order.
+//                            Foundation-first: easiest JLPT level first, then most
+//                            common first. NO SRS signal yet (the word isn't scheduled).
+//   2. In-SRS surfacing   — which active words to weave into the next article / order
+//                            the deck. Layers the SRS signal (mastery today; due-ness
+//                            once #67 lands) on top of level-fit + frequency.
+//
+// JLPT numbering convention (matches jmdict_entries.jlpt_level): 5 = N5 (easiest) …
+// 1 = N1 (hardest); null = untagged/rare. "Easier" therefore means a HIGHER number.
+//
+// This file is intentionally dependency-free and DOM/Deno-agnostic so it stays
+// portable. (When the frontend deck in Phase E needs it, decide then whether to share
+// this source across the Vite/Deno module boundary or call an edge function — see #70.)
+
+/** Per-user mastery bucket from `user_word_progress.mastery_level`. */
+export type Mastery = 'easy' | 'medium' | 'hard' | null | undefined;
+
+/** Palette bucket a word is assigned to for article generation. `null` = not placed. */
+export type PaletteBucket = 'known' | 'review' | 'new' | null;
+
+/**
+ * The signals the metric reads about one word. Callers map their own row shape
+ * (e.g. a `jmdict_vocab_candidates` row + a `user_word_progress` lookup) onto this,
+ * so the metric stays decoupled from any specific query.
+ */
+export interface WordSignal {
+  /** Canonical JMDict entry id. */
+  entryId: string;
+  /** 5 = N5 (easiest) … 1 = N1 (hardest); null = untagged/rare. */
+  jlptLevel: number | null;
+  /** 1 = most common; null = rare/unranked. */
+  freqRank: number | null;
+  /** JMDict "common" flag — a coarser commonness signal than freq_rank. */
+  isCommon: boolean;
+  /** Per-user SRS mastery; undefined/null = never tracked. */
+  mastery?: Mastery;
+}
+
+const FREQ_RANK_RARE = Number.POSITIVE_INFINITY; // null freq_rank sorts last (rarest)
+
+/**
+ * In-SRS surfacing order — "most useful word wins" for slicing the article palette.
+ * Common words first, then most-frequent (lowest freq_rank, nulls last), then easier
+ * (higher jlpt_level) first. Returns a standard Array.sort comparator result.
+ */
+export function compareSurfacing(a: WordSignal, b: WordSignal): number {
+  if (a.isCommon !== b.isCommon) return a.isCommon ? -1 : 1;
+  const fa = a.freqRank ?? FREQ_RANK_RARE;
+  const fb = b.freqRank ?? FREQ_RANK_RARE;
+  if (fa !== fb) return fa - fb;
+  return (b.jlptLevel ?? 0) - (a.jlptLevel ?? 0); // easier (higher number) first
+}
+
+/**
+ * Assign a word to the article palette bucket for a reader at `userJlpt`:
+ * - confirmed-easy            → known (the backbone the article is built on)
+ * - confirmed hard/medium     → review (resurface for reinforcement)
+ * - easier than the reader    → known (assumed-known, never explicitly tracked)
+ * - at the reader's level, untracked → new (a fresh introduction)
+ * - otherwise                 → null (not placed)
+ *
+ * NOTE (#22/#25): this is the *current* coarse, mastery-bucket logic, lifted verbatim
+ * from process-article so behavior is preserved by the extraction. Those follow-ups
+ * replace it with the richer metric (numeric difficulty + JLPT proximity + frequency
+ * weighting) — they change THIS function, and every consumer inherits the change.
+ */
+export function classifyBucket(w: WordSignal, userJlpt: number): PaletteBucket {
+  if (w.mastery === 'easy') return 'known';
+  if (w.mastery === 'hard' || w.mastery === 'medium') return 'review';
+  if (w.jlptLevel !== null && w.jlptLevel > userJlpt) return 'known';
+  if (w.jlptLevel === userJlpt && !w.mastery) return 'new';
+  return null;
+}
+
+/**
+ * Intake (pre-SRS) foundation-first order: easiest JLPT level first (higher number),
+ * then most common first. Words with an unknown level sort last (treated as hardest/
+ * rarest). No SRS signal — queued words aren't scheduled yet. Ready for #68's
+ * daily-promotion job; not yet wired to a caller.
+ */
+export function compareIntake(a: WordSignal, b: WordSignal): number {
+  const la = a.jlptLevel ?? Number.NEGATIVE_INFINITY; // unknown level = hardest, last
+  const lb = b.jlptLevel ?? Number.NEGATIVE_INFINITY;
+  if (la !== lb) return lb - la; // easier (higher number) first
+  const fa = a.freqRank ?? FREQ_RANK_RARE;
+  const fb = b.freqRank ?? FREQ_RANK_RARE;
+  return fa - fb; // most common (lowest rank) first
+}

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -2,6 +2,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { GoogleGenAI } from 'https://esm.sh/@google/genai';
 import { rtkKanjiList } from '../_shared/rtkKanji.ts';
 import { GEMINI_FLASH, GROQ_GENERAL as GROQ_MODEL } from '../_shared/models.ts';
+import { classifyBucket, compareSurfacing, type WordSignal } from '../_shared/wordPriority.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -254,31 +255,32 @@ Deno.serve(async (req) => {
           progressMap = new Map((progress ?? []).map((p: any) => [p.word_id, p.mastery_level]));
         }
 
-        // Sort candidates so the most useful words win the per-bucket slice below:
-        // common first, then by frequency rank (1 = most common, NULL = rare/unranked),
-        // then by jlpt_level (easier first). Feeds the known/review/new buckets alike,
-        // so frequent words are prioritized for study, not just for new introductions.
-        const sorted = [...(candidates ?? [])].sort((a: any, b: any) => {
-          if (a.is_common !== b.is_common) return a.is_common ? -1 : 1;
-          const fa = a.freq_rank ?? Infinity;
-          const fb = b.freq_rank ?? Infinity;
-          if (fa !== fb) return fa - fb;
-          return (b.jlpt_level ?? 0) - (a.jlpt_level ?? 0);
-        });
+        // Map DB rows onto the shared Word Priority Metric (../_shared/wordPriority.ts),
+        // the single source of "which word matters" across the palette, intake (#68),
+        // and the deck (#70). It owns the surfacing order (most useful first) and the
+        // known/review/new bucketing.
+        const display = new Map<string, string>();
+        const signals: WordSignal[] = [];
+        for (const c of (candidates ?? []) as any[]) {
+          const text = c.kanji || c.kana;
+          if (!text) continue;
+          display.set(c.entry_id, text);
+          signals.push({
+            entryId: c.entry_id,
+            jlptLevel: c.jlpt_level ?? null,
+            freqRank: c.freq_rank ?? null,
+            isCommon: !!c.is_common,
+            mastery: progressMap.get(c.entry_id) as WordSignal['mastery'],
+          });
+        }
+        signals.sort(compareSurfacing);
 
-        for (const c of sorted) {
-          const display = c.kanji || c.kana;
-          if (!display) continue;
-          const mastery = progressMap.get(c.entry_id);
-          if (mastery === 'easy') {
-            knownPalette.push(display);
-          } else if (mastery === 'hard' || mastery === 'medium') {
-            reviewPalette.push(display);
-          } else if (c.jlpt_level > jlptLevel) {
-            // Below user's study level (easier) => treat as assumed-known
-            knownPalette.push(display);
-          } else if (c.jlpt_level === jlptLevel && !mastery) {
-            newPalette.push(display);
+        for (const s of signals) {
+          const text = display.get(s.entryId)!;
+          switch (classifyBucket(s, jlptLevel)) {
+            case 'known': knownPalette.push(text); break;
+            case 'review': reviewPalette.push(text); break;
+            case 'new': newPalette.push(text); break;
           }
         }
         // De-dupe while preserving order


### PR DESCRIPTION
Closes #69. Phase B shared spine of the **Word Mastery Loop** plan (`docs/word-mastery-loop-plan.md`) — the one scorer that #25/#22 (palette), #68 (intake), and #70/#72 (deck) all build on, so "which word matters" can't drift into separate copies.

## What
- **New `supabase/functions/_shared/wordPriority.ts`** — dependency-free, DOM/Deno-agnostic. Exposes the two orderings the plan names:
  - **In-SRS surfacing** — `compareSurfacing` (most-useful-first) + `classifyBucket` (known/review/new). Lifted **verbatim** from `process-article`'s inline palette logic, so this PR is behavior-preserving. #22/#25 then replace the coarse mastery-bucket rules in `classifyBucket` with the richer numeric metric (difficulty + JLPT proximity + frequency), and every consumer inherits it.
  - **Intake (pre-SRS) foundation-first** — `compareIntake` (easiest JLPT level first, then most common first). Implemented and tested, ready for #68; no caller yet.
- **`process-article`** maps `jmdict_vocab_candidates` rows + per-user mastery onto `WordSignal` and calls the module instead of sorting/bucketing inline.

## Verification
- Behavioral equivalence test (the new comparators/bucketing vs. the old inline logic on a mixed sample) → surfacing order and bucket assignment **match exactly**; intake order is correctly foundation-first (N5→N4→N3→N2, common before null-freq within a level).
- `npm run build` passes (edge functions aren't in the `src`-only tsconfig; no deno locally to type-check, but the change is straightforward and logic is covered by the test above).

## Design notes
- **Location:** `supabase/functions/_shared/` serves every current and next-up consumer (palette + an edge-based intake job). The **frontend deck (#70, Phase E)** crosses the Vite/Deno module boundary — deferred decision flagged in the file header (share source vs. call an edge function).
- JLPT convention preserved from the schema: `5 = N5 (easiest) … 1 = N1 (hardest)`, null = rare/untagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)