### PR TITLE
fix: paginate fetchUserWordProgress (was capped at 1000 rows)

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -447,26 +447,36 @@ const mockArticles: NewsArticle[] = [
 
 
 export async function fetchUserWordProgress(userId: string): Promise<Record<string, any>> {
-  const { data, error } = await supabase
-    .from('user_word_progress')
-    .select('*')
-    .eq('user_id', userId);
-    
-  if (error) {
-    console.error("Error fetching word progress:", error);
-    return {};
-  }
-  
   const progress: Record<string, any> = {};
-  data?.forEach(row => {
-    progress[row.word_id] = {
-      mastery: row.mastery_level,
-      difficulty: row.difficulty ?? null,
-      timesSeen: row.times_seen,
-      streak: row.streak,
-      lastSeenTs: new Date(row.last_seen_at).getTime()
-    };
-  });
+  // PostgREST caps a select at ~1000 rows. A heavy user has more word-progress
+  // rows than that, so an unpaginated fetch silently returned only the first
+  // 1000 — which capped SRS sync, the JLPT/difficulty backfill, AND the
+  // post-wipe rehydration at 1000 words. Page through the full set.
+  const PAGE = 1000;
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('user_word_progress')
+      .select('*')
+      .eq('user_id', userId)
+      .range(from, from + PAGE - 1);
+
+    if (error) {
+      console.error("Error fetching word progress:", error);
+      break;
+    }
+
+    (data || []).forEach(row => {
+      progress[row.word_id] = {
+        mastery: row.mastery_level,
+        difficulty: row.difficulty ?? null,
+        timesSeen: row.times_seen,
+        streak: row.streak,
+        lastSeenTs: new Date(row.last_seen_at).getTime()
+      };
+    });
+
+    if (!data || data.length < PAGE) break; // last page
+  }
   return progress;
 }
 

--- a/src/services/jmdict.ts
+++ b/src/services/jmdict.ts
@@ -298,7 +298,10 @@ export async function fetchDetailsByEntryIds(
   const unique = [...new Set(ids.filter(Boolean))];
   if (unique.length === 0) return out;
 
-  const CHUNK = 300;
+  // Keep chunks small enough that a chunk's child-row queries (senses especially,
+  // several rows per entry) stay under the PostgREST ~1000-row cap, so no entry
+  // comes back missing its surface/meaning.
+  const CHUNK = 200;
   for (let i = 0; i < unique.length; i += CHUNK) {
     const entries = await fetchEntries(unique.slice(i, i + CHUNK));
 


### PR DESCRIPTION
## Problem

After a reinstall, Progress rebuilt to only **1106** of **2210** server words. The cause is **not** the rehydration chunking — diagnostics showed the server has 2199 distinct surfaces, all intact, and child-row volumes are well under the PostgREST 1000-row cap per chunk.

The real culprit is **`fetchUserWordProgress` has no pagination**, so PostgREST caps it at ~1000 rows. A user with >1000 tracked words only ever pulls the first 1000 down. That silently capped:
- SRS sync (only 1000 words ever merged),
- the JLPT/difficulty backfill and local→server reconcile (only saw 1000 rows — part of why `still_ungraded` never moved),
- the post-wipe rehydration (could only rebuild from ~1000 → the observed 1106, plus a few re-read words).

## Fix

- **`api.ts`** — `fetchUserWordProgress` now pages through `user_word_progress` in 1000-row `.range()` windows until a short page, loading the full set.
- **`jmdict.ts`** — `fetchDetailsByEntryIds` chunk 300 → 200, so a chunk's child-row queries (senses, several per entry) also stay under the 1000-row cap and no entry loses its surface/meaning.

## Verification

Built clean (`tsc -b`); lint unchanged (53 → 53). After deploy + a logged-in sync, Progress should rebuild to ~2199 words (not 1106), and — because backfill/reconcile now see all rows — `still_ungraded` should finally fall too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
