### PR TITLE
fix: track every word under one canonical entry_id key (#39)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ backups/
 
 # Generated personal vocabulary report (contains user stats)
 vocab-summary.html
+.playwright-mcp/

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -38,7 +38,8 @@ const levelKeyFor = (w: WordData): LevelKey =>
 const masteryOf = (w: WordData): MasteryLevel => w.mastery || 'unseen';
 
 interface WordRow extends WordData {
-  word: string;
+  word: string;   // display surface (the map key is now the JMDict entry_id, #39)
+  dbKey: string;  // the wordDatabase key — stable, unique React key
 }
 
 export function Progress() {
@@ -49,10 +50,10 @@ export function Progress() {
   const byLevel = useMemo(() => {
     const map = new Map<LevelKey, WordRow[]>();
     LEVELS.forEach((l) => map.set(l.value, []));
-    Object.entries(wordDatabase).forEach(([word, data]) => {
+    Object.entries(wordDatabase).forEach(([dbKey, data]) => {
       const key = levelKeyFor(data);
       if (!map.has(key)) map.set(key, []);
-      map.get(key)!.push({ word, ...data });
+      map.get(key)!.push({ ...data, word: data.surface ?? dbKey, dbKey });
     });
     return map;
   }, [wordDatabase]);
@@ -442,7 +443,7 @@ export function Progress() {
             <div style={{ backgroundColor: 'var(--bg-card)', borderRadius: '16px', overflow: 'hidden' }}>
               {visibleWords.map((w, i) => (
                 <WordRowView
-                  key={w.word}
+                  key={w.dbKey}
                   word={w.word}
                   reading={w.reading}
                   meaning={w.meaning}

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -11,6 +11,7 @@ import {
 } from '../services/api';
 import { enrichArticle, isEnriched } from '../services/enrich';
 import { useAppStore } from '../services/store';
+import { canonicalWordKey } from '../services/wordKey';
 import { touchLock } from '../services/touchLock';
 import { } from 'lucide-react'; // Empty block to show we're using icons elsewhere if needed, or just clear it.
 // Actually, let's just remove the line if no icons are used.
@@ -23,7 +24,7 @@ interface ReaderProps {
 
 // Minimal shape needed to grade a word: definition details (for a never-seen word)
 // and a jmdict id fallback. Article tokens carry more, but this is all grading reads.
-type GradeToken = { details?: WordDetails; jmdict_entry_id?: string };
+type GradeToken = { details?: WordDetails; jmdict_entry_id?: string; lemma?: string; text?: string };
 
 // Deterministic tap-target sizing. Kanji content words (furigana present) are
 // the ones users actually look up, so they get the widest hit area; short kana
@@ -89,6 +90,7 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
   const recordWordSeen = useAppStore(s => s.recordWordSeen);
   const setWordMastery = useAppStore(s => s.setWordMastery);
   const applyDifficultyEvent = useAppStore(s => s.applyDifficultyEvent);
+  const mergeWordRecords = useAppStore(s => s.mergeWordRecords);
   const setCurrentArticle = useAppStore(s => s.setCurrentArticle);
   const saveProcessedArticle = useAppStore(s => s.saveProcessedArticle);
 
@@ -117,15 +119,16 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     const jlptLevel = details?.jlptLevel;
     // Make sure a never-seen word exists before grading it (read latest store state).
     const existing = useAppStore.getState().wordDatabase[key];
+    const surface = details?.word ?? token.lemma ?? token.text ?? key;
     if (!existing) {
       saveWordDefinition(key, details
-        ? { reading: details.reading, meaning: details.meaning, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id }
-        : { reading: '...', meaning: 'Implicitly parsed context', jmdictEntryId: token.jmdict_entry_id });
+        ? { reading: details.reading, meaning: details.meaning, surface, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id }
+        : { reading: '...', meaning: 'Implicitly parsed context', surface, jmdictEntryId: token.jmdict_entry_id });
     } else if (details && existing.jlptLevel == null && details.jlptLevel != null) {
       // Self-heal: the word was first stored before enrichment linked it (so it had
       // no JLPT and sat in Progress's "Other"). Now that we have dictionary details,
       // patch in the level and full definition.
-      saveWordDefinition(key, { reading: details.reading, meaning: details.meaning, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id });
+      saveWordDefinition(key, { reading: details.reading, meaning: details.meaning, surface, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id });
     }
     recordWordSeen(key, true);
     // Count the read either way, but only seed a difficulty when the word is
@@ -233,8 +236,9 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     currentArticle?.blocks.forEach(b => {
       if (b.content) b.content.forEach(w => {
         if (!w.isInteractive && !w.furigana) return;
-        // Key by lemma so conjugations collapse and the key matches clickedWords.
-        const key = w.lemma ?? w.details?.word ?? w.text;
+        // Canonical key: entry_id when linked (collapses conjugations/variants of one
+        // entry), else lemma/surface. Matches the grade-key and clickedWords sets.
+        const key = canonicalWordKey({ jmdictEntryId: w.details?.jmdictEntryId || w.jmdict_entry_id, lemma: w.lemma, word: w.details?.word, text: w.text });
         const existing = map.get(key);
         if (!existing || (!existing.details && (w.details || w.jmdict_entry_id))) map.set(key, w);
       });
@@ -311,18 +315,21 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
       return;
     }
     determineAnchor(e);
-    recordWordSeen(details.word);
-    setClickedWords(prev => new Set(prev).add(details.word));
+    // Track under the canonical key (entry_id when linked, else the surface/lemma),
+    // so a click and a passive read of the same word land on one record (#39).
+    const key = canonicalWordKey({ jmdictEntryId: details.jmdictEntryId, word: details.word });
+    recordWordSeen(key);
+    setClickedWords(prev => new Set(prev).add(key));
 
-    const cached = wordDatabase[details.word];
+    const cached = wordDatabase[key];
     const merged = { ...details, grammarNote: cached?.grammarNote || details.grammarNote };
     setSelectedWord(merged);
     setSelectedSentence(null);
     setActiveHighlightId(tokenId);
     setTargetRect(e.currentTarget.getBoundingClientRect());
-    saveWordDefinition(details.word, details);
+    saveWordDefinition(key, { ...details, surface: details.word });
     // Looking a word up means it wasn't known: nudge its difficulty up.
-    applyDifficultyEvent(details.word, 'click', details.jlptLevel);
+    applyDifficultyEvent(key, 'click', details.jlptLevel);
 
     if (!merged.grammarNote) {
       fetchWordGrammarInsight(details.word, sentText).then(insight => {
@@ -330,7 +337,7 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
           if (!prev || prev.word !== details.word) return prev;
           return { ...prev, grammarNote: insight };
         });
-        saveWordDefinition(details.word, { grammarNote: insight });
+        saveWordDefinition(key, { grammarNote: insight });
       });
     }
   };
@@ -343,15 +350,18 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
       return;
     }
     determineAnchor(e);
-    recordWordSeen(word);
-    setClickedWords(prev => new Set(prev).add(word));
+    // Canonical key: the entry_id when the token was already linked, else the surface
+    // word (a lookup that discovers an id later re-keys onto it — see below) (#39).
+    const key = canonicalWordKey({ jmdictEntryId, word });
+    recordWordSeen(key);
+    setClickedWords(prev => new Set(prev).add(key));
     setSelectedSentence(null);
-    
-    const localData = wordDatabase[word];
-    // Self-healing: If we have local data but it's missing important metadata (JLPT or JMDict ID), 
+
+    const localData = wordDatabase[key];
+    // Self-healing: If we have local data but it's missing important metadata (JLPT or JMDict ID),
     // we allow the lookup to proceed to enrich the entry.
     if (localData && localData.meaning && localData.meaning !== 'Implicitly parsed context' && localData.jlptLevel && localData.jmdictEntryId) {
-      applyDifficultyEvent(word, 'click', localData.jlptLevel);
+      applyDifficultyEvent(key, 'click', localData.jlptLevel);
       setSelectedWord({
         word,
         reading: localData.reading,
@@ -371,7 +381,7 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
             if (!prev || prev.word !== word) return prev;
             return { ...prev, grammarNote: insight };
           });
-          saveWordDefinition(word, { grammarNote: insight });
+          saveWordDefinition(key, { grammarNote: insight });
         });
       }
       return;
@@ -401,7 +411,16 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
         jmdictEntryId: quickDef.jmdictEntryId
       };
       setSelectedWord(combinedInitial);
-      
+
+      // The lookup may resolve an entry_id for a token that had none pre-linked. Its
+      // canonical key is that id — migrate the surface-keyed record we just created
+      // onto it so the word stays a single record (#39).
+      const canonKey = canonicalWordKey({ jmdictEntryId: quickDef.jmdictEntryId || jmdictEntryId, word });
+      if (canonKey !== key) {
+        mergeWordRecords(key, canonKey);
+        setClickedWords(prev => new Set(prev).add(canonKey)); // keep grade-dedup aligned
+      }
+
       // 2. SMART PATH (Gemini 3 Flash) - Parallel Context Analysis
       fetchWordGrammarInsight(word, contextSentence).then((insight) => {
         setSelectedWord(prev => {
@@ -409,13 +428,13 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
           return { ...prev, grammarNote: insight };
         });
         // Cache the full enriched result
-        saveWordDefinition(word, { ...combinedInitial, grammarNote: insight });
+        saveWordDefinition(canonKey, { ...combinedInitial, surface: word, grammarNote: insight });
       });
 
       // Cache initial quick data
-      saveWordDefinition(word, combinedInitial);
+      saveWordDefinition(canonKey, { ...combinedInitial, surface: word });
       // Now that the JLPT level is known, nudge difficulty up for this lookup.
-      applyDifficultyEvent(word, 'click', quickDef.jlptLevel);
+      applyDifficultyEvent(canonKey, 'click', quickDef.jlptLevel);
       setIsModalLoading(false);
     } catch (err) {
       console.error("Word lookup failed:", err);
@@ -448,7 +467,7 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
   };
 
   const handleSetMastery = (level: 'hard' | 'medium' | 'easy') => {
-    if (selectedWord) setWordMastery(selectedWord.word, level);
+    if (selectedWord) setWordMastery(canonicalWordKey({ jmdictEntryId: selectedWord.jmdictEntryId, word: selectedWord.word }), level);
   };
 
   const renderParagraph = (block: any, blockIdx: number) => {
@@ -499,8 +518,9 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
         >
           {sentTokens.map((segment, j) => {
             if (segment.furigana || segment.isInteractive) {
-              // Key by lemma so the grade key matches clickedWords and the payload map.
-              const gradeKey = segment.lemma ?? segment.details?.word ?? segment.text;
+              // Canonical key (entry_id when linked, else lemma/surface) — must match
+              // the payload map and clickedWords so grading dedups correctly.
+              const gradeKey = canonicalWordKey({ jmdictEntryId: segment.details?.jmdictEntryId || segment.jmdict_entry_id, lemma: segment.lemma, word: segment.details?.word, text: segment.text });
               return (
                 // Inline wrapper carries the grade key and is the intersection target,
                 // so "fully visible for a dwell" grades this word (see grade-on-visible).
@@ -508,7 +528,7 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
                   <FuriganaText
                     word={segment.text}
                     furigana={segment.furigana}
-                    hitWeight={hitWeightFor(segment.text, segment.furigana, wordDatabase[segment.text]?.mastery)}
+                    hitWeight={hitWeightFor(segment.text, segment.furigana, wordDatabase[gradeKey]?.mastery)}
                     isSelected={activeHighlightId === `${sentenceId}-${j}`}
                     onClick={(e) => {
                       const tid = `${sentenceId}-${j}`;

--- a/src/components/WordModal.tsx
+++ b/src/components/WordModal.tsx
@@ -1,6 +1,7 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import { BookOpen, Sparkles } from 'lucide-react';
 import { useAppStore } from '../services/store';
+import { canonicalWordKey } from '../services/wordKey';
 import { rtkKanjiMap } from '../data/rtkKanji';
 import { useEffect, useRef } from 'react';
 
@@ -105,7 +106,7 @@ export function WordModal({
     }
 
     if (!wordData) return null;
-    const stats = wordDatabase[wordData.word];
+    const stats = wordDatabase[canonicalWordKey({ jmdictEntryId: wordData.jmdictEntryId, word: wordData.word })];
     const activeMastery = (!stats || stats.mastery === 'unseen') ? 'medium' : stats.mastery;
 
     const getTrackedSegments = () => {

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -73,6 +73,44 @@ function syncConsumed(id: string, kind: 'read' | 'dismissed'): void {
   }).catch(() => { /* never block the UI on a sync failure */ });
 }
 
+/**
+ * Combine two tracking records that turned out to be the same word (#39): the same
+ * entry reached under two keys (e.g. a conjugation and its dictionary form, or a
+ * pre-link surface key and its later-resolved entry_id). Exposures are additive —
+ * they were genuinely separate sightings — while the graded SRS signal from the
+ * stronger source wins. `into` is treated as the surviving record.
+ */
+export function mergeWordData(into: WordData, from: WordData): WordData {
+  // Prefer an explicitly graded signal (manual > click > skip) over an ungraded one.
+  const rank = (w: WordData) =>
+    w.lastAdjustReason === 'manual' ? 3 : w.lastAdjustReason === 'click' ? 2 : w.difficulty != null ? 1 : 0;
+  const graded = rank(from) > rank(into) ? from : into;
+  const days = Array.from(new Set([...(into.uniqueDaysSeen ?? []), ...(from.uniqueDaysSeen ?? [])]));
+  return {
+    ...into,
+    // Richest display/definition fields win (a linked record over a placeholder).
+    reading: into.reading || from.reading,
+    meaning: into.meaning && into.meaning !== 'Implicitly parsed context' ? into.meaning : (from.meaning || into.meaning),
+    grammarNote: into.grammarNote ?? from.grammarNote,
+    furiganaMap: into.furiganaMap ?? from.furiganaMap,
+    pos: into.pos ?? from.pos,
+    jlptLevel: into.jlptLevel ?? from.jlptLevel,
+    jlptDerived: into.jlptLevel != null ? into.jlptDerived : from.jlptDerived,
+    surface: into.surface ?? from.surface,
+    jmdictEntryId: into.jmdictEntryId ?? from.jmdictEntryId,
+    // SRS state from whichever record carried the stronger grade.
+    difficulty: graded.difficulty ?? into.difficulty ?? from.difficulty,
+    mastery: graded.mastery ?? into.mastery,
+    lastAdjustedDay: graded.lastAdjustedDay ?? into.lastAdjustedDay,
+    lastAdjustReason: graded.lastAdjustReason ?? into.lastAdjustReason,
+    // Exposures are additive; recency and streak take the most recent.
+    timesSeen: (into.timesSeen ?? 0) + (from.timesSeen ?? 0),
+    uniqueDaysSeen: days,
+    lastSeenTs: Math.max(into.lastSeenTs ?? 0, from.lastSeenTs ?? 0),
+    streak: (into.lastSeenTs ?? 0) >= (from.lastSeenTs ?? 0) ? (into.streak ?? 0) : (from.streak ?? 0),
+  };
+}
+
 export interface WordData {
   reading: string;
   meaning: string;
@@ -82,6 +120,10 @@ export interface WordData {
   jlptDerived?: boolean;
   pos?: string[];
   jmdictEntryId?: string;
+  // Human-readable form for display/lists. Since the map key is the JMDict
+  // entry_id once a word is linked (#39 canonical keying), the surface can no
+  // longer be read off the key — it's carried here (the dictionary/lemma form).
+  surface?: string;
   mastery: MasteryLevel;          // derived bucket, kept in sync with `difficulty`
   difficulty?: number | null;     // 1..10 source of truth; null/undefined = unseen
   lastAdjustedDay?: string;       // YYYY-MM-DD of the last difficulty change (daily dedup)
@@ -139,6 +181,7 @@ interface AppState {
   recordWordSeen: (word: string, withoutLookup?: boolean) => void;
   applyDifficultyEvent: (word: string, event: 'skip' | 'click', jlptLevel?: number | null) => void;
   setWordMastery: (word: string, level: MasteryLevel) => void;
+  mergeWordRecords: (fromKey: string, toKey: string) => void;
   checkDailyKanji: () => void;
   syncSrsWithSupabase: (userId: string) => Promise<void>;
   backfillWordProgress: () => Promise<void>;
@@ -290,7 +333,23 @@ export const useAppStore = create<AppState>()(
             }
           };
         }),
-        
+
+      // Collapse two records for one word onto a single key (#39). Used when a
+      // dictionary lookup resolves an entry_id for a token that was first tracked
+      // under its surface/lemma — the surface-keyed record is merged into the
+      // canonical entry_id key so the word stays one record (and one server row).
+      mergeWordRecords: (fromKey: string, toKey: string) =>
+        set((state) => {
+          if (fromKey === toKey) return {};
+          const from = state.wordDatabase[fromKey];
+          if (!from) return {};
+          const db = { ...state.wordDatabase };
+          const existing = db[toKey];
+          db[toKey] = existing ? mergeWordData(existing, from) : { ...from };
+          delete db[fromKey];
+          return { wordDatabase: db };
+        }),
+
         
       recordWordSeen: (word: string, withoutLookup = false) => 
         set((state) => {
@@ -469,9 +528,14 @@ export const useAppStore = create<AppState>()(
           let changed = false;
 
           Object.entries(remoteProgress).forEach(([wordId, remoteData]: [string, any]) => {
-            const localWord = Object.entries(newDatabase).find(([_, data]) => data.jmdictEntryId === wordId);
-            if (localWord) {
-              const [wordKey, localData] = localWord;
+            // Local records are keyed by entry_id (#39), so the server word_id is a
+            // direct lookup; fall back to a scan for any legacy surface-keyed record
+            // that still carries this entry_id.
+            const wordKey =
+              newDatabase[wordId] ? wordId
+              : Object.entries(newDatabase).find(([_, data]) => data.jmdictEntryId === wordId)?.[0];
+            if (wordKey) {
+              const localData = newDatabase[wordKey];
               if (remoteData.lastSeenTs > localData.lastSeenTs) {
                 newDatabase[wordKey] = { ...localData, ...remoteData };
                 changed = true;
@@ -503,11 +567,13 @@ export const useAppStore = create<AppState>()(
                 details.forEach((d, id) => {
                   const r = remoteProgress[id];
                   if (!r) return;
-                  // Don't overwrite a local entry already keyed by this surface.
-                  if (newDatabase[d.word]?.jmdictEntryId === id) return;
-                  newDatabase[d.word] = {
+                  // Keyed by entry_id (#39). Skip if already present (merge above
+                  // handled it); this only ADDS server-only words.
+                  if (newDatabase[id]) return;
+                  newDatabase[id] = {
                     reading: d.reading,
                     meaning: d.meaning,
+                    surface: d.word,
                     jlptLevel: d.jlptLevel,
                     jlptDerived: d.jlptDerived,
                     pos: d.pos,
@@ -665,7 +731,7 @@ export const useAppStore = create<AppState>()(
     }),
     {
       name: 'yugen-storage',
-      version: 4,
+      version: 5,
       // A persist write throws QuotaExceededError once localStorage fills up. That
       // exception used to propagate out of store actions (markArticleRead,
       // recordWordSeen, ...) and abort the tap handler — silently breaking article
@@ -754,6 +820,24 @@ export const useAppStore = create<AppState>()(
             }
           });
           state = { ...state, wordDatabase };
+        }
+        // v5: canonical entry_id keying (#39). Re-key every dictionary-linked record
+        // from its old surface/lemma key to its JMDict entry_id, carrying the old key
+        // over as the `surface` display form. Records that share an entry_id (a word
+        // tracked under a conjugation AND its base form, kana vs kanji, etc.) collapse
+        // into one via mergeWordData — summing exposures, keeping the stronger grade.
+        // Entry-less records (proper nouns, parse artifacts) keep their surface key.
+        if (version < 5 && state?.wordDatabase) {
+          const rekeyed: Record<string, WordData> = {};
+          Object.entries(state.wordDatabase as Record<string, WordData>).forEach(([key, w]) => {
+            if (!w) return;
+            const targetKey = w.jmdictEntryId || key;
+            const withSurface: WordData = { ...w, surface: w.surface ?? key };
+            rekeyed[targetKey] = rekeyed[targetKey]
+              ? mergeWordData(rekeyed[targetKey], withSurface)
+              : withSurface;
+          });
+          state = { ...state, wordDatabase: rekeyed };
         }
         return state;
       },

--- a/src/services/wordKey.ts
+++ b/src/services/wordKey.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical word-tracking key (issue #39).
+ *
+ * A word is tracked in exactly one place — the store's `wordDatabase` map, the
+ * server's `user_word_progress.word_id`, and the Reader's grade/click dedup sets.
+ * Historically each path derived its own key from a different string (kuromoji
+ * `lemma` on passive reads, JMDict `details.word` on clicks, `entry_id` on sync),
+ * so one word fragmented into several under-counted records and entry-less tokens
+ * never synced.
+ *
+ * The fix: derive every key from one function. When a word is dictionary-linked we
+ * key by its JMDict `entry_id` — this collapses conjugations and kana/kanji
+ * variants that share an entry into a single record, and makes the local key equal
+ * the server `word_id` (so sync/rehydrate are direct lookups). Only genuinely
+ * unlinkable tokens (proper nouns, parse artifacts) fall back to their surface
+ * form; those can't sync anyway (no id) and stay local-only by nature.
+ *
+ * entry_ids are JMDict sequence numbers (7-digit strings) and surfaces are Japanese
+ * text, so the two key spaces don't collide in practice.
+ */
+export function canonicalWordKey(o: {
+  jmdictEntryId?: string | null;
+  lemma?: string | null;
+  word?: string | null;
+  text?: string | null;
+}): string {
+  return o.jmdictEntryId || o.lemma || o.word || o.text || '';
+}
+
+/** True when a key is a JMDict entry_id (all digits) rather than a surface form. */
+export function isEntryIdKey(key: string): boolean {
+  return /^\d+$/.test(key);
+}


### PR DESCRIPTION
## Summary

Closes #39 (Phase A of the Word Mastery Loop plan). Word tracking fragmented **one word into several under-counted records** because each path keyed it differently:

- passive reads keyed by kuromoji **lemma** (`走る`)
- clicks keyed by JMDict **`details.word`**
- sync keyed by **`entry_id`**

So a word read in one form and clicked in another became separate records, conjugations / kana-vs-kanji variants never collapsed, and `entry_id`-less tokens never synced (lost on reinstall). Since the shipped **Phase B** selection ranks on `times_seen`/`difficulty`/`last_seen_at`, this was quietly degrading article word-selection — and it's a hard prerequisite for **Phase D** (FSRS needs exactly one record per word).

### Scope note
The original issue also targeted a **server-side Pass 3** that first-match-linked entries and overrode the client. That pass has since been removed — all tokenization/linking is now client-side (kuromoji + `enrich.ts`), which already attaches `jmdict_entry_id` at enrich time. So Concern B is moot and this PR is purely the **client-side canonical keying** fix (it also absorbs the folded-in #74 `times_seen` under-count work).

## What changed

- **`services/wordKey.ts`** (new) — `canonicalWordKey()`: key by JMDict `entry_id` when a word is linked (collapses conjugations + variants, and makes the local key equal the server `word_id`), else fall back to surface/lemma.
- **`store.ts`** — add `WordData.surface` (display form, since the key is now an id); `mergeWordData()` + `mergeWordRecords` action to collapse duplicate records (exposures additive, stronger grade wins); sync-merge + rehydrate key **directly by `entry_id`**; **v5 persist migration** re-keys existing data and merges duplicates.
- **`Reader.tsx`** — payload map, `data-grade-key`, both click paths, hit-weight lookup, and `setWordMastery` use the canonical key; the dictionary-lookup path **re-keys onto a late-resolved `entry_id`** so it still collapses to one record.
- **`WordModal.tsx` / `Progress.tsx`** — keyed lookups + display use the canonical key + `surface` (with a stable `dbKey` for React keys).

## Acceptance (#39, incl. #74)
- [x] All tracking — `wordDatabase` key, grade/click dedup sets, Supabase `word_id` — keyed by one canonical `entry_id`; surface/lemma are display-only.
- [x] A word read in one form and clicked in another increments **one** record; conjugations and kana/kanji variants collapse.
- [x] Local and remote agree — no `entry_id`-less orphans, no last-write-wins clobber (local key == server `word_id`).

## Verification
- `tsc --noEmit` clean; `npm run build` passes. (Remaining lint errors are pre-existing `no-explicit-any` across untouched files.)
- **Browser-tested the v4→v5 migration** on a seeded `localStorage` blob: two records for one verb (dict form + conjugation) collapse into one — `timesSeen` summed (3+2→5), seen-days unioned, stronger grade kept (click/hard over skip), display surface preserved; a single linked word re-keys cleanly; an entry-less proper noun keeps its surface key. Idempotent on a second reload; zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)