### PR TITLE
fix: rehydrate Progress word cache from the server after a wipe

### DIFF
--- a/src/services/jmdict.ts
+++ b/src/services/jmdict.ts
@@ -285,6 +285,45 @@ export async function fetchJlptByEntryIds(
   return out;
 }
 
+/**
+ * Reconstruct full word details (surface, reading, meaning, JLPT, pos, furigana)
+ * for each JMDict entry id. Used to rehydrate the local word cache from the
+ * server after a reinstall/localStorage wipe, where only entry ids + SRS state
+ * survive. Keyed by entry id; `word` is the primary surface (kanji else kana).
+ */
+export async function fetchDetailsByEntryIds(
+  ids: string[],
+): Promise<Map<string, { word: string; reading: string; meaning: string; jlptLevel: number | null; jlptDerived: boolean; pos: string[]; furiganaMap: { kanji: string; kana: string }[]; jmdictEntryId: string }>> {
+  const out = new Map<string, { word: string; reading: string; meaning: string; jlptLevel: number | null; jlptDerived: boolean; pos: string[]; furiganaMap: { kanji: string; kana: string }[]; jmdictEntryId: string }>();
+  const unique = [...new Set(ids.filter(Boolean))];
+  if (unique.length === 0) return out;
+
+  const CHUNK = 300;
+  for (let i = 0; i < unique.length; i += CHUNK) {
+    const entries = await fetchEntries(unique.slice(i, i + CHUNK));
+
+    const needKanji = new Set<string>();
+    for (const e of entries) {
+      if (e.jlptLevel == null) {
+        for (const form of e.kanji) for (const ch of form) if (hasKanji(ch)) needKanji.add(ch);
+      }
+    }
+    const kanjiLevels = await fetchKanjiJlpt(needKanji);
+
+    for (const e of entries) {
+      const surface = e.kanji[0] ?? e.readings[0] ?? '';
+      if (!surface) continue;
+      // jmdictToWordDetails reads result.derivedJlpt when the official tag is null.
+      const withDerived = e.jlptLevel == null
+        ? { ...e, derivedJlpt: deriveJlpt(e.kanji.join(''), e.freqRank, kanjiLevels) }
+        : e;
+      const d = jmdictToWordDetails(surface, withDerived);
+      out.set(e.entryId, { word: surface, ...d });
+    }
+  }
+  return out;
+}
+
 /** Coarse JLPT bucket from a frequency band (1 = most common … 48 = rare). */
 function freqRankToJlpt(rank: number | null): number | null {
   if (rank == null) return null;

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -483,6 +483,52 @@ export const useAppStore = create<AppState>()(
           return {};
         });
 
+        // Rehydrate remote-only words. The merge above only UPDATES words already
+        // cached locally — it never ADDS ones that exist on the server but not in
+        // the local store. So a wiped localStorage (reinstall / cleared cache) left
+        // Progress empty despite intact server data. Pull full JMDict details for
+        // any server word missing locally and reconstruct its WordData. Guarded by
+        // `missingIds`, so once the cache is whole this fetch is skipped.
+        const haveIds = new Set(
+          Object.values(get().wordDatabase).map((w) => w.jmdictEntryId).filter(Boolean),
+        );
+        const missingIds = Object.keys(remoteProgress).filter((id) => !haveIds.has(id));
+        if (missingIds.length > 0) {
+          try {
+            const { fetchDetailsByEntryIds } = await import('./jmdict');
+            const details = await fetchDetailsByEntryIds(missingIds);
+            if (details.size > 0) {
+              set((state) => {
+                const newDatabase = { ...state.wordDatabase };
+                details.forEach((d, id) => {
+                  const r = remoteProgress[id];
+                  if (!r) return;
+                  // Don't overwrite a local entry already keyed by this surface.
+                  if (newDatabase[d.word]?.jmdictEntryId === id) return;
+                  newDatabase[d.word] = {
+                    reading: d.reading,
+                    meaning: d.meaning,
+                    jlptLevel: d.jlptLevel,
+                    jlptDerived: d.jlptDerived,
+                    pos: d.pos,
+                    furiganaMap: d.furiganaMap,
+                    jmdictEntryId: id,
+                    mastery: r.mastery ?? 'unseen',
+                    difficulty: r.difficulty ?? null,
+                    timesSeen: r.timesSeen ?? 0,
+                    streak: r.streak ?? 0,
+                    lastSeenTs: r.lastSeenTs ?? Date.now(),
+                    uniqueDaysSeen: [],
+                  };
+                });
+                return { wordDatabase: newDatabase };
+              });
+            }
+          } catch (e) {
+            console.warn('[store] word-cache rehydrate failed:', e);
+          }
+        }
+
         // Repair words stored without a JLPT level (→ Progress "Other") and/or
         // without a difficulty (→ "Ungraded") — read-past / pre-enrichment / legacy
         // records. They carry a JMDict entry id, so the level is recoverable and a


### PR DESCRIPTION
## Problem

After reinstalling the PWA (clearing `localStorage`), the Progress page showed **0 words at every level** — even though all ~2,210 word-progress rows are intact in Supabase.

**Root cause:** Progress renders entirely from the local `wordDatabase`. `syncSrsWithSupabase` only *updates* words already cached locally (it matches remote rows to existing local entries by `jmdictEntryId`); it never *adds* a server word that's missing from the store. `user_word_progress` also stores only entry id + SRS state — no surface/reading/meaning — so a wiped cache can't rebuild itself, and the page renders empty. (No data is lost; it just can't be displayed.)

## Fix

- **`jmdict.ts`** — `fetchDetailsByEntryIds()` reconstructs full word details (surface, reading, meaning, JLPT, pos, furigana) per entry id, reusing the official → kanji → frequency JLPT fallback. Chunked at 300 ids/request.
- **`store.ts`** — in `syncSrsWithSupabase`, after the existing merge, fetch details for any server word not present locally and rebuild its `WordData`, carrying the server's `mastery`/`difficulty`/`timesSeen`/`streak`/`lastSeenTs`. Guarded by `missingIds`, so it's a one-time fetch after a wipe and is skipped once the cache is whole.

This makes Progress fully reconstructable from Supabase — surviving reinstalls, cleared caches, and new devices.

## Verification

Built clean (`tsc -b`); lint unchanged (53 → 53). After deploy + a logged-in sync on a freshly-installed app, Progress should repopulate from the server (~2,210 words across N5–N1/Other) instead of showing 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
