### PR TITLE
feat: FSRS spaced-repetition scheduling engine (#67)

### DIFF
--- a/database/23_fsrs_scheduling.sql
+++ b/database/23_fsrs_scheduling.sql
@@ -1,0 +1,86 @@
+-- 23. FSRS scheduling layer (#67)
+--
+-- Adds a genuine spaced-repetition schedule (stability + due_at + intervals + a
+-- review log) ON TOP OF the existing `difficulty` (1..10) signal — difficulty stays
+-- the coarse palette signal and the seed; these fields are the real due-date engine.
+--
+-- The canonical implementation of the algorithm + seeding is src/services/srs.ts
+-- (wraps ts-fsrs, FSRS-6, request_retention 0.85). The backfill below is a ONE-TIME
+-- synthesis of a plausible starting schedule for rows that predate this engine; it
+-- mirrors `seedSrsFromDifficulty` in that module. Any word touched after migration
+-- is rescheduled by the TS engine, so small backfill approximations self-correct.
+--
+-- Applied by hand in Supabase (project convention).
+
+-- ── Scheduling columns on user_word_progress ────────────────────────────────
+-- NULL scheduling fields = word is not yet on a schedule (unseen / queued — the
+-- intake gate that promotes queued→active is #68's job, not this migration's).
+alter table public.user_word_progress
+  add column if not exists stability         double precision,           -- FSRS S, in days
+  add column if not exists fsrs_difficulty    double precision            -- FSRS D, 1..10 (algorithm-managed; DISTINCT from `difficulty`)
+    check (fsrs_difficulty is null or (fsrs_difficulty between 1 and 10)),
+  add column if not exists due_at             timestamptz,                -- next review — the "what's due" key
+  add column if not exists last_reviewed_at   timestamptz,                -- last scheduler event (≠ last_seen_at, which is any exposure)
+  add column if not exists interval_days      double precision,           -- convenience mirror of the scheduled gap (derivable from S)
+  add column if not exists reps               integer default 0,          -- successful reviews
+  add column if not exists lapses             integer default 0,          -- Again-after-review count
+  add column if not exists srs_status         text                        -- FSRS card lifecycle
+    check (srs_status is null or srs_status in ('new','learning','review','relearning'));
+
+-- "What's due today" — the query the flashcard deck (#70) and article feed (#72) hang off.
+create index if not exists idx_uwp_due
+  on public.user_word_progress(user_id, due_at)
+  where due_at is not null;
+
+-- ── Precise, append-only scheduler-input log ────────────────────────────────
+-- Distinct from the coarse `study_history` UX log: this records the exact FSRS
+-- rating + before/after state per review, for auditability and future FSRS weight
+-- optimisation. `source` distinguishes in-context reads from explicit flashcard grades.
+create table if not exists public.srs_review_log (
+  id                 uuid default gen_random_uuid() primary key,
+  user_id            uuid references auth.users not null,
+  word_id            text not null,
+  rating             smallint not null check (rating between 1 and 4), -- 1=Again 2=Hard 3=Good 4=Easy
+  source             text not null check (source in ('reader_skip','reader_click','flashcard')),
+  stability_before   double precision,
+  stability_after    double precision,
+  difficulty_before  double precision,
+  difficulty_after   double precision,
+  scheduled_days     double precision,   -- interval assigned by this review
+  elapsed_days       double precision,   -- actual gap since last_reviewed_at
+  reviewed_at        timestamptz default timezone('utc'::text, now()) not null
+);
+
+alter table public.srs_review_log enable row level security;
+
+create policy "Users can manage own srs review log"
+  on public.srs_review_log for all
+  using (auth.uid() = user_id);
+
+create index if not exists idx_srs_review_log_user_word
+  on public.srs_review_log(user_id, word_id);
+
+-- ── One-time backfill: seed a schedule from difficulty + last_seen_at ────────
+-- Mirrors src/services/srs.ts:
+--   stability  S0(d) = 21 * ((10 - d)/9)^1.5 + 0.5   (easy→~21.5d, hard→~0.5d)
+--   interval        = 1.906 * S0                     (FSRS-6 interval @ retention 0.85; t is linear in S)
+--   due_at          = last_seen_at + interval
+--   fsrs_difficulty = difficulty (same 1..10 scale/direction — clean carry-over)
+-- Rows with difficulty IS NULL (unseen) stay unscheduled — they belong in #68's queue.
+-- Idempotent: only seeds rows not already scheduled.
+update public.user_word_progress
+set
+  stability        = 21 * power((10 - difficulty) / 9.0, 1.5) + 0.5,
+  fsrs_difficulty  = difficulty,
+  interval_days    = 1.906 * (21 * power((10 - difficulty) / 9.0, 1.5) + 0.5),
+  due_at           = last_seen_at
+                     + ((1.906 * (21 * power((10 - difficulty) / 9.0, 1.5) + 0.5)) * interval '1 day'),
+  last_reviewed_at = last_seen_at,
+  reps             = 0,
+  lapses           = 0,
+  srs_status       = 'review'
+where difficulty is not null
+  and stability is null;
+
+-- Note: for a large table this bulk UPDATE rewrites many rows; run `vacuum analyze
+-- public.user_word_progress;` afterward (autovacuum's 20% trigger may not fire soon).

--- a/docs/fsrs-engine-design-67.md
+++ b/docs/fsrs-engine-design-67.md
@@ -1,0 +1,235 @@
+# #67 — FSRS Scheduling Engine: Design Doc
+**Phase D, Goal 5 foundation.** Add a genuine spaced-repetition layer (`stability` + `due_at` + intervals + a review log) _on top of_ — not replacing — the existing `difficulty` (1–10) signal. This is the prerequisite for the intake queue (#68), the flashcard deck (#70), and feeding real due-dates into article generation (#72, which upgrades #51's staleness heuristic).
+
+> **Status:** ✅ **implemented** (2026-07-11). Decisions locked in review: FSRS + wrapped `ts-fsrs` (D1), extend-table + `srs_review_log` (D2), **read-past always advances the schedule with an early-review-diminished gain** (D3, revised from the original conservative proposal). `requestRetention` = **0.85**; easy words keep long (~40-day) initial intervals; test tooling = standalone `scripts/` runner.
+>
+> **As-built notes / deviations:**
+> - **Module lives at `src/services/srs.ts`, not `supabase/functions/_shared/`.** #67's only consumer is the browser (`store.applyDifficultyEvent`), and `_shared` uses Deno/esm.sh URL imports while the browser bundle uses npm — mixing runtimes for a browser-only feature isn't worth it. The pure seed/mapping is isolated so #72 can share it edge-side (via esm.sh) when it needs it, exactly as `wordPriority.ts`'s header anticipates.
+> - **`enable_short_term: false`** → the lifecycle is just `new → review` (no sub-day learning/relearning steps, which don't fit an article-reading cadence). A lapse shows up as collapsed stability + `lapses++` while the card stays `review`; urgency lives in `due_at`, not a status label. `SrsStatus` keeps all four values for a future flashcard mode that might enable short-term steps.
+> - Verified: 18/18 `scripts/test-srs.mjs`, `tsc -b`, full `vite build` (ts-fsrs bundles), zero new lint errors.
+
+* * *
+## 1. What exists today (grounded baseline)
+A read of the current code establishes exactly what we're building on:
+
+- `user_word_progress` (`database/08_srs_schema.sql`) — PK `(user_id, word_id)`. Columns: `mastery_level` (`unseen|hard|medium|easy`), `times_seen`, `streak`, `last_seen_at`, `created_at`. **No scheduling fields.**
+  
+- `difficulty smallint` **1–10** added in `database/11_difficulty.sql` — _"now the source of truth for SRS"_, `mastery_level` derived from it (1–3 easy / 4–7 medium / 8–10 hard). 1 = easiest **for the user**, 10 = hardest.
+  
+- `study_history` (`08_srs_schema.sql`) — append-only-ish audit log: `action ∈ (seen|lookup|mastery_change)`, `metadata jsonb`. Written on every grade via `logStudyEventToSupabase` (`api.ts`).
+  
+- **The nudge state machine** — `applyDifficultyEvent(word, 'skip'|'click', jlpt)` in `store.ts:408`. First contact seeds from `seedDifficulty(jlpt, userLevel) = clamp(6 + (userLevel − jlpt)·2, 1, 10)`; `skip` = seed−1, `click` = raw seed. Repeat: `click` = +2, `skip` = −1. **Daily dedup:** ≤1 passive adjustment/word/day, except a `click` may override an earlier same-day `skip` once. `mastery` re-derived via `bucketForDifficulty`.
+  
+- **Reader hooks** (`Reader.tsx`) — read-past fires `applyDifficultyEvent(key,'skip')` after 500 ms on-screen (`gradeWordByKey`, ~line 137); lookup fires `applyDifficultyEvent(key,'click')` (`handleWordClick` ~332, `handleDictionaryLookup` ~364/437). Only dictionary-linked words are graded. Canonical `entry_id` keying (#39) means one record per word.
+  
+- **Sync** (`api.ts`) — `fetchUserWordProgress` (paginated 1000/page) maps `difficulty/times_seen/streak/last_seen_at`; `upsertWordProgressToSupabase` / `…Batch` write the full row (must include `difficulty` or it nulls out). Client `WordData` (`store.ts:114`) is the mirror; **persist version 5**.
+  
+- `wordPriority.ts` — `compareStuck()` (line ~167) already carries the marker comment: _"interim staleness heuristic; #72 swaps primary key for true_ `due_at` _once FSRS lands (#67)."_ `WordSignal` reads `difficulty/timesSeen/lastSeenAt/jlptLevel/freqRank`. **This is the exact plug point.**
+  
+- **Scheduling code today: none.** No `due_at`, `interval`, `stability`, `ease` anywhere.
+  
+
+The key semantic fact: **the app's** `difficulty` **(1–10, user-perceived) is NOT FSRS's difficulty**. FSRS maintains its own `D` (card inherent difficulty) and `S` (stability, in days). They point the same direction (higher = harder) but are updated by different logic. We keep both; the app's `difficulty` seeds the FSRS state and remains the coarse signal `wordPriority` already reads.
+
+* * *
+## 2. Three decisions to lock 🔒
+### 🔒 DECISION 1 — FSRS vs SM-2
+**Recommend: FSRS (v6-style).** Better retention modeling, open-source default weights, `stability` maps cleanly to "how long until due," and it's the algorithm #72/#73 will report on. SM-2's single ease-factor is coarser and we'd likely migrate to FSRS later anyway.
+
+_Implementation:_ use the maintained `ts-fsrs` library (dependency-light, runs in both Vite/browser **and** Deno edge — important because #72 schedules server-side) wrapped behind **our own** pure `schedule()`, so we own the seed/mapping + soft-bump logic but lean on a maintained implementation for the algorithm's correctness. ✅ approved.
+### 🔒 DECISION 2 — New table vs extend `user_word_progress`
+**Recommend: extend** `user_word_progress` **with scheduling columns, + one new append-only** `srs_review_log` **table.** Word progress is already exactly 1 row per `(user, word)` and the whole sync path upserts that row — extending keeps fetch/upsert one round-trip and avoids a join on every article generation. The review log is genuinely append-only and high-volume, so it earns its own table (and enables future FSRS weight optimization). `study_history` stays as the coarse UX audit log; `srs_review_log` is the precise scheduler-input log (rating + before/after state). ✅ approved.
+### 🔒 DECISION 3 — How aggressively does a Reader read-past advance the schedule? ✅ RESOLVED (revised)
+**North star (per review): reading a word in natural context should push its due date out, so the flashcard deck stays as small as possible.** In-context reading is the primary study mode; flashcards are the fallback for words reading alone isn't reinforcing. So a read-past **always** advances the schedule — but the size of the push is governed by FSRS's own math, which makes it self-limiting rather than gameable:
+
+- **read-past (`skip`) → rating "Good" (3), always** (still subject to the existing once-per-word-per-day dedup). Capped at "Good," never "Easy" — passive recognition-in-context isn't free recall.
+- **FSRS makes the push proportional to how due the word was.** A successful review yields a large stability gain when retrievability `R` is low (you recalled something you were about to forget → big information gain) and a **small** gain when `R` is high (you just saw it → little gain). So reading a word the day after you saw it barely moves its due date; reading one that's at/near due moves it a lot. This is exactly "some benefit for early reads, big benefit for due reads" — with no special-casing and no way to inflate intervals by re-scrolling (daily dedup + diminishing early-review gain both bound it).
+- **lookup (`click`) → rating "Again" (1)** — a lapse (they didn't know it); resets/shortens the interval.
+- Explicit flashcard grades (Phase E) always apply, full Again/Hard/Good/Easy.
+
+This keeps read and deck converging on one SRS state (#71): every in-context read legitimately extends the schedule, so words the user keeps meeting while reading naturally graduate out of the due deck. `srs_review_log.source` still distinguishes `reader_*` from `flashcard` for later analysis.
+
+*(Dropped from the original draft: the "not-yet-due read → record exposure only, no reschedule" rule. Reading now always reschedules — the early-review-diminished gain replaces that guard.)*
+
+* * *
+## 3. Schema (assumes Decisions 1 & 2 as recommended)
+New migration `database/23_fsrs_scheduling.sql`:
+
+```sql
+-- 23. FSRS scheduling layer on top of user_word_progress.
+-- `difficulty` (1..10, user-perceived) stays the coarse signal + seed.
+-- These fields are the real spaced-repetition schedule. NULL = not yet on a schedule
+-- (word is queued/unscheduled — the intake gate is #68's job).
+alter table public.user_word_progress
+  add column if not exists stability        double precision,          -- FSRS S, in days
+  add column if not exists fsrs_difficulty   double precision           -- FSRS D, 1..10 (algorithm-managed; distinct from `difficulty`)
+    check (fsrs_difficulty is null or (fsrs_difficulty between 1 and 10)),
+  add column if not exists due_at            timestamptz,               -- next review; the "what's due" key
+  add column if not exists last_reviewed_at  timestamptz,               -- last scheduler event (≠ last_seen_at, which is any exposure)
+  add column if not exists interval_days     double precision,          -- convenience mirror of the scheduled gap (derivable from S)
+  add column if not exists reps              integer default 0,         -- successful reviews
+  add column if not exists lapses            integer default 0,         -- Again-after-review count
+  add column if not exists srs_status        text                       -- FSRS card lifecycle
+    check (srs_status is null or srs_status in ('new','learning','review','relearning'));
+
+-- "What's due today" — the query the deck (#70) and #72 hang off.
+create index if not exists idx_uwp_due on public.user_word_progress(user_id, due_at)
+  where due_at is not null;
+
+-- Precise, append-only scheduler-input log (distinct from the coarse study_history UX log).
+create table if not exists public.srs_review_log (
+  id                 uuid default gen_random_uuid() primary key,
+  user_id            uuid references auth.users not null,
+  word_id            text not null,
+  rating             smallint not null check (rating between 1 and 4), -- 1=Again 2=Hard 3=Good 4=Easy
+  source             text not null check (source in ('reader_skip','reader_click','flashcard')),
+  stability_before   double precision,
+  stability_after    double precision,
+  difficulty_before  double precision,
+  difficulty_after   double precision,
+  scheduled_days     double precision,   -- interval assigned by this review
+  elapsed_days       double precision,   -- actual gap since last_reviewed_at
+  reviewed_at        timestamptz default now() not null
+);
+alter table public.srs_review_log enable row level security;
+create policy "Users can manage own srs review log"
+  on public.srs_review_log for all using (auth.uid() = user_id);
+create index if not exists idx_srs_review_log_user_word on public.srs_review_log(user_id, word_id);
+```
+
+> DB migrations are applied by hand in Supabase (per project convention) — this file is authored, not auto-run.
+
+* * *
+## 4. The pure scheduler — `schedule()`
+Module `src/services/srs.ts` (as-built; the design originally proposed `_shared/` — see status note above for why it landed browser-side). Wraps `ts-fsrs` behind a pure, app-shaped surface:
+
+```ts
+export type Rating = 1 | 2 | 3 | 4; // Again | Hard | Good | Easy
+export type SrsStatus = 'new' | 'learning' | 'review' | 'relearning';
+
+export interface SrsState {
+  stability: number | null;        // S, days (null = never scheduled)
+  fsrsDifficulty: number | null;   // D, 1..10
+  dueAt: number | null;            // ms epoch
+  lastReviewedAt: number | null;   // ms epoch
+  reps: number;
+  lapses: number;
+  status: SrsStatus;
+}
+
+export interface Scheduled extends SrsState {
+  intervalDays: number;            // gap assigned this review
+}
+
+// Pure: no clock reads inside — `now` is injected (keeps it testable + resume-safe).
+export function schedule(
+  state: SrsState | null,
+  rating: Rating,
+  now: number,
+  params?: FsrsParams,          // default weights + requestRetention (0.85)
+): Scheduled;
+```
+
+**Behavior:**
+
+- `state == null` (first-ever review) → FSRS "new-card" init: `S0`/`D0` from the default weights for the given `rating`. But most existing words won't hit this path — they arrive pre-seeded by the backfill (§5).
+  
+- Otherwise compute elapsed days = `(now − lastReviewedAt)/86.4e6`, retrievability `R`, then FSRS-6 update of `S` and `D`; `Again` increments `lapses` and sets `status='relearning'`.
+  
+- Next `intervalDays = I(S, requestRetention)`; `dueAt = now + intervalDays·day`.
+  
+- **Pure** (no `Date.now()` inside) so it's unit-testable with fixed clocks and safe under Claude Code's resume constraints.
+  
+
+The FSRS-6 equations (retrievability `R = (1 + F·t/S)^C`, interval `I = S/F·(rr^{1/C} − 1)`, stability-on-success/failure, difficulty update) come from `ts-fsrs`'s default parameter set — we don't re-derive weights in-house; we own only the wrapper, the seed mapping, and the soft-bump rating translation.
+
+**Reader soft-bump adapter** (encodes Decision 3), also in `srs.ts`:
+
+```ts
+// Translate a Reader event into an FSRS rating. Read-past ALWAYS reschedules (D3);
+// FSRS's elapsed-time math makes an early read a small push and a due read a big one.
+export function ratingForReaderEvent(event: 'skip' | 'click'): Rating {
+  return event === 'click' ? 1 : 3;   // lookup = Again (lapse); read-past = Good (never Easy)
+}
+```
+
+The self-limiting behavior lives entirely in `schedule()` (via the `elapsed_days → R → stability` update), not in a due-gate here — so the adapter is a trivial mapping and the "don't over-credit re-scrolls" guarantee comes from FSRS + the caller's daily dedup, exactly as D3 argues.
+
+* * *
+## 5. Backfill / migration of existing rows
+We can't replay history, so we synthesize a plausible FSRS state from the two signals we have: `difficulty` **(1–10) and** `last_seen_at`**.** Goal: _mature/easy words get long initial intervals (due later); hard words come due soon._
+
+Proposed seed (constants to calibrate at build time against real row distribution):
+
+```
+fsrs_difficulty_0 = difficulty                    -- same 1..10 scale, same direction — clean carry-over
+stability_0(d)    = S_MAX * ((10 - d) / 9)^k + S_MIN   -- d=1 (easy) → ~S_MAX; d=10 (hard) → ~S_MIN
+                    -- e.g. S_MIN≈0.5d, S_MAX≈21d, k≈1.5 (tunable)
+due_at            = last_seen_at + I(stability_0)  -- already-overdue hard words → due immediately (correct)
+srs_status        = 'review'    (difficulty ≤ 7)  |  'relearning' (difficulty 8–10)
+reps = 0, lapses = 0                               -- unknown history; start counters fresh
+```
+
+- Rows with `difficulty IS NULL` (unseen) stay **unscheduled** (`due_at` null) — they belong in #68's intake queue, not on a review schedule.
+  
+- Runs as SQL in the same migration file (a bulk `update`), mirroring how `11_difficulty.sql` backfilled. **Note (memory): bulk backfill under autovacuum's 20% trigger can bloat** — for a large table, batch the update.
+  
+- `created_at`/`last_seen_at` preserved; nothing destructive.
+  
+
+* * *
+## 6. Client + sync wiring
+- `WordData` (`store.ts:114`) gains: `stability?`, `fsrsDifficulty?`, `dueAt?` (ms), `lastReviewedTs?`, `reps?`, `lapses?`, `srsStatus?`. **Persist bump v5 → v6** with a no-op-safe migration (existing words simply have `undefined` schedule until first backfill/sync brings it down).
+  
+- `applyDifficultyEvent` stays (it still maintains the coarse `difficulty` the palette reads) but gains a scheduling arm: after the nudge, map the event via `ratingForReaderEvent(...)`, run `schedule(prevState, rating, now)`, merge the new fields into the record, and write an `srs_review_log` row. The existing daily-dedup guard still gates passive reads to one/day (so re-scrolls don't stack). This _subsumes_ the ±1/+2 as the coarse companion to the real schedule, exactly as the plan intends.
+  
+- `api.ts` — `upsertWordProgressToSupabase` / `…Batch` payloads extend to the new columns; `fetchUserWordProgress` maps them back (incl. `due_at → dueAt` ms). New `logSrsReviewToSupabase(...)`. Pagination unchanged.
+  
+- `wordPriority.ts` — add `dueAt`/`stability` to `WordSignal` and a `compareByDue` that ranks genuinely-due words first, `stability` ascending as tiebreak. **We do NOT rewire** `compareStuck`**'s callers in this PR** — that's #72's job; #67 only _provides_ the due-date and the comparator so #72 is a small swap. (Keeps #67 scoped to the engine.)
+  
+
+* * *
+## 7. Acceptance criteria (from the plan) + how we verify
+| Criterion | Verification |
+|---|---|
+| Every *active* word has a `due_at` | Post-backfill query: `count(*) where difficulty is not null and due_at is null` = 0 |
+| Reviewing/reading an active word reschedules it | Unit: `schedule()` with fixed clocks; integration: read-past a due word → `due_at` advances, `srs_review_log` row written |
+| A "due today" query returns the right set | `idx_uwp_due` range query returns expected fixtures |
+| Existing `difficulty` preserved as the seed | Migration keeps `difficulty`; `fsrs_difficulty_0 = difficulty`; no column dropped |
+| Read-past ≠ flashcard double-count (#71 preview) | Existing daily-dedup gates read-past to 1/day; log `source` distinguishes `reader_*` vs `flashcard` |
+| Early read pushes due-date less than a due read (D3) | Unit: same `schedule(Good)` from higher `R` (small elapsed) yields smaller stability gain than from lower `R` |
+
+**Tests:** `schedule()` is pure → straightforward unit tests with injected `now` (Again/Hard/Good/Easy paths, lapse counting, first-review init, monotonic interval growth on repeated Good, early-vs-due-read gain). Per the review, test tooling is my call: a small **standalone `scripts/` runner (Node/`tsx`)** in the spirit of the eval harness — no new framework dependency, matches how this repo already does throwaway-free verification.
+
+* * *
+## 8. Out of scope for #67 (explicit handoffs)
+- **Intake queue /** `queued`**→**`active` **gate + daily new-word cap** → **#68**. #67 backfills all currently-graded words as active; the queue is a separate PR.
+  
+- **Flashcard UI + real Again/Hard/Good/Easy buttons** → **#70**. #67 exposes `schedule()`; the deck consumes it.
+  
+- **Feeding due words into article generation** (rewiring `compareStuck` callers) → **#72**. #67 ships `dueAt` + `compareByDue`; #72 flips the switch.
+  
+- **Study dashboard** (due/new/learning counts) → **#73**.
+  
+
+* * *
+## 9. Proposed build order (once decisions confirmed)
+1. `srs.ts` — `schedule()` + `ratingForReaderEvent()` + weights, with the standalone test runner (pure, no app deps — lowest risk first).
+  
+2. `database/23_fsrs_scheduling.sql` — columns + `srs_review_log` + index + backfill.
+  
+3. `api.ts` — extend upsert/fetch payloads + `logSrsReviewToSupabase`.
+  
+4. `store.ts` — `WordData` fields, persist v6, scheduling arm in `applyDifficultyEvent`.
+  
+5. `wordPriority.ts` — `dueAt`/`stability` on `WordSignal` + `compareByDue` (provide only; #72 wires).
+  
+6. Browser-test the read→reschedule loop end to end.
+  
+
+* * *
+## 10. Decisions — RESOLVED (2026-07-11 review)
+1. **D1** FSRS, wrapping `ts-fsrs` behind our own `schedule()` ✅ · **D2** extend `user_word_progress` + new `srs_review_log` ✅ · **D3** read-past always advances the schedule, capped at "Good," push self-limited by FSRS early-review math ✅ (revised from the conservative draft).
+2. **`requestRetention` = 0.85** (gentler than the 0.9 standard — passive reading is a big share of reviews).
+3. **Backfill:** easy words keep long (~3-week) initial intervals (`S_MAX ≈ 21d`).
+4. **Test tooling:** standalone `scripts/` runner (Node/`tsx`), no new framework.

--- a/docs/task.md
+++ b/docs/task.md
@@ -176,3 +176,25 @@
   - [ ] Known gap: words with no jmdictEntryId (proper nouns / tokenizer fragments,
         ~577) are never synced, so a reinstall still loses them. Future work: back
         them up via a string word_id (the table already allows it).
+- [x] #67 FSRS scheduling engine (Phase D, 2026-07-11): real spaced-repetition
+      due-dates on top of the coarse `difficulty` signal. Design + decisions in
+      docs/fsrs-engine-design-67.md.
+  - [x] src/services/srs.ts — pure `schedule(state,rating,now)` wrapping ts-fsrs
+        (FSRS-6, request_retention 0.85, deterministic) + `ratingForReaderEvent`
+        + `seedSrsFromDifficulty` (seeds initial stability from difficulty 1..10).
+  - [x] scripts/test-srs.mjs (`npm run test:srs`) — 18/18 standalone assertions
+        (esbuild-bundled, no framework): first review, monotonic growth, Again
+        lapse, D3 early-vs-due gain, seed gradient.
+  - [x] database/23_fsrs_scheduling.sql — scheduling columns + idx_uwp_due partial
+        index + append-only srs_review_log; one-time backfill from difficulty +
+        last_seen_at. APPLY BY HAND in Supabase, then vacuum analyze the table.
+  - [x] store.applyDifficultyEvent scheduling arm — read-past="Good", lookup=
+        "Again"; reading ALWAYS advances the schedule (push self-limited by FSRS
+        early-review math → shrinks the flashcard deck). Persist v5→v6 eager seed.
+  - [x] api.ts — scheduling columns in fetch/upsert (partial upsert never nulls a
+        schedule) + logSrsReviewToSupabase.
+  - [x] wordPriority.ts — dueAt/stability on WordSignal + compareByDue comparator
+        (provided; #72 wires compareStuck's callers over to it).
+  - Verified: 18/18 tests, tsc -b, full vite build (ts-fsrs bundles), 0 new lint.
+  - [ ] APPLY (your step): run database/23_fsrs_scheduling.sql in the Supabase SQL
+        editor, then `vacuum analyze public.user_word_progress;`.

--- a/docs/word-mastery-loop-plan.md
+++ b/docs/word-mastery-loop-plan.md
@@ -24,7 +24,7 @@
 - **Phase C is complete** — models pinned + upgraded to `gemini-3.5-flash` (#64 ✅); the **eval harness (#65 ✅)** ships — `scripts/eval-article-rewrite.mjs` scores rewrites on a frozen golden set (`scripts/eval-fixtures/`) via the extracted, shared prompt module, with EVAL-001 as an automated regression. Its verdict: **flash beats/ties `gemini-3.1-pro-preview` on every axis at ~half latency/cost → stay on flash**. The **prompt restructure (#66 ✅)** then closed the one remaining gap: a surgical GOLDEN-RULE anti-fabrication edit lifted factual fidelity **4.00 → 5.00** at equal-or-lower cost, measured against the harness (see [`phase-c-eval-notes.md`](./phase-c-eval-notes.md)).
 - Goals 4–5's remainder (eval/prompt, then the real SRS engine + flashcards) are the open frontier: **Phase C** (#65/#66) can run anytime; **Phase D** (#67 FSRS engine + #68 intake queue) is the next big build, with **Phase E** (flashcards) on top.
 
-> **➡️ NEXT UP: Phase D #67 (FSRS engine) → #68 (intake queue).** Phases A, B, and C are all done, so the frontier is the real spaced-repetition due-date engine. #67 directly benefits from #39's one-record-per-word foundation.
+> **➡️ NEXT UP: Phase D #68 (intake queue).** #67 (FSRS engine) shipped 2026-07-11 — words now carry a real `due_at`/stability schedule seeded from `difficulty`, and in-context reads advance it (see [`fsrs-engine-design-67.md`](./fsrs-engine-design-67.md)). The frontier is now the foundation-first intake queue + daily new-word cap that gates words into that schedule.
 >
 > **Scope note (2026-07-05, discovered during #39):** #39's original spec also targeted a *server-side* Pass 3 that first-match-linked JMDict entries and could override the client's disambiguation (Concern B). **That server pass has since been removed** — all tokenization + entry-linking is now client-side (kuromoji + `enrich.ts`, which attaches `jmdict_entry_id` at enrich time). So Concern B was moot; #39 shipped as purely the client-side canonical-keying fix (which also absorbed the folded-in #74 `times_seen` work).
 
@@ -133,13 +133,13 @@ No prompt-eval harness exists and models are unpinned. Make model choice data-dr
 
 The decision: a genuine FSRS/SM-2 layer with `due_at` + intervals, on top of (not replacing) the existing `difficulty` signal, **plus the intake queue that gates words into it**. This is what makes "study what's due today," "feed due words to the LLM," and "pace new words" possible.
 
-- [ ] **#67 SRS scheduling layer (FSRS/SM-2)** 🔴
-  - **Schema:** extend `user_word_progress` (or a new `srs_state` table) with scheduling fields — interval, `due_at`, stability/ease (FSRS) or EF (SM-2), `last_reviewed_at`, lapse count. Add a `srs_review_log` append-only table (word_id, rating, scheduled_interval, reviewed_at) for auditability and future FSRS optimization.
-  - **Algorithm:** implement the chosen scheduler (recommend **FSRS** — better retention modeling, open-source params) as a pure function `schedule(state, rating, now) → newState`. Keep `difficulty` (1–10) as a *seed/prior* into initial stability so existing tracking isn't thrown away.
-  - **Migration:** backfill `due_at`/interval for existing rows from current `difficulty` + `last_seen_at` (mature/easy words → longer initial intervals; hard → due soon).
-  - **Reader integration (soft-bump):** a read-past on a due word counts as a "Good"-ish pass (extends interval); a lookup counts as "Again/Hard" (resets/shortens). This subsumes today's ±1/+2 nudge with schedule-aware logic.
-  - **Decisions to confirm at build time:** FSRS vs SM-2; new table vs extend; how aggressively read-past advances the schedule vs explicit flashcard grades.
-  - **Acceptance:** every *active* word has a `due_at`; reviewing/reading an active word reschedules it; a "due today" query returns the right set; existing difficulty data is preserved as the seed.
+- ✅ **#67 SRS scheduling layer (FSRS)** 🔴 *(done 2026-07-11 — see [`fsrs-engine-design-67.md`](./fsrs-engine-design-67.md))*
+  - **Schema** (`database/23_fsrs_scheduling.sql`): extended `user_word_progress` with `stability`, `fsrs_difficulty`, `due_at`, `last_reviewed_at`, `interval_days`, `reps`, `lapses`, `srs_status` + a `idx_uwp_due` partial index; added the append-only `srs_review_log` table (rating + before/after state + source). One-time SQL backfill seeds a schedule from `difficulty` + `last_seen_at`.
+  - **Algorithm** (`src/services/srs.ts`): pure `schedule(state, rating, now)` wrapping `ts-fsrs` (FSRS-6, `request_retention` 0.85, deterministic); `ratingForReaderEvent` + `seedSrsFromDifficulty` seed initial stability from the coarse `difficulty` so existing tracking is preserved. 18/18 unit tests (`scripts/test-srs.mjs`, `npm run test:srs`).
+  - **Reader integration:** `store.applyDifficultyEvent` gained a scheduling arm — read-past → "Good", lookup → "Again"; **reading always advances the schedule** (D3, revised in review) with the push self-limited by FSRS's early-review math, so in-context reading shrinks the flashcard deck. Persist bumped v5→v6 (eager client seed). Sync extended (`api.ts`): scheduling columns + `logSrsReviewToSupabase`.
+  - **#72 hook provided (not wired):** `wordPriority.ts` gained `dueAt`/`stability` on `WordSignal` + a `compareByDue` comparator; #72 flips `compareStuck`'s callers over to it.
+  - **Acceptance (met):** every active word gets a `due_at`; reading/reviewing reschedules it + writes a review-log row; the `idx_uwp_due` "due today" query is in place; `difficulty` preserved as the seed. **Decisions:** FSRS; extend-table + review-log; read-past always advances (early gain diminished).
+  - **Deploy note:** `database/23_fsrs_scheduling.sql` must be applied by hand in Supabase (migrations are manual); run `vacuum analyze user_word_progress` after the bulk backfill.
 - [ ] **#68 Word intake queue + daily new-word limit (foundation-first promotion)** 🔴
   - Add an intake queue so encountered-but-unscheduled words **wait** instead of being graded on sight. Model as a `status` on `user_word_progress` (`queued` → `active`) or a dedicated queue table.
   - **Promotion ordering: JLPT level ascending, then `freq_rank` ascending** (lowest level + most common first) — the foundation-first rule. Lower levels are fully drained before higher levels start promoting.
@@ -191,7 +191,7 @@ Phase C (prompt/model) ───────────[parallel]────�
 - **D before E** — the engine **and intake queue (#68)** are the flashcard foundation. **#72** is where #51's interim heuristic graduates to real due-dates.
 
 ### Recommended order
-~~#64 (pin)~~ ✅ → ~~B (#69 metric → #25 → #22 → #51)~~ ✅ → ~~A (#39 canonical key → #37 → #41)~~ ✅ → ~~C (#65 eval → #66 prompt)~~ ✅ → **NEXT: #67 (FSRS)** → #68 (intake queue) → #70→#71→#72→#73 (flashcards).
+~~#64 (pin)~~ ✅ → ~~B (#69 metric → #25 → #22 → #51)~~ ✅ → ~~A (#39 canonical key → #37 → #41)~~ ✅ → ~~C (#65 eval → #66 prompt)~~ ✅ → ~~#67 (FSRS)~~ ✅ → **NEXT: #68 (intake queue)** → #70→#71→#72→#73 (flashcards).
 
 Rationale: cheapest reproducibility win first; finish the in-flight selection refactor on correct data while extracting the shared metric; stand up the eval harness so model/prompt changes are measured; build the engine, then the intake queue that paces words into it; then the deck. Prompt restructure (#66) slots in once the harness exists and can run alongside D.
 
@@ -205,7 +205,7 @@ Rationale: cheapest reproducibility win first; finish the in-flight selection re
 | [#65](https://github.com/kdevoe/language-study/issues/65) | process-article eval harness + investigate latest Gemini flash (3.5?) for flash-vs-pro decision | 🟡 | C | ✅ done |
 | [#66](https://github.com/kdevoe/language-study/issues/66) | Restructure & optimize the article-rewrite prompt (measured against #65) | 🟡 | C | ✅ done |
 | [#69](https://github.com/kdevoe/language-study/issues/69) | Extract the Word Priority Metric into a shared scoring module (SRS + level + frequency) | 🟡 | B (shared) | ✅ done |
-| [#67](https://github.com/kdevoe/language-study/issues/67) | SRS scheduling engine: FSRS/SM-2 due-dates + intervals + review log atop existing difficulty | 🔴 | D | not started |
+| [#67](https://github.com/kdevoe/language-study/issues/67) | SRS scheduling engine: FSRS due-dates + intervals + review log atop existing difficulty | 🔴 | D | ✅ done |
 | [#68](https://github.com/kdevoe/language-study/issues/68) | Word intake queue + daily new-word limit, foundation-first promotion (level↑ then freq↑) | 🔴 | D | not started |
 | [#70](https://github.com/kdevoe/language-study/issues/70) | Flashcard study UI (Zen front/back/reveal, Again/Hard/Good/Easy) wired to #67 | 🔴 | E | not started |
 | [#71](https://github.com/kdevoe/language-study/issues/71) | Reader ↔ flashcard synergy: converge read-past and graded reviews on one SRS state | 🟡 | E | not started |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "lucide-react": "^1.6.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "ts-fsrs": "^5.4.1",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -2966,6 +2967,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-fsrs": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ts-fsrs/-/ts-fsrs-5.4.1.tgz",
+      "integrity": "sha512-mOp9+oexJexBTkwjg/jQI1aSUQRLIAvbimeKHLSmVdNJPwObugFNKmZkoggH5d6kZ0uaWLboP1Al1DnXAfIb9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:srs": "node scripts/test-srs.mjs"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
@@ -17,6 +18,7 @@
     "lucide-react": "^1.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "ts-fsrs": "^5.4.1",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/scripts/test-srs.mjs
+++ b/scripts/test-srs.mjs
@@ -1,0 +1,123 @@
+/**
+ * Standalone test runner for the FSRS scheduler (#67).
+ *
+ *   node scripts/test-srs.mjs
+ *
+ * No test framework (matches the repo's eval-harness style): src/services/srs.ts
+ * imports `ts-fsrs`, so we bundle it to a temp file with esbuild and import it,
+ * then assert on the pure scheduling behaviour with fixed clocks. Exits non-zero on
+ * any failure so it can gate CI later.
+ *
+ * What it locks in:
+ *   • ratingForReaderEvent: skip→Good(3), click→Again(1)
+ *   • schedule(null, …): first review initialises a Review-state card
+ *   • repeated Good grows the interval monotonically (learning)
+ *   • Again lapses: stability collapses, lapses increments
+ *   • D3 self-limit: an early read-past pushes the due date LESS than a due read
+ *   • seedSrsFromDifficulty: easy words seed long, hard words seed short/overdue
+ */
+import esbuild from 'esbuild';
+import { pathToFileURL } from 'node:url';
+import { rmSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+const TMP = path.join('scripts', '.tmp-srs-bundle.mjs');
+
+let passed = 0;
+let failed = 0;
+function check(name, cond, detail = '') {
+  if (cond) {
+    passed++;
+    console.log(`  \x1b[32m✓\x1b[0m ${name}`);
+  } else {
+    failed++;
+    console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? `  — ${detail}` : ''}`);
+  }
+}
+
+const DAY = 86_400_000;
+const T0 = Date.parse('2026-07-01T00:00:00Z'); // fixed clock — no Date.now()
+
+async function main() {
+  mkdirSync('scripts', { recursive: true });
+  await esbuild.build({
+    entryPoints: ['src/services/srs.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    outfile: TMP,
+    logLevel: 'silent',
+  });
+  const srs = await import(pathToFileURL(TMP).href);
+  const { schedule, ratingForReaderEvent, seedSrsFromDifficulty, seedStability, REQUEST_RETENTION } = srs;
+
+  console.log('\nFSRS scheduler (#67) — request_retention', REQUEST_RETENTION);
+
+  console.log('\nratingForReaderEvent');
+  check('skip → Good (3)', ratingForReaderEvent('skip') === 3);
+  check('click → Again (1)', ratingForReaderEvent('click') === 1);
+
+  console.log('\nschedule(null, …) — first review');
+  const first = schedule(null, 3 /* Good */, T0);
+  check('due is in the future', first.dueAt > T0, `dueAt=${first.dueAt} T0=${T0}`);
+  check('status is a review-ish state', ['review', 'learning'].includes(first.status), `status=${first.status}`);
+  check('stability > 0', first.stability > 0, `S=${first.stability}`);
+  check('reps incremented to 1', first.reps === 1, `reps=${first.reps}`);
+  check('lastReviewedAt == now', first.lastReviewedAt === T0);
+
+  console.log('\nrepeated Good grows the interval (review at due each time)');
+  let state = seedSrsFromDifficulty(5, T0); // medium word
+  let prevInterval = 0;
+  let monotonic = true;
+  let clock = state.dueAt;
+  for (let i = 0; i < 4; i++) {
+    const next = schedule(state, 3, clock);
+    if (next.intervalDays < prevInterval) monotonic = false;
+    prevInterval = next.intervalDays;
+    state = next;
+    clock = next.dueAt; // always review exactly when due
+  }
+  check('interval grows monotonically across 4 Goods', monotonic, `last interval=${prevInterval}`);
+  check('final interval is multiple weeks', prevInterval > 14, `interval=${prevInterval}d`);
+
+  console.log('\nAgain (lookup) lapses the word');
+  const mature = seedSrsFromDifficulty(3, T0); // easy word, high stability
+  const lapsed = schedule(mature, 1 /* Again */, mature.dueAt);
+  check('stability collapses on Again', lapsed.stability < mature.stability, `${mature.stability.toFixed(1)} → ${lapsed.stability.toFixed(1)}`);
+  check('lapses incremented', lapsed.lapses === 1, `lapses=${lapsed.lapses}`);
+  check('due date pulled in close (short-term steps off → stays review)', lapsed.dueAt - mature.dueAt < 5 * DAY && lapsed.status === 'review', `dueΔ=${Math.round((lapsed.dueAt - mature.dueAt) / DAY)}d status=${lapsed.status}`);
+
+  console.log('\nD3 — early read pushes due date LESS than a due read');
+  const base = seedSrsFromDifficulty(5, T0);
+  const dueDay = Math.round((base.dueAt - T0) / DAY);
+  const earlyRead = schedule(base, 3, T0 + 1 * DAY);            // read 1 day after seeding
+  const dueRead = schedule(base, 3, base.dueAt);                // read exactly at due
+  check(`early read gains less stability than due read (due≈+${dueDay}d)`,
+    earlyRead.stability < dueRead.stability,
+    `early S=${earlyRead.stability.toFixed(2)} vs due S=${dueRead.stability.toFixed(2)}`);
+  check('but an early read still advances the schedule (> original stability)',
+    earlyRead.stability > base.stability,
+    `${base.stability.toFixed(2)} → ${earlyRead.stability.toFixed(2)}`);
+
+  console.log('\nseedSrsFromDifficulty — easy seeds long, hard seeds short');
+  check('easier word seeds higher stability than harder', seedStability(2) > seedStability(9),
+    `S(2)=${seedStability(2).toFixed(1)} S(9)=${seedStability(9).toFixed(1)}`);
+  const easy = seedSrsFromDifficulty(1, T0);
+  const hard = seedSrsFromDifficulty(10, T0);
+  check('easy word due well in the future', easy.dueAt - T0 > 21 * DAY, `+${Math.round((easy.dueAt - T0) / DAY)}d`);
+  check('hard word due soon', hard.dueAt - T0 < 3 * DAY, `+${Math.round((hard.dueAt - T0) / DAY)}d`);
+  check('seeded words enter as review', hard.status === 'review' && easy.status === 'review',
+    `hard=${hard.status} easy=${easy.status}`);
+
+  console.log(`\n\x1b[1m${passed} passed, ${failed} failed\x1b[0m\n`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    failed++;
+  })
+  .finally(() => {
+    try { rmSync(TMP, { force: true }); } catch { /* ignore */ }
+    process.exit(failed > 0 ? 1 : 0);
+  });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -471,7 +471,16 @@ export async function fetchUserWordProgress(userId: string): Promise<Record<stri
         difficulty: row.difficulty ?? null,
         timesSeen: row.times_seen,
         streak: row.streak,
-        lastSeenTs: new Date(row.last_seen_at).getTime()
+        lastSeenTs: new Date(row.last_seen_at).getTime(),
+        // FSRS scheduling (#67) — null until the word has been scheduled.
+        stability: row.stability ?? null,
+        fsrsDifficulty: row.fsrs_difficulty ?? null,
+        dueAt: row.due_at ? new Date(row.due_at).getTime() : null,
+        lastReviewedTs: row.last_reviewed_at ? new Date(row.last_reviewed_at).getTime() : null,
+        intervalDays: row.interval_days ?? null,
+        reps: row.reps ?? 0,
+        lapses: row.lapses ?? 0,
+        srsStatus: row.srs_status ?? null,
       };
     });
 
@@ -480,10 +489,41 @@ export async function fetchUserWordProgress(userId: string): Promise<Record<stri
   return progress;
 }
 
+/**
+ * FSRS scheduling fields (#67), all optional. Included in an upsert only when
+ * present, so a caller that just touches difficulty never nulls out a word's
+ * existing schedule (PostgREST upsert only updates the columns it's given).
+ */
+export interface SrsSyncFields {
+  stability?: number | null;
+  fsrsDifficulty?: number | null;
+  dueAt?: number | null;          // ms epoch
+  lastReviewedTs?: number | null; // ms epoch
+  intervalDays?: number | null;
+  reps?: number | null;
+  lapses?: number | null;
+  srsStatus?: string | null;
+}
+
+// Map the SRS sync fields that are actually present onto snake_case columns
+// (ms → ISO for the two timestamps). Absent fields are omitted, not nulled.
+function srsColumns(p: SrsSyncFields): Record<string, unknown> {
+  const cols: Record<string, unknown> = {};
+  if (p.stability !== undefined) cols.stability = p.stability;
+  if (p.fsrsDifficulty !== undefined) cols.fsrs_difficulty = p.fsrsDifficulty;
+  if (p.dueAt !== undefined) cols.due_at = p.dueAt == null ? null : new Date(p.dueAt).toISOString();
+  if (p.lastReviewedTs !== undefined) cols.last_reviewed_at = p.lastReviewedTs == null ? null : new Date(p.lastReviewedTs).toISOString();
+  if (p.intervalDays !== undefined) cols.interval_days = p.intervalDays;
+  if (p.reps !== undefined) cols.reps = p.reps;
+  if (p.lapses !== undefined) cols.lapses = p.lapses;
+  if (p.srsStatus !== undefined) cols.srs_status = p.srsStatus;
+  return cols;
+}
+
 export async function upsertWordProgressToSupabase(
   userId: string,
   wordId: string,
-  progress: { mastery: string; difficulty?: number | null; timesSeen: number; streak: number; lastSeenTs: number }
+  progress: { mastery: string; difficulty?: number | null; timesSeen: number; streak: number; lastSeenTs: number } & SrsSyncFields
 ) {
   const { error } = await supabase
     .from('user_word_progress')
@@ -494,10 +534,46 @@ export async function upsertWordProgressToSupabase(
       difficulty: progress.difficulty ?? null,
       times_seen: progress.timesSeen,
       streak: progress.streak,
-      last_seen_at: new Date(progress.lastSeenTs).toISOString()
+      last_seen_at: new Date(progress.lastSeenTs).toISOString(),
+      ...srsColumns(progress),
     });
-    
+
   if (error) console.error(`Error syncing progress for ${wordId}:`, error);
+}
+
+/**
+ * Append a precise FSRS review record (rating + before/after state) to
+ * srs_review_log. Distinct from logStudyEventToSupabase (the coarse UX log):
+ * this is the scheduler-input audit trail for #67, used later for FSRS tuning.
+ */
+export async function logSrsReviewToSupabase(
+  userId: string,
+  wordId: string,
+  entry: {
+    rating: number;
+    source: 'reader_skip' | 'reader_click' | 'flashcard';
+    stabilityBefore?: number | null;
+    stabilityAfter?: number | null;
+    difficultyBefore?: number | null;
+    difficultyAfter?: number | null;
+    scheduledDays?: number | null;
+    elapsedDays?: number | null;
+  }
+) {
+  const { error } = await supabase.from('srs_review_log').insert({
+    user_id: userId,
+    word_id: wordId,
+    rating: entry.rating,
+    source: entry.source,
+    stability_before: entry.stabilityBefore ?? null,
+    stability_after: entry.stabilityAfter ?? null,
+    difficulty_before: entry.difficultyBefore ?? null,
+    difficulty_after: entry.difficultyAfter ?? null,
+    scheduled_days: entry.scheduledDays ?? null,
+    elapsed_days: entry.elapsedDays ?? null,
+  });
+
+  if (error) console.error(`Error logging SRS review for ${wordId}:`, error);
 }
 
 /**

--- a/src/services/srs.ts
+++ b/src/services/srs.ts
@@ -1,0 +1,176 @@
+// FSRS spaced-repetition scheduler (#67) — the real due-date engine that sits on
+// top of the coarse `difficulty` (1..10) signal, not replacing it.
+//
+// This is the one place scheduling math lives, wrapping the maintained `ts-fsrs`
+// (FSRS-6) library behind a small, pure, app-shaped surface:
+//
+//   schedule(state, rating, now)      — advance a word's schedule by one review
+//   ratingForReaderEvent(event)       — map a Reader skip/click to an FSRS rating
+//   seedSrsFromDifficulty(diff, seen) — first-time seed from the existing difficulty
+//
+// Design decisions (see docs/fsrs-engine-design-67.md):
+//   • request_retention = 0.85 (gentler than the 0.9 default — reading is a big
+//     share of "reviews", so we accept slightly lower recall for a smaller deck).
+//   • Reading in natural context ALWAYS advances the schedule (read-past = "Good").
+//     FSRS's own elapsed-time math makes the push self-limiting: reviewing a word
+//     while retrievability is still high yields a small stability gain, so an early
+//     read nudges the due date a little and a due read pushes it a lot — with no
+//     special-casing and no way to inflate intervals by re-scrolling.
+//   • Deterministic: enable_fuzz=false and `now` is always injected, so the same
+//     inputs always produce the same schedule (unit-testable, resume-safe).
+//
+// `fsrsDifficulty` (the FSRS "D", 1..10, algorithm-managed) is DISTINCT from the
+// app's `difficulty` (1..10, user-perceived, nudged ±1/±2). They point the same
+// direction but update by different logic; the app's difficulty only *seeds* D here.
+
+import {
+  fsrs,
+  generatorParameters,
+  createEmptyCard,
+  State,
+  type Card,
+  type FSRS,
+  type Grade,
+} from 'ts-fsrs';
+
+/** Target probability of recall at review time. Lower = longer intervals, smaller deck. */
+export const REQUEST_RETENTION = 0.85;
+
+/** 1=Again, 2=Hard, 3=Good, 4=Easy — aligned 1:1 with FSRS's grade values. */
+export type Rating = 1 | 2 | 3 | 4;
+
+/** FSRS card lifecycle, mirrored to `user_word_progress.srs_status`. */
+export type SrsStatus = 'new' | 'learning' | 'review' | 'relearning';
+
+/**
+ * The persisted schedule for one word. Mirrors the scheduling columns added to
+ * `user_word_progress` in database/23_fsrs_scheduling.sql. Timestamps are ms epochs
+ * (the store already keeps `lastSeenTs` in ms) so nothing here reads a clock.
+ */
+export interface SrsState {
+  stability: number;        // FSRS S, in days
+  fsrsDifficulty: number;   // FSRS D, 1..10 (algorithm-managed)
+  dueAt: number;            // ms epoch — next review
+  lastReviewedAt: number;   // ms epoch — last scheduler event
+  reps: number;             // successful reviews
+  lapses: number;           // Again-after-review count
+  status: SrsStatus;
+}
+
+export interface Scheduled extends SrsState {
+  intervalDays: number;     // gap assigned by this review (days)
+}
+
+const DAY_MS = 86_400_000;
+
+// One shared scheduler instance. enable_short_term=false: a word graduates straight
+// to review scheduling rather than sub-day learning steps (we don't cram same-day).
+const scheduler: FSRS = fsrs(
+  generatorParameters({
+    request_retention: REQUEST_RETENTION,
+    enable_fuzz: false,
+    enable_short_term: false,
+  }),
+);
+
+const STATUS_TO_STATE: Record<SrsStatus, State> = {
+  new: State.New,
+  learning: State.Learning,
+  review: State.Review,
+  relearning: State.Relearning,
+};
+const STATE_TO_STATUS: readonly SrsStatus[] = ['new', 'learning', 'review', 'relearning'];
+
+function toCard(s: SrsState): Card {
+  return {
+    due: new Date(s.dueAt),
+    stability: s.stability,
+    difficulty: s.fsrsDifficulty,
+    elapsed_days: 0,       // recomputed by the scheduler from last_review vs. now
+    scheduled_days: 0,
+    reps: s.reps,
+    lapses: s.lapses,
+    learning_steps: 0,
+    state: STATUS_TO_STATE[s.status],
+    last_review: new Date(s.lastReviewedAt),
+  };
+}
+
+function fromCard(card: Card, now: number): Scheduled {
+  return {
+    stability: card.stability,
+    fsrsDifficulty: card.difficulty,
+    dueAt: card.due.getTime(),
+    lastReviewedAt: now,
+    reps: card.reps,
+    lapses: card.lapses,
+    status: STATE_TO_STATUS[card.state],
+    intervalDays: card.scheduled_days,
+  };
+}
+
+/**
+ * Advance a word's schedule by one review. `state === null` means the word has
+ * never been scheduled (first-ever review, initialised from FSRS defaults). `now`
+ * is a ms epoch and is the only "clock" — the function itself is pure.
+ */
+export function schedule(state: SrsState | null, rating: Rating, now: number): Scheduled {
+  const card = state ? toCard(state) : createEmptyCard(new Date(now));
+  const { card: next } = scheduler.next(card, new Date(now), rating as unknown as Grade);
+  return fromCard(next, now);
+}
+
+/**
+ * Map a Reader event to an FSRS rating. Reading past a word (`skip`) is a successful
+ * in-context recall → "Good" (never "Easy" — passive recognition isn't free recall);
+ * looking it up (`click`) means they didn't know it → "Again" (a lapse). Read-past
+ * always reschedules; the self-limiting behaviour lives in `schedule()`, not here.
+ */
+export function ratingForReaderEvent(event: 'skip' | 'click'): Rating {
+  return event === 'click' ? 1 : 3;
+}
+
+// ── Seeding an existing word into the schedule ───────────────────────────────
+// A word already tracked by `difficulty` but not yet scheduled gets a synthesised
+// FSRS state so its first read/lookup advances a plausible schedule instead of
+// starting from scratch. Easy words (low difficulty) seed with high stability →
+// long initial interval; hard words seed short → due soon. These constants mirror
+// the one-time SQL backfill in database/23_fsrs_scheduling.sql; TS is canonical.
+
+const SEED_S_MIN = 0.5;   // days — hardest word (difficulty 10)
+const SEED_S_MAX = 21;    // days — easiest word (difficulty 1); ~40d first interval at 0.85
+const SEED_K = 1.5;       // curve shape: how fast stability falls as difficulty rises
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/** Initial stability (days) for a given app difficulty (1=easy … 10=hard). */
+export function seedStability(difficulty: number): number {
+  const d = clamp(difficulty, 1, 10);
+  return SEED_S_MAX * Math.pow((10 - d) / 9, SEED_K) + SEED_S_MIN;
+}
+
+/**
+ * Build an initial `SrsState` from a word's coarse `difficulty` and when it was last
+ * seen, so an already-known word joins the schedule mid-stream rather than as brand
+ * new. The due date is `lastSeenAt + interval(S0)` — an already-overdue hard word
+ * comes due immediately, which is correct. Seeded words enter as `review`: with
+ * short-term steps disabled the engine's lifecycle is just `new → review` (a hard
+ * word's urgency is carried by its short stability / near due date, not a status
+ * label), so there's no meaningful `learning`/`relearning` seed to assign.
+ */
+export function seedSrsFromDifficulty(difficulty: number, lastSeenAt: number): SrsState {
+  const stability = seedStability(difficulty);
+  const fsrsDifficulty = clamp(difficulty, 1, 10);
+  const intervalDays = scheduler.next_interval(stability, 0);
+  return {
+    stability,
+    fsrsDifficulty,
+    dueAt: lastSeenAt + intervalDays * DAY_MS,
+    lastReviewedAt: lastSeenAt,
+    reps: 0,
+    lapses: 0,
+    status: 'review',
+  };
+}

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 import { rtkKanjiList } from '../data/rtkKanji';
 import { NewsArticle } from './api';
 import { supabase } from './supabase';
+import { schedule, ratingForReaderEvent, seedSrsFromDifficulty, type SrsState, type SrsStatus } from './srs';
 
 export type MasteryLevel = 'unseen' | 'hard' | 'medium' | 'easy';
 
@@ -132,6 +133,16 @@ export interface WordData {
   uniqueDaysSeen: string[];
   lastSeenTs: number;
   streak: number;
+  // FSRS schedule (#67). Undefined until the word is first scheduled; `difficulty`
+  // stays the coarse palette signal and seeds the initial state. See services/srs.ts.
+  stability?: number | null;      // FSRS S, days
+  fsrsDifficulty?: number | null; // FSRS D, 1..10 (algorithm-managed; ≠ `difficulty`)
+  dueAt?: number | null;          // ms epoch — next review ("what's due")
+  lastReviewedTs?: number | null; // ms epoch — last scheduler event
+  intervalDays?: number | null;   // scheduled gap (days)
+  reps?: number | null;
+  lapses?: number | null;
+  srsStatus?: SrsStatus | null;
 }
 
 interface AppState {
@@ -434,12 +445,44 @@ export const useAppStore = create<AppState>()(
           }
           const mastery = bucketForDifficulty(difficulty);
 
+          // ── FSRS schedule (#67) ────────────────────────────────────────────
+          // Reading a word in context always advances its real spaced-repetition
+          // schedule (read-past = "Good", lookup = "Again"). The daily-dedup guard
+          // above already caps passive reads to one/day, and FSRS makes the push
+          // self-limiting (early reads gain little), so re-scrolls can't inflate it.
+          // The word joins the schedule seeded from its coarse `difficulty` the
+          // first time; thereafter the stored SRS state drives everything.
+          const now = Date.now();
+          const rating = ratingForReaderEvent(event);
+          const priorSrs: SrsState =
+            current.stability != null && current.dueAt != null
+              ? {
+                  stability: current.stability,
+                  fsrsDifficulty: current.fsrsDifficulty ?? difficulty,
+                  dueAt: current.dueAt,
+                  lastReviewedAt: current.lastReviewedTs ?? current.lastSeenTs ?? now,
+                  reps: current.reps ?? 0,
+                  lapses: current.lapses ?? 0,
+                  status: (current.srsStatus ?? 'review') as SrsStatus,
+                }
+              : seedSrsFromDifficulty(difficulty, current.lastSeenTs ?? now);
+          const elapsedDays = (now - priorSrs.lastReviewedAt) / 86_400_000;
+          const sched = schedule(priorSrs, rating, now);
+
           const updatedWord: WordData = {
             ...current,
             difficulty,
             mastery,
             lastAdjustedDay: today,
-            lastAdjustReason: event
+            lastAdjustReason: event,
+            stability: sched.stability,
+            fsrsDifficulty: sched.fsrsDifficulty,
+            dueAt: sched.dueAt,
+            lastReviewedTs: sched.lastReviewedAt,
+            intervalDays: sched.intervalDays,
+            reps: sched.reps,
+            lapses: sched.lapses,
+            srsStatus: sched.status,
           };
 
           currentUserId().then((uid) => {
@@ -450,9 +493,27 @@ export const useAppStore = create<AppState>()(
                   difficulty,
                   timesSeen: updatedWord.timesSeen,
                   streak: updatedWord.streak,
-                  lastSeenTs: updatedWord.lastSeenTs
+                  lastSeenTs: updatedWord.lastSeenTs,
+                  stability: sched.stability,
+                  fsrsDifficulty: sched.fsrsDifficulty,
+                  dueAt: sched.dueAt,
+                  lastReviewedTs: sched.lastReviewedAt,
+                  intervalDays: sched.intervalDays,
+                  reps: sched.reps,
+                  lapses: sched.lapses,
+                  srsStatus: sched.status,
                 });
                 m.logStudyEventToSupabase(uid, updatedWord.jmdictEntryId!, 'mastery_change', { difficulty, mastery, event });
+                m.logSrsReviewToSupabase(uid, updatedWord.jmdictEntryId!, {
+                  rating,
+                  source: event === 'click' ? 'reader_click' : 'reader_skip',
+                  stabilityBefore: priorSrs.stability,
+                  stabilityAfter: sched.stability,
+                  difficultyBefore: priorSrs.fsrsDifficulty,
+                  difficultyAfter: sched.fsrsDifficulty,
+                  scheduledDays: sched.intervalDays,
+                  elapsedDays,
+                });
               });
             }
           });
@@ -738,7 +799,7 @@ export const useAppStore = create<AppState>()(
     }),
     {
       name: 'yugen-storage',
-      version: 5,
+      version: 6,
       // A persist write throws QuotaExceededError once localStorage fills up. That
       // exception used to propagate out of store actions (markArticleRead,
       // recordWordSeen, ...) and abort the tap handler — silently breaking article
@@ -845,6 +906,32 @@ export const useAppStore = create<AppState>()(
               : withSurface;
           });
           state = { ...state, wordDatabase: rekeyed };
+        }
+        // v6: FSRS scheduling (#67). Seed a real schedule for every already-graded
+        // word from its coarse `difficulty` + `lastSeenTs`, mirroring the server-side
+        // SQL backfill (database/23_fsrs_scheduling.sql) — easy words seed with a long
+        // interval, hard words come due soon. This also covers local-only words (no
+        // entry_id) that the SQL backfill can't reach. Ungraded words stay unscheduled
+        // (they belong in #68's intake queue); anything read after this seeds lazily.
+        if (version < 6 && state?.wordDatabase) {
+          const wordDatabase = { ...state.wordDatabase };
+          Object.keys(wordDatabase).forEach((key) => {
+            const w = wordDatabase[key];
+            if (!w || w.difficulty == null || w.stability != null) return;
+            const s = seedSrsFromDifficulty(w.difficulty, w.lastSeenTs ?? Date.now());
+            wordDatabase[key] = {
+              ...w,
+              stability: s.stability,
+              fsrsDifficulty: s.fsrsDifficulty,
+              dueAt: s.dueAt,
+              lastReviewedTs: s.lastReviewedAt,
+              intervalDays: (s.dueAt - s.lastReviewedAt) / 86_400_000,
+              reps: s.reps,
+              lapses: s.lapses,
+              srsStatus: s.status,
+            };
+          });
+          state = { ...state, wordDatabase };
         }
         return state;
       },

--- a/supabase/functions/_shared/wordPriority.ts
+++ b/supabase/functions/_shared/wordPriority.ts
@@ -54,6 +54,14 @@ export interface WordSignal {
    * null/undefined = never tracked. Used for staleness ordering (#51).
    */
   lastSeenAt?: string | null;
+  /**
+   * ISO-8601 next-review time (`user_word_progress.due_at`) from the FSRS engine (#67).
+   * null/undefined = not yet scheduled. Kept as a string so it compares chronologically
+   * without date parsing (module stays Date-free). Consumed by #72.
+   */
+  dueAt?: string | null;
+  /** FSRS stability in days; lower = more fragile memory. null = unscheduled. (#67) */
+  stability?: number | null;
 }
 
 /**
@@ -174,6 +182,27 @@ export function compareStuck(a: WordSignal, b: WordSignal): number {
   const db = b.difficulty ?? 0;
   if (da !== db) return db - da; // hardest first
   return (a.timesSeen ?? 0) - (b.timesSeen ?? 0); // least-seen first
+}
+
+/**
+ * Due-date order for the in-SRS review floor, backed by the real FSRS schedule (#67).
+ * Genuinely-due words first (soonest `due_at` ahead of later ones); never-scheduled
+ * words (null due_at) sort last. Ties break by lower stability (more fragile memory
+ * first), then fall back to the staleness heuristic. dueAt is an ISO-8601 string so it
+ * compares chronologically without date parsing (module stays Date-free).
+ *
+ * #67 provides this comparator; #72 is where compareStuck's callers switch over to it,
+ * so the topic-independent review slot pulls genuinely-due words instead of merely stale
+ * ones. Not yet wired to a caller.
+ */
+export function compareByDue(a: WordSignal, b: WordSignal): number {
+  const da = a.dueAt ?? '￿'; // unscheduled sorts last (all ISO chars < ￿)
+  const db = b.dueAt ?? '￿';
+  if (da !== db) return da < db ? -1 : 1; // sooner due first
+  const sa = a.stability ?? Number.POSITIVE_INFINITY;
+  const sb = b.stability ?? Number.POSITIVE_INFINITY;
+  if (sa !== sb) return sa - sb; // more fragile (lower stability) first
+  return compareStuck(a, b);
 }
 
 /**


### PR DESCRIPTION
Closes #67. Phase D foundation — a genuine spaced-repetition schedule (`stability` + `due_at` + intervals + a review log) **on top of** the existing coarse `difficulty` (1..10) signal, not replacing it. Prerequisite for the intake queue (#68), flashcard deck (#70), and feeding real due-dates into article generation (#72).

Design doc + locked decisions: `docs/fsrs-engine-design-67.md`.

## What's in it
- **`src/services/srs.ts`** — pure `schedule(state, rating, now)` wrapping `ts-fsrs` (FSRS-6, `request_retention` 0.85, deterministic) + `ratingForReaderEvent` + `seedSrsFromDifficulty` (seeds initial stability from `difficulty`, so existing tracking is preserved).
- **`database/23_fsrs_scheduling.sql`** — scheduling columns on `user_word_progress` + `idx_uwp_due` partial index + append-only `srs_review_log`; one-time backfill from `difficulty` + `last_seen_at`. ✅ **Applied by hand in Supabase** (incl. `vacuum analyze`).
- **`store.applyDifficultyEvent` scheduling arm** — read-past = "Good", lookup = "Again"; **reading always advances the schedule**, with the push self-limited by FSRS's early-review math so in-context reading shrinks the flashcard deck. Persist bump v5→v6 (eager client seed).
- **`api.ts`** — scheduling columns in fetch/upsert (partial upsert never nulls an existing schedule) + `logSrsReviewToSupabase`.
- **`wordPriority.ts`** — `dueAt`/`stability` on `WordSignal` + `compareByDue` comparator (provided here; #72 flips `compareStuck`'s callers over to it).

## Key decisions (from review)
- **FSRS** over SM-2, wrapping `ts-fsrs` for algorithm correctness.
- **Extend `user_word_progress`** + one new append-only `srs_review_log` (vs. a separate state table).
- **Read-past always reschedules** (revised from the original conservative "only when due" proposal) — the point is to minimize flashcard load by rewarding natural in-context reading; FSRS makes an early read a small push and a due read a big one, so it's self-limiting, not gameable.
- `request_retention` = **0.85**; easy words keep long (~40-day) initial intervals.

## As-built deviations (see design doc)
- Module lives at `src/services/srs.ts`, not `supabase/functions/_shared/` — #67's only consumer is the browser, and `_shared` uses Deno/esm.sh imports while the bundle uses npm. #72 can share it edge-side later.
- `enable_short_term: false` → lifecycle is just `new → review` (fits an article-reading cadence); a lapse shows as collapsed stability + `lapses++`.

## Testing
- `npm run test:srs` — **18/18** standalone assertions (`scripts/test-srs.mjs`): first review, monotonic interval growth, Again-lapse, D3 early-vs-due gain, seed gradient.
- `tsc -b` clean · full `vite build` (ts-fsrs bundles) · zero new lint errors (baseline `main` already has the same 52).

## Deploy
- [x] `database/23_fsrs_scheduling.sql` applied in Supabase + `vacuum analyze public.user_word_progress;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)