### PR TITLE
feat: rank unknown vocab by JLPT proximity + surface stretch words (#22)

### DIFF
--- a/database/22_vocab_candidates_stretch.sql
+++ b/database/22_vocab_candidates_stretch.sql
@@ -1,0 +1,67 @@
+-- 22. Expose slightly-harder "stretch" vocab to the candidate pool (#22)
+--
+-- jmdict_vocab_candidates previously returned only entries at or EASIER than the
+-- user's level (`jlpt_level >= user_jlpt`), so an unknown word one level harder than
+-- the reader (e.g. N3 for an N4 user) was never a candidate and could never be
+-- surfaced as a "new" learning target. The Word Priority Metric (#22) wants those
+-- stretch words available so it can rank them just below in-reach words, closest-
+-- harder first.
+--
+-- JLPT numbering: 5 = N5 (easiest) … 1 = N1 (hardest). "1-2 levels harder" therefore
+-- means a NUMERICALLY LOWER jlpt_level, so we widen the floor to `user_jlpt - 2`:
+--   N4 user (4): now matches N5,N4 (at/easier) + N3,N2 (1-2 harder); N1 still excluded.
+--   N5 user (5): matches N5,N4,N3.
+-- NULL jlpt_level (untagged/rare) stays excluded — we don't suggest rare vocab to
+-- learners. The app's classifyBucket()/proximityRank() decide placement and ordering;
+-- this only controls eligibility.
+--
+-- Return columns are unchanged from migration 10, so CREATE OR REPLACE is sufficient.
+
+CREATE OR REPLACE FUNCTION public.jmdict_vocab_candidates(
+  keywords     TEXT[],
+  user_jlpt    INT,
+  max_results  INT DEFAULT 200
+)
+RETURNS TABLE (
+  entry_id    TEXT,
+  jlpt_level  SMALLINT,
+  kanji       TEXT,
+  kana        TEXT,
+  is_common   BOOLEAN,
+  freq_rank   SMALLINT
+)
+LANGUAGE sql
+STABLE
+AS $$
+  -- Keep the most frequent matches when capping at max_results: order by
+  -- freq_rank (1 = most common, NULL = rare/unranked) BEFORE the LIMIT so common
+  -- candidates are never arbitrarily dropped before the app can prioritize them.
+  WITH matched_entries AS (
+    SELECT DISTINCT e.id, e.jlpt_level, e.common, e.freq_rank
+    FROM public.jmdict_senses s
+    JOIN public.jmdict_entries e ON e.id = s.entry_id
+    WHERE e.jlpt_level IS NOT NULL
+      AND e.jlpt_level >= user_jlpt - 2   -- at/easier + up to 2 levels harder (#22)
+      AND EXISTS (
+        SELECT 1 FROM unnest(s.gloss) g
+        WHERE g ILIKE ANY(keywords)
+      )
+    ORDER BY e.common DESC, e.freq_rank ASC NULLS LAST
+    LIMIT max_results
+  )
+  SELECT
+    m.id                                     AS entry_id,
+    m.jlpt_level                             AS jlpt_level,
+    (SELECT k.text FROM public.jmdict_kanji k
+       WHERE k.entry_id = m.id
+       ORDER BY k.common DESC, k.id ASC LIMIT 1) AS kanji,
+    (SELECT ka.text FROM public.jmdict_kana ka
+       WHERE ka.entry_id = m.id
+       ORDER BY ka.common DESC, ka.id ASC LIMIT 1) AS kana,
+    m.common                                 AS is_common,
+    m.freq_rank                              AS freq_rank
+  FROM matched_entries m;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.jmdict_vocab_candidates(TEXT[], INT, INT)
+  TO anon, authenticated, service_role;

--- a/supabase/functions/_shared/wordPriority.ts
+++ b/supabase/functions/_shared/wordPriority.ts
@@ -64,7 +64,7 @@ export function isConfirmedFamiliar(w: WordSignal): boolean {
 const FREQ_RANK_RARE = Number.POSITIVE_INFINITY; // null freq_rank sorts last (rarest)
 
 /**
- * In-SRS surfacing order — "most useful word wins" for slicing the article palette.
+ * KNOWN-backbone order — "safest, most useful word wins" for slicing the backbone.
  *
  * Confirmed-familiar words sort first (#25): they're verified-easy backbone material,
  * strictly better than below-level words the user has never seen, so the KNOWN cap drops
@@ -73,12 +73,11 @@ const FREQ_RANK_RARE = Number.POSITIVE_INFINITY; // null freq_rank sorts last (r
  *
  * Everything else (and the tiebreak among confirmed words) falls back to frequency:
  * common first, then most-frequent (lowest freq_rank, nulls last), then easier
- * (higher jlpt_level) first. Returns a standard Array.sort comparator result.
- *
- * Note: only confirmed-easy words ever land in the KNOWN bucket, so promoting them here
- * reorders the backbone only — the review/new buckets keep their frequency ordering.
+ * (higher jlpt_level) first. Returns a standard Array.sort comparator result. Also used
+ * as the frequency tiebreaker inside compareByProximity (its confirmed-familiar branch is
+ * inert for the review/new buckets, which hold no verified-easy words).
  */
-export function compareSurfacing(a: WordSignal, b: WordSignal): number {
+export function compareKnown(a: WordSignal, b: WordSignal): number {
   const ca = isConfirmedFamiliar(a);
   const cb = isConfirmedFamiliar(b);
   if (ca !== cb) return ca ? -1 : 1;
@@ -97,25 +96,59 @@ export function compareSurfacing(a: WordSignal, b: WordSignal): number {
   return (b.jlptLevel ?? 0) - (a.jlptLevel ?? 0); // easier (higher number) first
 }
 
+const STRETCH_PENALTY = 100; // above-level "stretch" words rank after every in-reach word
+
+/**
+ * JLPT-proximity rank for an UNKNOWN / not-yet-mastered word, relative to a reader at
+ * `userJlpt` (#22). Lower = higher priority. A word at the reader's level ranks highest;
+ * easier in-reach words follow; words harder than the reader ("stretch") rank after all
+ * in-reach words, closest-harder first with priority decreasing as they get harder.
+ * Untagged level (null) sorts last. Numbering: 5 = N5 easiest … 1 = N1 hardest.
+ *
+ * Examples (reader N4 → userJlpt 4): at-level N4 → 0; easier N5 → 1; stretch N3 → 101;
+ * harder stretch N2 → 102 — so an unknown N3 outranks an unknown N2.
+ */
+export function proximityRank(w: WordSignal, userJlpt: number): number {
+  if (w.jlptLevel === null) return Number.POSITIVE_INFINITY;
+  const easierBy = w.jlptLevel - userJlpt; // >= 0 at the reader's level or easier
+  if (easierBy >= 0) return easierBy; // in-reach: at-level (0) first, then easier
+  return STRETCH_PENALTY + (userJlpt - w.jlptLevel); // harder: after in-reach, closest first
+}
+
+/**
+ * In-SRS surfacing order for the REVIEW and NEW buckets: rank unknown words by JLPT
+ * proximity to the reader (#22), then fall back to frequency. Returns a comparator bound
+ * to `userJlpt` for Array.sort.
+ */
+export function compareByProximity(userJlpt: number): (a: WordSignal, b: WordSignal) => number {
+  return (a, b) => {
+    const pa = proximityRank(a, userJlpt);
+    const pb = proximityRank(b, userJlpt);
+    if (pa !== pb) return pa - pb;
+    return compareKnown(a, b); // frequency tiebreaker
+  };
+}
+
 /**
  * Assign a word to the article palette bucket for a reader at `userJlpt`:
- * - confirmed-easy            → known (the backbone the article is built on)
- * - confirmed hard/medium     → review (resurface for reinforcement)
- * - easier than the reader    → known (assumed-known, never explicitly tracked)
- * - at the reader's level, untracked → new (a fresh introduction)
- * - otherwise                 → null (not placed)
+ * - confirmed-easy             → known (the backbone the article is built on)
+ * - confirmed hard/medium      → review (resurface for reinforcement)
+ * - easier than the reader     → known (assumed-known, never explicitly tracked)
+ * - at the reader's level OR a stretch harder, untracked → new (#22: stretch words used
+ *                                 to be dropped; they're now surfaced, ranked by
+ *                                 proximityRank so the closest-harder lead)
+ * - untagged level (null)      → null (rare/untagged — not suggested to learners)
  *
- * NOTE (#22/#25): this is the *current* coarse, mastery-bucket logic, lifted verbatim
- * from process-article so behavior is preserved by the extraction. Those follow-ups
- * replace it with the richer metric (numeric difficulty + JLPT proximity + frequency
- * weighting) — they change THIS function, and every consumer inherits the change.
+ * The *ordering* within each bucket comes from compareKnown (KNOWN) and compareByProximity
+ * (REVIEW/NEW); this function only decides placement. How far above-level a stretch word
+ * may reach is bounded upstream by the jmdict_vocab_candidates query (user_jlpt - 2).
  */
 export function classifyBucket(w: WordSignal, userJlpt: number): PaletteBucket {
   if (w.mastery === 'easy') return 'known';
   if (w.mastery === 'hard' || w.mastery === 'medium') return 'review';
-  if (w.jlptLevel !== null && w.jlptLevel > userJlpt) return 'known';
-  if (w.jlptLevel === userJlpt && !w.mastery) return 'new';
-  return null;
+  if (w.jlptLevel === null) return null; // untagged/rare — don't suggest
+  if (w.jlptLevel > userJlpt) return 'known'; // easier than the reader → assumed-known
+  return 'new'; // at the reader's level or a stretch harder, never tracked
 }
 
 /**

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -2,7 +2,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { GoogleGenAI } from 'https://esm.sh/@google/genai';
 import { rtkKanjiList } from '../_shared/rtkKanji.ts';
 import { GEMINI_FLASH, GROQ_GENERAL as GROQ_MODEL } from '../_shared/models.ts';
-import { classifyBucket, compareSurfacing, type WordSignal } from '../_shared/wordPriority.ts';
+import { classifyBucket, compareByProximity, compareKnown, type WordSignal } from '../_shared/wordPriority.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -264,16 +264,17 @@ Deno.serve(async (req) => {
 
         // Map DB rows onto the shared Word Priority Metric (../_shared/wordPriority.ts),
         // the single source of "which word matters" across the palette, intake (#68),
-        // and the deck (#70). It owns the surfacing order (most useful first) and the
-        // known/review/new bucketing.
+        // and the deck (#70). It owns the known/review/new bucketing and the per-bucket
+        // ordering: the KNOWN backbone by confirmed-familiarity then frequency (#25), and
+        // REVIEW/NEW by JLPT proximity to the reader then frequency (#22).
         const display = new Map<string, string>();
-        const signals: WordSignal[] = [];
+        const buckets: Record<'known' | 'review' | 'new', WordSignal[]> = { known: [], review: [], new: [] };
         for (const c of (candidates ?? []) as any[]) {
           const text = c.kanji || c.kana;
           if (!text) continue;
           display.set(c.entry_id, text);
           const prog = progressMap.get(c.entry_id);
-          signals.push({
+          const signal: WordSignal = {
             entryId: c.entry_id,
             jlptLevel: c.jlpt_level ?? null,
             freqRank: c.freq_rank ?? null,
@@ -281,18 +282,17 @@ Deno.serve(async (req) => {
             mastery: prog?.mastery,
             difficulty: prog?.difficulty ?? null,
             timesSeen: prog?.timesSeen ?? null,
-          });
+          };
+          const bucket = classifyBucket(signal, jlptLevel);
+          if (bucket) buckets[bucket].push(signal);
         }
-        signals.sort(compareSurfacing);
-
-        for (const s of signals) {
-          const text = display.get(s.entryId)!;
-          switch (classifyBucket(s, jlptLevel)) {
-            case 'known': knownPalette.push(text); break;
-            case 'review': reviewPalette.push(text); break;
-            case 'new': newPalette.push(text); break;
-          }
-        }
+        const byProximity = compareByProximity(jlptLevel);
+        buckets.known.sort(compareKnown);
+        buckets.review.sort(byProximity);
+        buckets.new.sort(byProximity);
+        knownPalette = buckets.known.map((s) => display.get(s.entryId)!);
+        reviewPalette = buckets.review.map((s) => display.get(s.entryId)!);
+        newPalette = buckets.new.map((s) => display.get(s.entryId)!);
         // De-dupe while preserving order
         knownPalette = Array.from(new Set(knownPalette)).slice(0, KNOWN_WORDS_PER_PARAGRAPH * targetParagraphs);
         reviewPalette = Array.from(new Set(reviewPalette)).slice(0, Math.max(5, targetReview + 2));


### PR DESCRIPTION
Closes #22. Phase B of the **Word Mastery Loop** plan. Builds on #69/#25 (already merged).

## Problem
When building the palette, `process-article` (1) **dropped any word harder than the reader** — only exact-level unseen words became "new" targets, so an N3 word for an N4 user landed in no palette at all — and (2) had **no notion of proximity** among unknown words (ordered only by frequency).

## Change
- **`database/22_vocab_candidates_stretch.sql`** — widen the `jmdict_vocab_candidates` floor from `jlpt_level >= user_jlpt` to `>= user_jlpt - 2`, so words 1–2 levels harder ("stretch") enter the candidate pool. NULL/rare levels stay excluded. **Manual migration** (apply in Supabase per repo convention).
- **`wordPriority.ts`**:
  - `proximityRank(w, userJlpt)` — at-level ranks highest (0); easier in-reach next; above-level **stretch** words rank after *all* in-reach words, closest-harder first, priority decreasing as they get harder; NULL last. (reader N4 → N4=0, N5=1, N3=101, N2=102.)
  - `compareByProximity(userJlpt)` — orders the REVIEW/NEW buckets by proximity, then frequency.
  - `classifyBucket` now routes at-level **or harder** unseen words to `new` (stretch words no longer dropped); easier-than-reader stays `known` (assumed); NULL → unplaced.
  - Renamed `compareSurfacing` → `compareKnown` (it's specifically the KNOWN-backbone order; also reused as the frequency tiebreaker inside `compareByProximity`).
- **`process-article`** — bucket first, then sort each bucket with its own comparator: KNOWN by `compareKnown` (#25), REVIEW/NEW by `compareByProximity` (#22). (Cleaner than one global sort, and avoids a bucket-aware comparator's transitivity pitfalls.)

## Verification (sample, reader N4)
```
KNOWN : easy-known > N5-easier
NEW   : N4-atlevel > N3-stretch > N2-stretch    <- issue's example: N3 outranks N2
REVIEW: hard-rev-N4 > hard-rev-N3
```
- Stretch words (N3, N2) now surface as `new` instead of being dropped. ✓
- Unknown N3 outranks unknown N2 (the issue's concrete requirement). ✓
- Easier words stay in the assumed-known backbone; #25 confirmed-familiar ordering preserved. ✓
- `npm run build` passes.

## Deploy coupling
Full effect needs **both** the migration applied **and** `process-article` redeployed — but each is harmless without the other (migration-only = harder words fetched then dropped by old code; code-only = no harder words in the pool, so no stretch words to rank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)