### PR TITLE
fix: backfill missing JLPT levels so words leave Progress "Other" bucket

### DIFF
--- a/docs/word-mastery-loop-plan.md
+++ b/docs/word-mastery-loop-plan.md
@@ -23,6 +23,8 @@
 - **Phase C is partially done** — models are pinned and upgraded to `gemini-3.5-flash` (#64 ✅). The eval harness (#65) and prompt restructure (#66) are next-up; the first concrete regression case is logged in [`phase-c-eval-notes.md`](./phase-c-eval-notes.md).
 - Goals 4–5's remainder (eval/prompt, then the real SRS engine + flashcards) are the open frontier: **Phase C** (#65/#66) can run anytime; **Phase D** (#67 FSRS engine + #68 intake queue) is the next big build, with **Phase E** (flashcards) on top.
 
+> **➡️ NEXT UP (pick this up first): Phase A — #39.** Phase B's selection logic shipped, but it ranks on per-word signals (`times_seen`, `difficulty`, `last_seen_at`) that **Phase A says are currently fragmented/under-counted** — one word splits across multiple tracking keys (kuromoji lemma on reads, JMDict word on clicks, entry_id on sync). So the smart scoring is running on noisy data. **#39 (canonical entry-id keying) is the foundational fix** that retroactively sharpens the shipped B work *and* is a hard prerequisite for Phase D (FSRS schedules per-word — fragmented keys → fragmented schedules). Phase A was deferred this session only because B chained cleanly within the edge function while #39 is larger and lives in the client read/tracking path — **not** because it was deprioritized. Recommended order from here: **A (#39 → #37 → #41) → C #65 → D #67**. Start #39 by mapping the exact keying divergence before writing code.
+
 **Two decisions locked (2026-06-20):**
 1. **SRS foundation → real FSRS/SM-2 due-dates.** We add a genuine scheduling layer (intervals + `due_at`) on top of the existing `difficulty` signal — not a pseudo-due hack. This is the prerequisite for the flashcard deck (Phase D → E).
 2. **Model → investigate before committing.** Audit/pin current versions, **check whether a newer Gemini flash (e.g. 3.5-flash) is available**, and decide flash-vs-pro per task against an eval harness rather than upgrading blind.
@@ -69,10 +71,10 @@ For words already promoted, a single comparable **priority score** decides which
 
 ---
 
-## Phase A — Foundation correctness (Goal 1: assign JLPT right · Goal 2: track right)
-*Status: detailed in [`content-and-word-selection-plan.md`](./content-and-word-selection-plan.md) Tier 3. Listed here because everything downstream inherits its data.*
+## Phase A — Foundation correctness (Goal 1: assign JLPT right · Goal 2: track right) — ⬅️ IMMEDIATE NEXT
+*Status: **open and now the top priority** (#39 → #37 → #41). Detailed in [`content-and-word-selection-plan.md`](./content-and-word-selection-plan.md) Tier 3. Deferred while Phase B shipped — see the NEXT UP callout above for why this should be picked up before Phase C/D.*
 
-Garbage-in guard: if JLPT/entry resolution is wrong **or reads aren't counted**, the SRS schedule, the LLM palette, and the flashcard deck all inherit the error. Do this alongside/ahead of Phase D.
+Garbage-in guard: if JLPT/entry resolution is wrong **or reads aren't counted**, the SRS schedule, the LLM palette, and the flashcard deck all inherit the error. **This is no longer hypothetical: Phase B (#25/#51) is already live and ranking on `times_seen`/`difficulty`/`last_seen_at`, so the keying bug in #39 is silently degrading shipped features right now.** Do this ahead of Phase D.
 
 - [ ] **#39 — Unify entry resolution (displayed vs stored JLPT) + canonical `times_seen` keying** 🔴 *(do early — foundational)* — homographs must resolve to one canonical `entry_id` so the badge, SRS seed, and palette read the same entry; stop the server's first-match Pass-3 linking from overriding the client's disambiguation; align NULL-JLPT handling (client "hard" vs server "ignored"). **Now also absorbs the `times_seen` under-count fix (folded in from #74):** the same word fragments across key spaces — passive reads key by kuromoji `lemma`, clicks by JMDict `details.word`, sync by `entry_id` (`Reader.tsx:231/308/340`, `tokenizer.ts:123`, `store.ts:313`), and entry_id-less tokens never sync — so all tracking must key on one canonical `entry_id`. Distinct from #41 (sync/display layer).
 - [ ] **#37 — JMDict sense miss (手当て → "salary")** 🟢 — prefer the entry whose kanji form exactly matches the surface; consider context-disambiguating the sense.
@@ -184,7 +186,7 @@ Phase C (prompt/model) ───────────[parallel]────�
 - **D before E** — the engine **and intake queue (#68)** are the flashcard foundation. **#72** is where #51's interim heuristic graduates to real due-dates.
 
 ### Recommended order
-~~#64 (pin)~~ ✅ → ~~B (#69 metric → #25 → #22 → #51)~~ ✅ → **next:** A (#39 canonical key / counts reads right → #37 → #41) + #65 (eval) → #67 (FSRS) → #68 (intake queue) → #66 (prompt) → #70→#71→#72→#73 (flashcards).
+~~#64 (pin)~~ ✅ → ~~B (#69 metric → #25 → #22 → #51)~~ ✅ → **NEXT: A (#39 canonical key / counts reads right → #37 → #41)** → #65 (eval) → #67 (FSRS) → #68 (intake queue) → #66 (prompt) → #70→#71→#72→#73 (flashcards).
 
 Rationale: cheapest reproducibility win first; finish the in-flight selection refactor on correct data while extracting the shared metric; stand up the eval harness so model/prompt changes are measured; build the engine, then the intake queue that paces words into it; then the deck. Prompt restructure (#66) slots in once the harness exists and can run alongside D.
 

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -116,10 +116,16 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     gradedRef.current.add(key);
     const jlptLevel = details?.jlptLevel;
     // Make sure a never-seen word exists before grading it (read latest store state).
-    if (!useAppStore.getState().wordDatabase[key]) {
+    const existing = useAppStore.getState().wordDatabase[key];
+    if (!existing) {
       saveWordDefinition(key, details
         ? { reading: details.reading, meaning: details.meaning, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id }
         : { reading: '...', meaning: 'Implicitly parsed context', jmdictEntryId: token.jmdict_entry_id });
+    } else if (details && existing.jlptLevel == null && details.jlptLevel != null) {
+      // Self-heal: the word was first stored before enrichment linked it (so it had
+      // no JLPT and sat in Progress's "Other"). Now that we have dictionary details,
+      // patch in the level and full definition.
+      saveWordDefinition(key, { reading: details.reading, meaning: details.meaning, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id });
     }
     recordWordSeen(key, true);
     // Count the read either way, but only seed a difficulty when the word is

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -490,6 +490,30 @@ export async function upsertWordProgressToSupabase(
   if (error) console.error(`Error syncing progress for ${wordId}:`, error);
 }
 
+/**
+ * Upsert many word-progress rows in a single request. Used by the one-time
+ * backfill so repairing hundreds of words is one round-trip, not a write burst.
+ */
+export async function upsertWordProgressBatch(
+  userId: string,
+  rows: { wordId: string; mastery: string; difficulty: number | null; timesSeen: number; streak: number; lastSeenTs: number }[]
+) {
+  if (rows.length === 0) return;
+  const { error } = await supabase
+    .from('user_word_progress')
+    .upsert(rows.map(r => ({
+      user_id: userId,
+      word_id: r.wordId,
+      mastery_level: r.mastery,
+      difficulty: r.difficulty ?? null,
+      times_seen: r.timesSeen,
+      streak: r.streak,
+      last_seen_at: new Date(r.lastSeenTs).toISOString()
+    })));
+
+  if (error) console.error('Error batch-syncing word progress:', error);
+}
+
 export async function logStudyEventToSupabase(
   userId: string, 
   wordId: string, 

--- a/src/services/jmdict.ts
+++ b/src/services/jmdict.ts
@@ -202,33 +202,87 @@ async function applyJlptFallback(byLemma: Map<string, JMDictResult>): Promise<vo
     }
   });
 
-  let kanjiLevels = new Map<string, number>();
-  if (needKanji.size > 0) {
-    try {
-      const { data } = await withTimeout(
-        supabase.from('kanji_jlpt').select('kanji, jlpt_level').in('kanji', [...needKanji]),
-        LOOKUP_TIMEOUT_MS,
-        'kanji_jlpt fallback',
-      );
-      kanjiLevels = new Map(
-        ((data || []) as { kanji: string; jlpt_level: number }[]).map(r => [r.kanji, r.jlpt_level]),
-      );
-    } catch (e) {
-      console.warn('kanji_jlpt fallback failed:', e);
-    }
-  }
+  const kanjiLevels = await fetchKanjiJlpt(needKanji);
 
   byLemma.forEach((entry, lemma) => {
     if (entry.jlptLevel != null) return;
-    // Hardest kanji = lowest JLPT number (N1 hardest = 1).
-    let derived: number | null = null;
-    for (const ch of lemma) {
-      const lv = kanjiLevels.get(ch);
-      if (lv != null) derived = derived == null ? lv : Math.min(derived, lv);
-    }
-    if (derived == null) derived = freqRankToJlpt(entry.freqRank);
-    entry.derivedJlpt = derived;
+    entry.derivedJlpt = deriveJlpt(lemma, entry.freqRank, kanjiLevels);
   });
+}
+
+/** Look up the JLPT level for each kanji character. Empty/failed → empty map. */
+async function fetchKanjiJlpt(chars: Set<string>): Promise<Map<string, number>> {
+  if (chars.size === 0) return new Map();
+  try {
+    const { data } = await withTimeout(
+      supabase.from('kanji_jlpt').select('kanji, jlpt_level').in('kanji', [...chars]),
+      LOOKUP_TIMEOUT_MS,
+      'kanji_jlpt fallback',
+    );
+    return new Map(
+      ((data || []) as { kanji: string; jlpt_level: number }[]).map(r => [r.kanji, r.jlpt_level]),
+    );
+  } catch (e) {
+    console.warn('kanji_jlpt fallback failed:', e);
+    return new Map();
+  }
+}
+
+/**
+ * Derive an approximate JLPT level for an untagged entry: the hardest (lowest-
+ * numbered) JLPT level among `scanText`'s kanji, else a coarse frequency bucket.
+ */
+function deriveJlpt(
+  scanText: string,
+  freqRank: number | null,
+  kanjiLevels: Map<string, number>,
+): number | null {
+  // Hardest kanji = lowest JLPT number (N1 hardest = 1).
+  let derived: number | null = null;
+  for (const ch of scanText) {
+    const lv = kanjiLevels.get(ch);
+    if (lv != null) derived = derived == null ? lv : Math.min(derived, lv);
+  }
+  if (derived == null) derived = freqRankToJlpt(freqRank);
+  return derived;
+}
+
+/**
+ * Resolve a JLPT level for each JMDict entry id, applying the same official-tag →
+ * kanji → frequency fallback used during enrichment. Used to backfill word
+ * records that were stored (e.g. read-past, pre-enrichment) without a level.
+ * Chunks the id list so a large backlog doesn't blow the PostgREST `in(...)` limit.
+ */
+export async function fetchJlptByEntryIds(
+  ids: string[],
+): Promise<Map<string, { jlptLevel: number | null; jlptDerived: boolean }>> {
+  const out = new Map<string, { jlptLevel: number | null; jlptDerived: boolean }>();
+  const unique = [...new Set(ids.filter(Boolean))];
+  if (unique.length === 0) return out;
+
+  const CHUNK = 300;
+  for (let i = 0; i < unique.length; i += CHUNK) {
+    const entries = await fetchEntries(unique.slice(i, i + CHUNK));
+
+    // Gather kanji from untagged entries' surfaces for one batched fallback query.
+    const needKanji = new Set<string>();
+    for (const e of entries) {
+      if (e.jlptLevel == null) {
+        for (const form of e.kanji) for (const ch of form) if (hasKanji(ch)) needKanji.add(ch);
+      }
+    }
+    const kanjiLevels = await fetchKanjiJlpt(needKanji);
+
+    for (const e of entries) {
+      if (e.jlptLevel != null) {
+        out.set(e.entryId, { jlptLevel: e.jlptLevel, jlptDerived: false });
+      } else {
+        const derived = deriveJlpt(e.kanji.join(''), e.freqRank, kanjiLevels);
+        out.set(e.entryId, { jlptLevel: derived, jlptDerived: derived != null });
+      }
+    }
+  }
+  return out;
 }
 
 /** Coarse JLPT bucket from a frequency band (1 = most common … 48 = rare). */

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -141,7 +141,7 @@ interface AppState {
   setWordMastery: (word: string, level: MasteryLevel) => void;
   checkDailyKanji: () => void;
   syncSrsWithSupabase: (userId: string) => Promise<void>;
-  backfillMissingJlptLevels: () => Promise<void>;
+  backfillWordProgress: () => Promise<void>;
 }
 
 export const useAppStore = create<AppState>()(
@@ -483,18 +483,24 @@ export const useAppStore = create<AppState>()(
           return {};
         });
 
-        // Repair words stored without a JLPT level (read-past / pre-enrichment
-        // grades, which land in the Progress "Other" bucket). They carry a JMDict
-        // entry id, so we can resolve the level from the dictionary and patch the
-        // local cache. Early-returns once everything is backfilled.
-        await get().backfillMissingJlptLevels();
+        // Repair words stored without a JLPT level (→ Progress "Other") and/or
+        // without a difficulty (→ "Ungraded") — read-past / pre-enrichment / legacy
+        // records. They carry a JMDict entry id, so the level is recoverable and a
+        // first-contact difficulty can be seeded. Early-returns once backfilled.
+        await get().backfillWordProgress();
       },
 
-      // Fill in jlptLevel for any cached word that has a JMDict entry id but no
-      // level. Resolves official → kanji → frequency, matching enrichment.
-      backfillMissingJlptLevels: async () => {
+      // Backfill cached words that have a JMDict entry id but are missing a JLPT
+      // level and/or a difficulty:
+      //   - jlptLevel: resolved official → kanji → frequency (matches enrichment).
+      //   - difficulty: seeded from the (now-known) JLPT as a read-past 'skip',
+      //     exactly like applyDifficultyEvent's first contact, so a word seen before
+      //     grading existed stops sitting in the unseen/ungraded bucket.
+      // Only seeds difficulty for words actually encountered (timesSeen >= 1) and
+      // syncs the seeded grades to Supabase in one batched round-trip.
+      backfillWordProgress: async () => {
         const targets = Object.entries(get().wordDatabase)
-          .filter(([, w]) => w.jlptLevel == null && !!w.jmdictEntryId);
+          .filter(([, w]) => !!w.jmdictEntryId && (w.jlptLevel == null || w.difficulty == null));
         if (targets.length === 0) return;
 
         const { fetchJlptByEntryIds } = await import('./jmdict');
@@ -502,25 +508,67 @@ export const useAppStore = create<AppState>()(
         try {
           resolved = await fetchJlptByEntryIds(targets.map(([, w]) => w.jmdictEntryId!));
         } catch (e) {
-          console.warn('[store] JLPT backfill failed:', e);
+          console.warn('[store] word-progress backfill failed:', e);
           return;
         }
+
+        const synced: { wordId: string; mastery: MasteryLevel; difficulty: number | null; timesSeen: number; streak: number; lastSeenTs: number }[] = [];
 
         set((state) => {
           const newDatabase = { ...state.wordDatabase };
           let changed = false;
           for (const [key] of targets) {
-            // Re-read latest; a concurrent enrichment may have already set it.
+            // Re-read latest; a concurrent enrichment/grade may have already set it.
             const current = newDatabase[key];
-            if (!current || current.jlptLevel != null || !current.jmdictEntryId) continue;
+            if (!current || !current.jmdictEntryId) continue;
             const hit = resolved.get(current.jmdictEntryId);
-            if (hit && hit.jlptLevel != null) {
-              newDatabase[key] = { ...current, jlptLevel: hit.jlptLevel, jlptDerived: hit.jlptDerived };
+            const next: WordData = { ...current };
+            let touched = false;
+
+            // 1. Backfill JLPT level → moves the word out of "Other".
+            if (next.jlptLevel == null && hit && hit.jlptLevel != null) {
+              next.jlptLevel = hit.jlptLevel;
+              next.jlptDerived = hit.jlptDerived;
+              touched = true;
+            }
+
+            // 2. Seed a difficulty for seen-but-ungraded words → out of "Ungraded".
+            //    Treat the past encounter as a read-past 'skip' (seed - 1), matching
+            //    first contact in applyDifficultyEvent.
+            if (next.difficulty == null && current.timesSeen >= 1) {
+              next.difficulty = clampDifficulty(seedDifficulty(next.jlptLevel ?? null, state.jlptLevel) - 1);
+              next.mastery = bucketForDifficulty(next.difficulty);
+              next.lastAdjustReason = 'skip';
+              touched = true;
+            }
+
+            if (touched) {
+              newDatabase[key] = next;
               changed = true;
+              // Only the difficulty path needs a server write (the level is always
+              // re-derivable client-side); push those rows for one batched upsert.
+              if (next.difficulty !== current.difficulty) {
+                synced.push({
+                  wordId: current.jmdictEntryId,
+                  mastery: next.mastery,
+                  difficulty: next.difficulty ?? null,
+                  timesSeen: next.timesSeen,
+                  streak: next.streak,
+                  lastSeenTs: next.lastSeenTs,
+                });
+              }
             }
           }
           return changed ? { wordDatabase: newDatabase } : {};
         });
+
+        if (synced.length > 0) {
+          const uid = await currentUserId();
+          if (uid) {
+            const { upsertWordProgressBatch } = await import('./api');
+            upsertWordProgressBatch(uid, synced).catch(() => { /* best-effort sync */ });
+          }
+        }
       },
 
       checkDailyKanji: () => {

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -141,6 +141,7 @@ interface AppState {
   setWordMastery: (word: string, level: MasteryLevel) => void;
   checkDailyKanji: () => void;
   syncSrsWithSupabase: (userId: string) => Promise<void>;
+  backfillMissingJlptLevels: () => Promise<void>;
 }
 
 export const useAppStore = create<AppState>()(
@@ -480,6 +481,45 @@ export const useAppStore = create<AppState>()(
 
           if (changed) return { wordDatabase: newDatabase };
           return {};
+        });
+
+        // Repair words stored without a JLPT level (read-past / pre-enrichment
+        // grades, which land in the Progress "Other" bucket). They carry a JMDict
+        // entry id, so we can resolve the level from the dictionary and patch the
+        // local cache. Early-returns once everything is backfilled.
+        await get().backfillMissingJlptLevels();
+      },
+
+      // Fill in jlptLevel for any cached word that has a JMDict entry id but no
+      // level. Resolves official → kanji → frequency, matching enrichment.
+      backfillMissingJlptLevels: async () => {
+        const targets = Object.entries(get().wordDatabase)
+          .filter(([, w]) => w.jlptLevel == null && !!w.jmdictEntryId);
+        if (targets.length === 0) return;
+
+        const { fetchJlptByEntryIds } = await import('./jmdict');
+        let resolved: Map<string, { jlptLevel: number | null; jlptDerived: boolean }>;
+        try {
+          resolved = await fetchJlptByEntryIds(targets.map(([, w]) => w.jmdictEntryId!));
+        } catch (e) {
+          console.warn('[store] JLPT backfill failed:', e);
+          return;
+        }
+
+        set((state) => {
+          const newDatabase = { ...state.wordDatabase };
+          let changed = false;
+          for (const [key] of targets) {
+            // Re-read latest; a concurrent enrichment may have already set it.
+            const current = newDatabase[key];
+            if (!current || current.jlptLevel != null || !current.jmdictEntryId) continue;
+            const hit = resolved.get(current.jmdictEntryId);
+            if (hit && hit.jlptLevel != null) {
+              newDatabase[key] = { ...current, jlptLevel: hit.jlptLevel, jlptDerived: hit.jlptDerived };
+              changed = true;
+            }
+          }
+          return changed ? { wordDatabase: newDatabase } : {};
         });
       },
 


### PR DESCRIPTION
## Problem

The Progress page bucketed most vocabulary as **"Other"** (no JLPT level) and **"Ungraded"** (no difficulty) — on-device, 1,297 of 2,787 words showed as "Other," and 765 of those were also "Ungraded."

**Root cause (one condition, two symptoms):** Words graded on the read-past path were stored *before* enrichment linked them to a dictionary entry, so they got neither a `jlptLevel` (→ "Other") nor — for unlinkable words — a `difficulty` (→ "Ungraded", by design in `Reader.tsx`: difficulty is only seeded for dictionary-linked words). Records were write-once and `jlptLevel` is never persisted to Supabase, so nothing repaired them.

Verified against production data:
- All 2,210 synced records are JMDict-entry-id-keyed (0 string-keyed, 0 unmatched); every sampled word has a real `jlpt_level` → the level is always recoverable.
- 331 records are ungraded, and **all 331 are linkable** (216 with a JLPT/freq signal) → they're ungraded because they predate client grading, not because they're unlinkable.

## Fix

**JLPT backfill (→ "Other"):**
- `jmdict.ts` — `fetchJlptByEntryIds()` resolves a level per entry id using the same official-tag → kanji → frequency fallback as enrichment (shared logic extracted into `fetchKanjiJlpt` / `deriveJlpt`). Chunked at 300 ids/request.
- `store.ts` — `backfillWordProgress()`, run at the end of `syncSrsWithSupabase`; patches every cached word with a null level + entry id, then early-returns once drained.
- `Reader.tsx` — self-heal: once enrichment links a word, patch its null `jlptLevel` so no new orphans accumulate.

**Difficulty backfill (→ "Ungraded"):**
- Same `backfillWordProgress()` pass: for an encountered (`timesSeen >= 1`) word with no difficulty, seed one from the resolved JLPT as a read-past "skip" (`seedDifficulty(...) - 1`), set the mastery bucket — exactly like `applyDifficultyEvent`'s first contact.
- `api.ts` — `upsertWordProgressBatch()` syncs the seeded grades in one round-trip (not a per-word write burst).
- Mirrors `database/15_backfill_unseen_difficulty.sql`, but runs client-side (reflects on-device immediately, and avoids the migration's stale-sync gap) and uses the freq/kanji-derived JLPT instead of defaulting untagged words to "hard".

## Expected outcome

"Other" and "Ungraded" both shrink substantially. The remainder (~430 local-only words with no JMDict entry id — proper nouns, tokenizer artifacts) correctly stays Other/Ungraded, since the app won't guess a level or difficulty for a word it can't look up.

## Notes

- No `jlpt_level` column added to Supabase: the level is always re-derivable from the synced entry id.
- `tsc -b` build passes; lint error count unchanged (53 → 53, all pre-existing `no-explicit-any`).
- After deploy, the PWA may need a hard refresh / reinstall to pick up the new bundle (stale cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
