### PR TITLE
feat: topic-independent review floor — resurface stuck words regardless of topic (#51)

### DIFF
--- a/supabase/functions/_shared/wordPriority.ts
+++ b/supabase/functions/_shared/wordPriority.ts
@@ -49,6 +49,11 @@ export interface WordSignal {
   difficulty?: number | null;
   /** How many times this user has encountered the word. null/undefined = never tracked. */
   timesSeen?: number | null;
+  /**
+   * ISO-8601 timestamp of the user's last encounter (`user_word_progress.last_seen_at`).
+   * null/undefined = never tracked. Used for staleness ordering (#51).
+   */
+  lastSeenAt?: string | null;
 }
 
 /**
@@ -149,6 +154,26 @@ export function classifyBucket(w: WordSignal, userJlpt: number): PaletteBucket {
   if (w.jlptLevel === null) return null; // untagged/rare — don't suggest
   if (w.jlptLevel > userJlpt) return 'known'; // easier than the reader → assumed-known
   return 'new'; // at the reader's level or a stretch harder, never tracked
+}
+
+/**
+ * "Most-stuck" order for the topic-independent review floor (#51): surface the review
+ * words the user is most neglecting, regardless of the article's topic. Stalest first
+ * (oldest `last_seen_at`; never-seen sorts first), then hardest (highest difficulty),
+ * then least-seen. ISO-8601 timestamps compare chronologically as plain strings, so no
+ * date parsing is needed (keeps the module Date-free and portable).
+ *
+ * This is the interim staleness heuristic; #72 swaps the primary key for true `due_at`
+ * once the FSRS engine (#67) lands — callers keep using this comparator either way.
+ */
+export function compareStuck(a: WordSignal, b: WordSignal): number {
+  const la = a.lastSeenAt ?? ''; // never-seen / unknown = stalest, sorts first
+  const lb = b.lastSeenAt ?? '';
+  if (la !== lb) return la < lb ? -1 : 1; // older timestamp first
+  const da = a.difficulty ?? 0;
+  const db = b.difficulty ?? 0;
+  if (da !== db) return db - da; // hardest first
+  return (a.timesSeen ?? 0) - (b.timesSeen ?? 0); // least-seen first
 }
 
 /**

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -2,7 +2,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { GoogleGenAI } from 'https://esm.sh/@google/genai';
 import { rtkKanjiList } from '../_shared/rtkKanji.ts';
 import { GEMINI_FLASH, GROQ_GENERAL as GROQ_MODEL } from '../_shared/models.ts';
-import { classifyBucket, compareByProximity, compareKnown, type WordSignal } from '../_shared/wordPriority.ts';
+import { classifyBucket, compareByProximity, compareKnown, compareStuck, type WordSignal } from '../_shared/wordPriority.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -115,6 +115,11 @@ const WORDS_PER_PARAGRAPH = 67;
 // Backbone (KNOWN) pool size per paragraph — a draw-from pool, not a quota — so a
 // longer article has a richer known palette to build its spine from.
 const KNOWN_WORDS_PER_PARAGRAPH = 10;
+
+// #51: how many review slots to reserve for a topic-INDEPENDENT floor of the user's
+// most-stuck words, blended in regardless of whether they match the article's topic.
+// Clamped to the article's review budget so short articles don't get swamped.
+const STUCK_REVIEW_FLOOR = 2;
 
 // reading_intensity preset -> target distribution of known/review/new vocab.
 // See database/10_reading_intensity.sql for the column definition.
@@ -303,34 +308,58 @@ Deno.serve(async (req) => {
       console.error('[process-article] Palette pipeline error (continuing without palette):', palErr);
     }
 
-    // Legacy vocab_mode targets: any user review words, regardless of this article's topic.
-    // Still used below so the vocab_mode "Study" prompt keeps working even when the
-    // topic-keyed review palette is empty.
-    if (reviewPalette.length > 0) {
-      vocabTargets = reviewPalette.slice(0, 5);
-    } else {
-      const { data: wordProgress } = await supabase
+    // #51: topic-INDEPENDENT review floor. The palette above only re-injects a review
+    // word when the article's topic happens to match it, so words tied to a one-off
+    // story orphan (seen once, topic never recurs) and never drift easier. Reserve a
+    // couple of review slots for the user's most-stuck hard/medium words and blend them
+    // in regardless of topic. Needs no SRS engine — it routes the existing review pool
+    // by a staleness heuristic (compareStuck); #72 upgrades that ordering to real due_at.
+    const stuckFloor = Math.min(STUCK_REVIEW_FLOOR, Math.max(1, targetReview));
+    try {
+      const { data: stuckRows } = await supabase
         .from('user_word_progress')
-        .select('word_id')
+        .select('word_id, mastery_level, difficulty, times_seen, last_seen_at')
         .eq('user_id', userId)
         .in('mastery_level', ['hard', 'medium'])
-        .limit(30);
-      const ids = (wordProgress as any[])?.map((r) => r.word_id) ?? [];
-      if (ids.length > 0) {
-        // Pull the most common review words first (freq_rank 1 = most common,
-        // NULL = rare/unranked) instead of a random sample.
-        const { data: freqRows } = await supabase
-          .from('jmdict_entries')
-          .select('id, freq_rank')
-          .in('id', ids);
-        const rankMap = new Map((freqRows as any[] ?? []).map((r) => [r.id, r.freq_rank]));
-        const ranked = [...ids]
-          .sort((a, b) => (rankMap.get(a) ?? Infinity) - (rankMap.get(b) ?? Infinity))
-          .slice(0, 5);
-        const { data: kanjiRes } = await supabase.from('jmdict_kanji').select('text').in('entry_id', ranked);
-        if (kanjiRes) vocabTargets = Array.from(new Set(kanjiRes.map((r: any) => r.text)));
+        .limit(200);
+      const stuckSignals: WordSignal[] = (stuckRows as any[] ?? []).map((r) => ({
+        entryId: r.word_id,
+        jlptLevel: null,
+        freqRank: null,
+        isCommon: false,
+        mastery: r.mastery_level,
+        difficulty: r.difficulty ?? null,
+        timesSeen: r.times_seen ?? null,
+        lastSeenAt: r.last_seen_at ?? null,
+      }));
+      stuckSignals.sort(compareStuck);
+      const stuckIds = stuckSignals.slice(0, stuckFloor).map((s) => s.entryId);
+      if (stuckIds.length > 0) {
+        // Resolve surface forms (kanji preferred, kana fallback), preserving stuck order.
+        const [{ data: kanjiRows }, { data: kanaRows }] = await Promise.all([
+          supabase.from('jmdict_kanji').select('entry_id, text, common').in('entry_id', stuckIds).order('common', { ascending: false }),
+          supabase.from('jmdict_kana').select('entry_id, text, common').in('entry_id', stuckIds).order('common', { ascending: false }),
+        ]);
+        const firstByEntry = (rows: any[] | null) => {
+          const m = new Map<string, string>();
+          for (const r of rows ?? []) if (!m.has(r.entry_id)) m.set(r.entry_id, r.text);
+          return m;
+        };
+        const kanjiMap = firstByEntry(kanjiRows);
+        const kanaMap = firstByEntry(kanaRows);
+        const stuckReview = stuckIds
+          .map((id) => kanjiMap.get(id) ?? kanaMap.get(id))
+          .filter((t): t is string => !!t);
+        // Floor first (guaranteed to survive the slice), then topic-relevant review; dedupe.
+        reviewPalette = Array.from(new Set([...stuckReview, ...reviewPalette])).slice(0, Math.max(5, targetReview + 2));
+        console.log(`[process-article] Review floor: blended ${stuckReview.length} stuck word(s) [${stuckReview.join(', ')}]`);
       }
+    } catch (stuckErr) {
+      console.error('[process-article] Review-floor blend failed (continuing):', stuckErr);
     }
+
+    // vocab_mode "Study" prompt targets: drawn from the (now floor-blended) review palette.
+    vocabTargets = reviewPalette.slice(0, 5);
 
     // 3. Build Gemini prompts (same logic as client-side rewriteArticleWithGemini)
     const jlptStr = `N${jlptLevel}`;


### PR DESCRIPTION
Closes #51. **Completes Phase B** of the Word Mastery Loop plan. Builds on #69/#25/#22 (merged).

## Problem
Review re-injection was **topic-keyed**: a hard/medium word only came back when the article's extracted keywords matched it. Words tied to a one-off story (a place name, a niche term) **orphan** — seen once, the topic never recurs, so they never re-surface and never drift easier (the read-past `-1` nudge needs multi-day re-exposure they never get). The live audit in the issue found **36% of mature words never recurred after day one**.

## Change
Reserve up to `STUCK_REVIEW_FLOOR` (2, clamped to the article's review budget) review slots for a **topic-independent floor**: the user's most-stuck hard/medium words, blended into `reviewPalette` regardless of topic. No SRS engine or due-dates required — it routes the *existing* `mastery_level in ('hard','medium')` pool by a staleness heuristic.

- **`wordPriority.ts`** — add `compareStuck()`: stalest first (oldest `last_seen_at`; never-seen sorts first), then hardest (`difficulty`), then least-seen (`times_seen`). ISO-8601 timestamps compare chronologically as plain strings, so the module stays Date-free/portable. Adds `lastSeenAt` to `WordSignal`. **Interim heuristic — #72 swaps the primary key for true `due_at`** once the FSRS engine (#67) lands; callers keep using this comparator.
- **`process-article`** — replace the old "only-when-`reviewPalette`-empty" frequency fallback with an **always-on floor**: query hard/medium words (with `difficulty`/`times_seen`/`last_seen_at`), rank by `compareStuck`, resolve surface forms (kanji preferred, kana fallback), **prepend** the top N so they survive the palette slice, dedupe against topic review. `vocab_mode` targets now draw from the floor-blended palette. Logs the blended words. Wrapped in its own try/catch so a failure never breaks generation.

## Decisions (issue's open questions)
1. **Slots:** fixed `2`, clamped to `targetReview` (so short articles aren't swamped).
2. **Staleness ordering:** oldest `last_seen_at` primary (directly targets the orphan problem — neglected words), then `difficulty`, then `times_seen`.
3. **Prompt distinction:** forced-review words are treated **identically** to topic review for now (blended into one palette). It's ≤2 words, so prose impact is small; if off-topic forced words read unnaturally, distinguishing them is a #66 prompt-side follow-up.

## Verification
- `compareStuck` sample: `never-seen > stalest > stale-old > mid-hard > mid-easy > recent` — never-seen first, dates ascending, same-date tiebreak prefers harder. ✓
- `npm run build` passes.

## Deploy
No DB migration (uses existing `user_word_progress` columns). Ships on `supabase functions deploy process-article` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)