### PR TITLE
fix: reconcile locally-graded words to the server during SRS sync

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -499,17 +499,26 @@ export async function upsertWordProgressBatch(
   rows: { wordId: string; mastery: string; difficulty: number | null; timesSeen: number; streak: number; lastSeenTs: number }[]
 ) {
   if (rows.length === 0) return;
-  const { error } = await supabase
-    .from('user_word_progress')
-    .upsert(rows.map(r => ({
-      user_id: userId,
-      word_id: r.wordId,
-      mastery_level: r.mastery,
-      difficulty: r.difficulty ?? null,
-      times_seen: r.timesSeen,
-      streak: r.streak,
-      last_seen_at: new Date(r.lastSeenTs).toISOString()
-    })));
+  // last_seen_at is NOT NULL: a bad lastSeenTs (0/NaN/undefined) would make
+  // `new Date(ts).toISOString()` throw and abort the ENTIRE batch, so a single
+  // legacy row could silently sink every other write. Coerce to a valid instant.
+  const payload = rows
+    .filter(r => r.wordId)
+    .map(r => {
+      const ts = Number.isFinite(r.lastSeenTs) && r.lastSeenTs > 0 ? r.lastSeenTs : Date.now();
+      return {
+        user_id: userId,
+        word_id: r.wordId,
+        mastery_level: r.mastery,
+        difficulty: r.difficulty ?? null,
+        times_seen: r.timesSeen ?? 0,
+        streak: r.streak ?? 0,
+        last_seen_at: new Date(ts).toISOString(),
+      };
+    });
+  if (payload.length === 0) return;
+
+  const { error } = await supabase.from('user_word_progress').upsert(payload);
 
   if (error) console.error('Error batch-syncing word progress:', error);
 }

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -488,6 +488,32 @@ export const useAppStore = create<AppState>()(
         // records. They carry a JMDict entry id, so the level is recoverable and a
         // first-contact difficulty can be seeded. Early-returns once backfilled.
         await get().backfillWordProgress();
+
+        // Reconcile local → server: words graded locally but ungraded (or absent)
+        // on the server never had their grade persisted (legacy rows / failed past
+        // syncs). Local is authoritative — it reflects real reading — so push those
+        // grades up. We only FILL server nulls here; an existing server difficulty
+        // is left untouched, so this can't clobber a newer cross-device grade.
+        const toPush = Object.values(get().wordDatabase)
+          .filter((w) => {
+            if (!w.jmdictEntryId || w.difficulty == null) return false;
+            const remote = remoteProgress[w.jmdictEntryId];
+            return !remote || remote.difficulty == null;
+          })
+          .map((w) => ({
+            wordId: w.jmdictEntryId!,
+            mastery: w.mastery,
+            difficulty: w.difficulty!,
+            timesSeen: w.timesSeen,
+            streak: w.streak,
+            lastSeenTs: w.lastSeenTs,
+          }));
+        if (toPush.length > 0) {
+          const { upsertWordProgressBatch } = await import('./api');
+          await upsertWordProgressBatch(userId, toPush).catch((e) => {
+            console.warn('[store] local→server grade reconcile failed:', e);
+          });
+        }
       },
 
       // Backfill cached words that have a JMDict entry id but are missing a JLPT


### PR DESCRIPTION
## Problem

After #85, the Progress page is fixed client-side (JLPT "Other" drained, words graded), but the server copy of `user_word_progress` was unchanged — still **331 ungraded rows** (graded 1879 → 1879, zero writes landed). Article generation reads the server copy, so those words are still treated as `unseen`.

**Root cause:** #85's backfill only syncs difficulties it *newly seeds*. The 331 stale rows are already graded in the *local* store (from past sessions) but their grade never reached the server — so the backfill's difficulty branch skips them and nothing heals the divergence. (A latent contributor: the batch upsert wrapped `new Date(lastSeenTs).toISOString()`, which throws on a bad `lastSeenTs` and, with the error swallowed, could abort the whole batch silently.)

## Fix

- **`store.ts`** — after the backfill in `syncSrsWithSupabase`, reconcile local → server: for every word graded locally whose server difficulty is null/absent, push the local grade up. Local is authoritative (it reflects real reading). Only **fills server nulls** — an existing server difficulty is never overwritten, so this can't clobber a newer cross-device grade.
- **`api.ts`** — harden `upsertWordProgressBatch`: coerce a bad `lastSeenTs` (0/NaN/undefined) to a valid instant so one legacy row can't make the whole batch throw, and default `times_seen`/`streak`.

## Verification

Built clean (`tsc -b`); lint unchanged (53 → 53). After deploy + a logged-in sync, this query should show `still_ungraded` drop from 331 toward 0 (only genuinely-unsynced-and-locally-ungraded words remain):

```sql
with me as (select id from auth.users where email = 'kpdevoe@gmail.com')
select count(*) filter (where difficulty is null) as still_ungraded,
       count(*) filter (where difficulty is not null) as graded,
       count(*) as total
from user_word_progress p, me where p.user_id = me.id;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
