### PR TITLE
feat: prefer confirmed-familiar over assumed-from-level words in the KNOWN backbone (#25)

### DIFF
--- a/supabase/functions/_shared/wordPriority.ts
+++ b/supabase/functions/_shared/wordPriority.ts
@@ -42,16 +42,54 @@ export interface WordSignal {
   isCommon: boolean;
   /** Per-user SRS mastery; undefined/null = never tracked. */
   mastery?: Mastery;
+  /**
+   * Per-user numeric difficulty (1 = easiest for this user … 10 = hardest); the SRS
+   * source of truth that `mastery` is derived from. null/undefined = never tracked.
+   */
+  difficulty?: number | null;
+  /** How many times this user has encountered the word. null/undefined = never tracked. */
+  timesSeen?: number | null;
+}
+
+/**
+ * Confirmed-familiar = the user has actually interacted with the word and it graded out
+ * easy (real evidence), as opposed to "assumed-from-level" words inferred easy purely
+ * from JLPT level with no interaction history. Only these ever feed the KNOWN backbone
+ * as verified vocabulary (#25).
+ */
+export function isConfirmedFamiliar(w: WordSignal): boolean {
+  return w.mastery === 'easy';
 }
 
 const FREQ_RANK_RARE = Number.POSITIVE_INFINITY; // null freq_rank sorts last (rarest)
 
 /**
  * In-SRS surfacing order — "most useful word wins" for slicing the article palette.
- * Common words first, then most-frequent (lowest freq_rank, nulls last), then easier
+ *
+ * Confirmed-familiar words sort first (#25): they're verified-easy backbone material,
+ * strictly better than below-level words the user has never seen, so the KNOWN cap drops
+ * the guesses before the verified words. Within the confirmed group, strongest evidence
+ * leads — easiest-for-the-user (lowest numeric difficulty) then most-often-seen.
+ *
+ * Everything else (and the tiebreak among confirmed words) falls back to frequency:
+ * common first, then most-frequent (lowest freq_rank, nulls last), then easier
  * (higher jlpt_level) first. Returns a standard Array.sort comparator result.
+ *
+ * Note: only confirmed-easy words ever land in the KNOWN bucket, so promoting them here
+ * reorders the backbone only — the review/new buckets keep their frequency ordering.
  */
 export function compareSurfacing(a: WordSignal, b: WordSignal): number {
+  const ca = isConfirmedFamiliar(a);
+  const cb = isConfirmedFamiliar(b);
+  if (ca !== cb) return ca ? -1 : 1;
+  if (ca && cb) {
+    const da = a.difficulty ?? FREQ_RANK_RARE; // missing difficulty = least-confirmed, last
+    const db = b.difficulty ?? FREQ_RANK_RARE;
+    if (da !== db) return da - db; // easier for the user first
+    const ta = a.timesSeen ?? 0;
+    const tb = b.timesSeen ?? 0;
+    if (ta !== tb) return tb - ta; // more interaction evidence first
+  }
   if (a.isCommon !== b.isCommon) return a.isCommon ? -1 : 1;
   const fa = a.freqRank ?? FREQ_RANK_RARE;
   const fb = b.freqRank ?? FREQ_RANK_RARE;

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -245,14 +245,21 @@ Deno.serve(async (req) => {
         if (candErr) throw candErr;
 
         const entryIds: string[] = (candidates ?? []).map((c: any) => c.entry_id);
-        let progressMap = new Map<string, string>();
+        // Fetch the richer per-user signals (numeric difficulty + times_seen), not just
+        // the coarse mastery_level bucket, so the metric can rank by real familiarity (#25).
+        type Progress = { mastery: WordSignal['mastery']; difficulty: number | null; timesSeen: number | null };
+        let progressMap = new Map<string, Progress>();
         if (entryIds.length > 0) {
           const { data: progress } = await supabase
             .from('user_word_progress')
-            .select('word_id, mastery_level')
+            .select('word_id, mastery_level, difficulty, times_seen')
             .eq('user_id', userId)
             .in('word_id', entryIds);
-          progressMap = new Map((progress ?? []).map((p: any) => [p.word_id, p.mastery_level]));
+          progressMap = new Map((progress ?? []).map((p: any) => [p.word_id, {
+            mastery: p.mastery_level,
+            difficulty: p.difficulty ?? null,
+            timesSeen: p.times_seen ?? null,
+          }]));
         }
 
         // Map DB rows onto the shared Word Priority Metric (../_shared/wordPriority.ts),
@@ -265,12 +272,15 @@ Deno.serve(async (req) => {
           const text = c.kanji || c.kana;
           if (!text) continue;
           display.set(c.entry_id, text);
+          const prog = progressMap.get(c.entry_id);
           signals.push({
             entryId: c.entry_id,
             jlptLevel: c.jlpt_level ?? null,
             freqRank: c.freq_rank ?? null,
             isCommon: !!c.is_common,
-            mastery: progressMap.get(c.entry_id) as WordSignal['mastery'],
+            mastery: prog?.mastery,
+            difficulty: prog?.difficulty ?? null,
+            timesSeen: prog?.timesSeen ?? null,
           });
         }
         signals.sort(compareSurfacing);


### PR DESCRIPTION
Closes #25. Phase B of the **Word Mastery Loop** plan. **Stacked on #78** (#69 shared metric) — base will auto-retarget to `main` when #78 merges.

## Problem
The KNOWN backbone (~90–98% of an article's tokens) was ordered **only by frequency**, so a word the user has *verified* easy could be pushed out, under the backbone cap, by a common below-level word they've **never seen**. Verified-easy words are strictly better backbone material than level-derived guesses. Worse, the function only fetched the coarse `mastery_level` bucket, so it had no real familiarity signal to rank by.

## Change
- **`wordPriority.ts`** — `compareSurfacing` now ranks **confirmed-familiar** words (mastery `easy`) ahead of everything else, and within that group by **strongest evidence first**: lowest numeric `difficulty` (the SRS source of truth that `mastery` derives from — see `database/11_difficulty.sql`), then most `times_seen`. Frequency remains the tiebreaker. Because only confirmed-easy words ever reach the KNOWN bucket, this reorders the **backbone only** — review/new keep their frequency ordering. Adds `difficulty` + `timesSeen` to `WordSignal` and an `isConfirmedFamiliar()` helper.
- **`process-article`** — widens the `user_word_progress` select from `mastery_level` to also fetch `difficulty` + `times_seen`, and carries them into each `WordSignal`. (Server-side widen, per the issue's cheaper option — no client changes.)

## Verification (sample set, user N4)
```
KNOWN  : easy-strong > easy-weak > assumed-f1 > assumed-f2
REVIEW : review-common > review-rare
NEW    : new-word
```
- Confirmed-easy words (`easy-strong` diff 1, `easy-weak` diff 3) now lead the KNOWN bucket **ahead of** the more-frequent never-seen words (`assumed-f1/f2`) — previously those common assumed words sorted first and could evict verified words under the cap.
- Within confirmed: easier-for-the-user (lower difficulty) first. ✓
- Review/New ordering unchanged. ✓
- `npm run build` passes.

## Notes
- Candidate eligibility is unchanged — this is purely *ordering + data*. The pool still filters `jlpt_level >= user_jlpt`.
- Sets up **#22** (rank unknown vocab by JLPT proximity), which refines the *other* end (review/new) of the same `classifyBucket`/ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)