### PR TITLE
feat: word intake queue + daily new-word cap (#68)

### DIFF
--- a/database/24_intake_queue.sql
+++ b/database/24_intake_queue.sql
@@ -1,0 +1,97 @@
+-- ============================================================
+-- 24. Word intake queue + daily new-word limit (#68)
+-- ============================================================
+-- Gate words into the FSRS schedule (#67) instead of grading every word on sight.
+-- Today first contact immediately seeds difficulty + a full schedule, which floods a
+-- new/returning user with hundreds of "active" words. This migration adds a queue:
+-- words WAIT (unscheduled) until a daily cap promotes them, lowest JLPT level first,
+-- most-common-in-normal-text first.
+--
+-- `intake_status` is ORTHOGONAL to #67's `srs_status` (the FSRS card lifecycle,
+-- new/learning/review/relearning): a word is `queued` (waiting, no schedule) until the
+-- daily cap promotes it to `active` (scheduled). The promotion logic lives client-side
+-- (store.ts:promoteIntakeQueue, foundation-first via _shared/wordPriority.ts:compareIntake).
+--
+-- APPLY MANUALLY in the Supabase SQL editor (migrations in this repo are not
+-- auto-deployed). Safe to run repeatedly — IF NOT EXISTS + idempotent backfill.
+
+-- ── Intake status on user_word_progress ─────────────────────────────────────
+alter table public.user_word_progress
+  add column if not exists intake_status text
+    check (intake_status is null or intake_status in ('queued','active')),
+  add column if not exists promoted_at timestamptz;   -- when it entered active study
+
+-- Backfill (D2 — grandfather): every row that already has a schedule/grade is active;
+-- ungraded rows become queued. Non-destructive: no schedules touched. Idempotent —
+-- only stamps rows not already classified.
+update public.user_word_progress
+  set intake_status = case
+                        when stability is not null or difficulty is not null then 'active'
+                        else 'queued'
+                      end
+  where intake_status is null;
+
+-- Supports the queue-health dashboard (#73) and a future server-side promotion job.
+create index if not exists idx_uwp_intake
+  on public.user_word_progress(user_id, intake_status);
+
+-- ── Daily new-word cap preference (D3 — starts at 3) ────────────────────────
+alter table public.user_preferences
+  add column if not exists new_words_per_day smallint default 3
+    check (new_words_per_day between 0 and 50);
+
+-- ── Unseen-foundation intake candidates (D1, queue source #2) ────────────────
+-- The "important words the user hasn't read yet" feed. Sibling of get_unseen_common_words
+-- (database/14) but purpose-built for intake:
+--   (a) scans the user's level AND all easier levels in ONE call, foundation-first
+--       (jlpt_level DESC = easiest first, then freq_rank ASC),
+--   (b) excludes already-tracked words by canonical entry_id (correct post-#39 —
+--       the older RPC excludes by surface form, which no longer matches the store key),
+--   (c) returns entry_id + jlpt_level so a promoted word is canonically keyed and
+--       orderable by compareIntake.
+-- Perf shape mirrors database/14: order + LIMIT the candidate set on jmdict_entries
+-- FIRST (cheap — no display joins), then fetch the display fields for just the top
+-- p_limit rows via scalar subqueries.
+create or replace function public.get_intake_candidates(
+  p_user_jlpt smallint,
+  p_seen_ids  text[] default '{}',
+  p_limit     integer default 50
+)
+returns table (
+  entry_id   text,
+  jlpt_level smallint,
+  freq_rank  integer,
+  word       text,
+  reading    text,
+  meaning    text
+)
+language sql
+stable
+as $$
+  with ranked as (
+    select e.id, e.jlpt_level, e.freq_rank, e.common
+    from public.jmdict_entries e
+    where e.jlpt_level is not null
+      and e.jlpt_level >= p_user_jlpt        -- user's level and EASIER (higher number)
+      and not (e.id = any(p_seen_ids))       -- exclude already-tracked, by entry_id (#39)
+    order by e.jlpt_level desc, e.freq_rank asc nulls last, e.common desc, e.id asc
+    limit p_limit
+  )
+  select
+    r.id,
+    r.jlpt_level,
+    r.freq_rank::integer,
+    -- Prefer the kanji surface form; fall back to kana for kana-only entries.
+    coalesce(
+      (select k.text from public.jmdict_kanji k where k.entry_id = r.id order by k.id limit 1),
+      (select a.text from public.jmdict_kana  a where a.entry_id = r.id order by a.id limit 1)
+    ) as word,
+    (select a.text from public.jmdict_kana a where a.entry_id = r.id order by a.id limit 1) as reading,
+    (select array_to_string(s.gloss, '; ') from public.jmdict_senses s
+       where s.entry_id = r.id order by s.id limit 1) as meaning
+  from ranked r
+  order by r.jlpt_level desc, r.freq_rank asc nulls last, r.common desc, r.id asc;
+$$;
+
+grant execute on function public.get_intake_candidates(smallint, text[], integer)
+  to anon, authenticated;

--- a/docs/intake-queue-design-68.md
+++ b/docs/intake-queue-design-68.md
@@ -1,0 +1,268 @@
+# #68 — Word Intake Queue + Daily New-Word Limit: Design Doc
+**Phase D, second half.** Gate words into the FSRS schedule instead of grading every word on sight. Today the app immediately seeds `difficulty` + an FSRS schedule the first time it sees any dictionary-linked word (#67), which floods a new/returning user with hundreds of "active" words at once. #68 adds a **foundation-first intake queue**: words _wait_ (unscheduled) until a **daily new-word cap** promotes them — lowest JLPT level first, most-common-in-normal-text first. The queue draws from **two sources**: words the user has bumped into while reading, **and** important common words at/below their level they haven't read yet (so the foundation gets built even when articles skip it).
+
+> **Status:** ✅ decisions resolved (D1–D3, 2026-07-12) — ready to build.
+> 
+> **Depends on:** #67 (FSRS engine, ✅ shipped). Reuses `compareIntake` (already built in `_shared/wordPriority.ts:214` as the promotion comparator hook for this issue), `seedSrsFromDifficulty` / `schedule` from `src/services/srs.ts`, and the `get_unseen_common_words` RPC (`database/14`).
+> 
+> **Blocks:** #70 (deck reads _active_ words only), #72 (review palette pulls _active_ due words).
+
+* * *
+## 1. What exists today (grounded baseline)
+- **Every dictionary-linked word is graded on sight.** In `Reader.tsx`, a read-past (`gradeWordByKey`, ~L102) fires `recordWordSeen(key, true)` then `applyDifficultyEvent(key, 'skip')`; a lookup fires `applyDifficultyEvent(key, 'click')`. There is **no gate** — first contact immediately seeds `difficulty` (`seedDifficulty`) _and_, post-#67, a full FSRS schedule (`seedSrsFromDifficulty` → `schedule`). `store.ts:419` (`applyDifficultyEvent`) is the exact choke point.
+  
+- `recordWordSeen` **(**`store.ts:365`**)** already records exposure only (`timesSeen++`, `lastSeenTs`, `streak`) and does **not** grade — it's the behavior we want _queued_ words to have.
+  
+- `user_word_progress` carries `mastery_level`, `difficulty` (1–10), `times_seen`, `streak`, `last_seen_at`, plus the #67 schedule columns (`stability`, `due_at`, `srs_status`, …). `srs_status` is the FSRS _card lifecycle_ (`new/learning/review/relearning`) — **orthogonal** to intake status; #68 needs its own `queued`/`active` concept.
+  
+- **#67 already treats "unscheduled" as "belongs in #68's queue."** `database/23_fsrs_scheduling.sql:16` and `srs.ts` both comment that `stability IS NULL` / `difficulty IS NULL` = _not yet on a schedule → #68's intake gate_. So the schema already anticipates this split.
+  
+- `compareIntake` **exists and is unused** (`wordPriority.ts:214`) — foundation-first order: easiest JLPT level first (higher number), then lowest `freq_rank`. Built in #67 explicitly "Ready for #68's daily-promotion job; not yet wired to a caller."
+  
+- **An "unseen important words" source already exists** — `get_unseen_common_words(p_level, p_seen_words, p_limit)` (`database/13`, perf-rewritten in `database/14`) returns the most common words at an exact JLPT level the user has **not** encountered, ordered by `freq_rank`. Called today from `Progress.tsx` via `jmdict.ts:497`. This is the natural feed for the "important words not yet read" half of the queue (D1). _Caveat: it returns `(word, reading, rank, meaning)` only — no `entry_id`/`jlpt_level` — and excludes by surface form (stale post-#39). §3 adds a purpose-built sibling that returns `entry_id` and excludes by canonical id._
+  
+- `freq_rank` **is reachable client-side** — `jmdict.ts:109` already reads `entry.freq_rank` into enrichment (`freqRank`), but it is **not** stored on `WordData`. Foundation-first ordering of _encountered_ words needs it, so we carry it onto the record (small enrich-time add).
+  
+- **Daily client passes are an established pattern** — `checkDailyKanji` (`store.ts:780`) gates on `lastRtkUpdateTs > 86400000` and is invoked from `App.tsx:337` on mount. A promotion pass mirrors this exactly.
+  
+- **Preferences pattern** — `readingIntensity` / `targetParagraphs` show the full loop: a `user_preferences` column (`09_user_preferences.sql`), `fetch/upsertUserPreferences` (`api.ts:630/644`), a store field + setter that fires `upsertUserPreferences`, and a Settings control. The daily cap follows this pattern verbatim.
+  
+- **Server palette** (`process-article`) builds three buckets via `classifyBucket` (`wordPriority.ts:159`): the **review** floor query (`index.ts:320`) filters `mastery_level IN ('hard','medium')`; the **new** bucket surfaces at/near-level words _never tracked_. Queued words (ungraded, `mastery='unseen'`) are already naturally excluded from **review** — the only server change needed is making that exclusion explicit and safe.
+  
+
+* * *
+## 2. Design — decisions (RESOLVED 2026-07-12)
+### ✅ D1 — Promotion runs **client-side on-open**, and the queue has **two sources**
+**Resolved: client-side on-open pass** (mirroring `checkDailyKanji`), **and** the queue is fed by both words-read AND important-unread words (per c1).
+
+- **Why client-side:** foundation-first ordering needs only JLPT level + `freq_rank`, both available client-side (`freqRank` at enrich time; the unseen-words RPC returns it). It ships without new cron/edge infra, is consistent with #67's browser-side choice and `checkDailyKanji`, and the promotion logic stays a pure, testable function.
+  
+- **Two queue sources (c1 — "important words the user hasn't seen in reading must still enter the queue"):**
+  1. **Encountered-queued** — words bumped into while reading; stored locally as `intakeStatus='queued'` rows (exposure recorded, no schedule).
+  2. **Unseen-foundation** — important common words at/below the user's level they've **never** read, sourced on demand from the unseen-words RPC (§3), ordered level↑ then freq↑. **Virtual** — not stored until promoted, so we never materialise a huge backlog; JMDict _is_ the ordered source.
+  
+  The daily pass **merges both**, orders by `compareIntake`, and promotes the top `cap`. So even if articles never surface a common N5 word, the foundation pull feeds it in — the queue is a real "what to learn next" curriculum, not just "what I happened to read."
+  
+- **Cross-device:** two devices could promote different sets on the same day. Resolved as all SRS state is — LWW sync (`syncSrsWithSupabase`) reconciles the schedule fields, and a per-day stamp (`lastIntakePromotionTs`, like `lastRtkUpdateTs`) makes the pass idempotent per device. Worst case: a rare, self-healing over-promotion, not data loss.
+  
+- **Server-side alternative** (a cron promotion job): stronger cross-device story, but needs a new scheduled function + RLS-safe service-role queries and can't promote an all-day-offline device until it next syncs. **Deferred** — revisit only if promotion races prove real in practice.
+  
+
+> {>>D1: OK to go client-side on-open pass (recommended)
+> 
+> Although one thing to consider. We still want important words that the user hasn't seen in reading to make it into the queue somehow<<}{id="c1" by="user" at="2026-07-12T01:37:41.381Z"}
+> 
+> {==Resolved above (@c1)==}{>>Good catch — a real gap. The queue now has a second **unseen-foundation** source drawn from the existing `get_unseen_common_words` RPC (level↑/freq↑), merged with encountered words at promotion time, so common at/below-level words feed in even if no article surfaces them. Stays client-side per your approval — the pass just makes one RPC call, like `process-article` already does.<<}{#r1}
+### ✅ D2 — Migration: **grandfather** all currently-scheduled words as `active`
+**Resolved (c2): grandfather.** The queue starts empty of existing words; only words encountered / pulled _after_ #68 flow through the gate.
+
+- **Why:** yanking live schedules off hundreds of words a user is studying is destructive and confusing, and hard to reverse. Grandfathering is safe, non-destructive, and still delivers the core win — _new_ intake is paced from now on. The v6→v7 persist migration + the SQL backfill stamp `intakeStatus='active'` on every row with a schedule/grade, `'queued'` on any ungraded row.
+  
+- **Retroactive-queue** (move the un-established long tail back to `queued`) stays an explicit, opt-in follow-up ("Reset study pacing"), never a silent migration.
+  
+
+> {>>D2: Grandfather existing words as active (recommended, non-destructive)<<}{id="c2" by="user" at="2026-07-12T01:37:41.381Z"}
+### ✅ D3 — Daily cap **starts at 3/day**; **no lookup fast-track**
+**Resolved (c3, c4).**
+
+- **Default cap = 3/day** (c3), configurable 0–50 in Settings (0 = pause new words). Small and gentle to start; the user can raise it.
+  
+- **No fast-track on lookup (c4).** A lookup on a `queued` word signals only "I don't recognise this," _not_ intent to learn it — so a `click` on a queued word records exposure and **leaves it queued**. Queued words leave the queue **only** via the daily cap. (While queued, `skip` and `click` are both exposure-only; the "didn't know it" signal is moot until the word is scheduled.)
+  
+- **One deliberate exception — explicit manual mastery-set.** If the user opens the modal and _explicitly_ classifies a queued word (easy/medium/hard via `setWordMastery`), that's a direct declaration of knowledge, not a passive signal — it promotes + applies. Distinct from a lookup, and rare. {==Manual-set is the one remaining non-cap promotion path==}{>>Say the word if you'd rather a manual set ALSO just record without scheduling until the cap promotes it — I lean toward respecting the explicit classification.<<}{#r2}
+  
+
+> {>>D3a: Start with just 3<<}{id="c3" by="user" at="2026-07-12T01:37:41.381Z"}
+> 
+> {>>D3b: do not let lookups bypass the fasttrack. All a user is signaling with a lookup is that they don't know it, not that they are looking to learn it.<<}{id="c4" by="user" at="2026-07-12T01:37:41.381Z"}
+
+* * *
+## 3. Schema
+New migration `database/24_intake_queue.sql`:
+
+```sql
+-- 24. Word intake queue (#68). Gate words into the FSRS schedule (#67) instead of
+-- grading every word on sight. `intake_status` is ORTHOGONAL to `srs_status` (the
+-- FSRS card lifecycle): a word is `queued` (waiting, no schedule) until the daily
+-- cap promotes it to `active` (scheduled). Applied by hand (project convention).
+alter table public.user_word_progress
+  add column if not exists intake_status text
+    check (intake_status is null or intake_status in ('queued','active')),
+  add column if not exists promoted_at timestamptz;   -- when it entered active study
+
+-- Backfill (D2 — grandfather): every row with a schedule/grade is active; ungraded → queued.
+update public.user_word_progress
+  set intake_status = case when stability is not null or difficulty is not null
+                           then 'active' else 'queued' end
+  where intake_status is null;
+
+create index if not exists idx_uwp_intake
+  on public.user_word_progress(user_id, intake_status);
+
+-- Daily new-word cap preference (D3 — starts at 3).
+alter table public.user_preferences
+  add column if not exists new_words_per_day smallint default 3
+    check (new_words_per_day between 0 and 50);
+
+-- Unseen-foundation candidates for the intake pull (D1, source #2). Like
+-- get_unseen_common_words (database/14) but (a) scans the user's level AND all easier
+-- levels in ONE call, foundation-first (jlpt_level DESC = easiest first, then freq_rank
+-- ASC), (b) excludes by canonical entry_id (correct post-#39, vs the older surface-form
+-- exclusion), and (c) returns entry_id + jlpt_level so a promoted word is canonically
+-- keyed and orderable by compareIntake. Same perf shape as database/14: order+limit on
+-- jmdict_entries first, LATERAL/scalar subqueries for display only.
+create or replace function public.get_intake_candidates(
+  p_user_jlpt smallint,
+  p_seen_ids  text[] default '{}',
+  p_limit     integer default 50
+)
+returns table (entry_id text, jlpt_level smallint, freq_rank integer,
+               word text, reading text, meaning text)
+language sql stable as $$
+  with ranked as (
+    select e.id, e.jlpt_level, e.freq_rank, e.common
+    from public.jmdict_entries e
+    where e.jlpt_level >= p_user_jlpt        -- user's level and EASIER (higher number)
+      and not (e.id = any(p_seen_ids))       -- exclude already-tracked, by entry_id (#39)
+    order by e.jlpt_level desc, e.freq_rank asc nulls last, e.common desc, e.id asc
+    limit p_limit
+  )
+  select r.id, r.jlpt_level, r.freq_rank::integer,
+         coalesce((select k.text from public.jmdict_kanji k where k.entry_id = r.id order by k.id limit 1),
+                  (select a.text from public.jmdict_kana  a where a.entry_id = r.id order by a.id limit 1)) as word,
+         (select a.text from public.jmdict_kana a where a.entry_id = r.id order by a.id limit 1) as reading,
+         (select array_to_string(s.gloss, '; ') from public.jmdict_senses s where s.entry_id = r.id order by s.id limit 1) as meaning
+  from ranked r
+  order by r.jlpt_level desc, r.freq_rank asc nulls last, r.common desc, r.id asc;
+$$;
+grant execute on function public.get_intake_candidates(smallint, text[], integer) to anon, authenticated;
+```
+
+> Applied by hand in Supabase. `intake_status` is orthogonal to #67's `srs_status`.
+
+* * *
+## 4. Client changes
+### 4a. `WordData` + persist v6 → v7 (`store.ts`)
+- Add `freqRank?: number | null` (populated at enrich time from `jmdict.ts` — needed for `compareIntake`), `intakeStatus?: 'queued' | 'active'`, `promotedTs?: number | null`.
+  
+- **v7 migration** (mirrors the D2 SQL): stamp `intakeStatus='active'` on any word with a schedule (`stability != null`) or a grade (`difficulty != null`); everything else `'queued'`. No schedules touched.
+  
+- Bump `version: 6` → `7`.
+  
+### 4b. Intake gate in the grading path (`store.ts`)
+The core behavior change. First contact no longer seeds a schedule.
+
+- **New / queued word** encountered → ensure a record exists with `intakeStatus='queued'`, record exposure via the existing `recordWordSeen` machinery (`timesSeen`/recency/streak). **No** `seedDifficulty`**, no FSRS** `schedule()` — `difficulty` and `stability` stay null (so `classifyBucket` keeps treating it as discoverable-new, and it's excluded from review).
+  
+- `applyDifficultyEvent` gains an early guard: **if the word is** `queued`**, it does not grade or schedule** — `skip` and `click` alike only record exposure (D3b: a lookup does _not_ promote). If the word is `active`, it behaves exactly as today (difficulty nudge + FSRS advance).
+  
+- **Manual mastery-set exception (D3, `#r2`):** `setWordMastery` on a queued word promotes it first (`promoteWord(key)` → `active` + seeded schedule via `seedSrsFromDifficulty`, stamp `promotedTs`), then applies the explicit grade. Lookups never do this.
+  
+### 4c. `promoteIntakeQueue(now)` store action + daily trigger
+- New action, gated on `lastIntakePromotionTs > 86_400_000` (mirrors `checkDailyKanji`), invoked from `App.tsx:337` alongside it. Async (it makes one RPC call).
+  
+- **Build the merged candidate set:**
+  1. Local `intakeStatus==='queued'` words → `WordSignal[]` (carry `entryId`, `jlptLevel`, `freqRank`).
+  2. `get_intake_candidates(userJlpt, seenEntryIds, cap + buffer)` → unseen-foundation `WordSignal[]` (virtual; `seenEntryIds` = every tracked entry id, so nothing double-counts).
+  
+- **Order + slice:** merge, sort by `compareIntake` (level↑ then freq↑), take the top `new_words_per_day`. _(Optional tiebreak at equal level+freq: prefer higher `timesSeen` so a word the user has actually met edges out a never-seen one — a small local comparator layered on the shared one.)_
+  
+- **Promote each:** set `intakeStatus='active'`, `promotedTs=now`, seed via `seedSrsFromDifficulty(seedDifficulty(jlpt, userLevel), now)`. For a virtual unseen word, first materialise its `WordData` (entry_id key per #39, from the RPC's word/reading/meaning + level + freqRank, `timesSeen: 0`). Upsert the row — promotion is an initial schedule, **not** a review, so no `srs_review_log` write.
+  
+- Stamp `lastIntakePromotionTs=now`.
+  
+### 4d. Daily cap preference (follow the `readingIntensity` pattern exactly)
+- Store: `newWordsPerDay: number` (default 3) + `setNewWordsPerDay(n)` setter firing `upsertUserPreferences({ new_words_per_day: n })`; hydrate in `syncSrsWithSupabase` from `remotePrefs.new_words_per_day`.
+  
+- `api.ts`: map `new_words_per_day` in `fetchUserPreferences` / `upsertUserPreferences`.
+  
+- `Settings.tsx`: a stepper (0–50) near the reading-intensity section — "New words per day", defaulting to 3.
+  
+### 4e. Sync (`api.ts` / `jmdict.ts`)
+- Extend `upsertWordProgressToSupabase` / `…Batch` payloads + `fetchUserWordProgress` mapping with `intake_status` ↔ `intakeStatus` and `promoted_at` ↔ `promotedTs`. Pagination unchanged.
+  
+- Add a thin `fetchIntakeCandidates(userJlpt, seenIds, limit)` wrapper around the `get_intake_candidates` RPC (mirrors the existing `get_unseen_common_words` wrapper in `jmdict.ts:510`).
+  
+
+* * *
+## 5. Server changes (`process-article`) — minimal
+The acceptance "the deck/LLM never see a word before promotion" is _mostly already satisfied_: queued words are ungraded (`mastery='unseen'`), so they never enter the **review** floor and never rank as **known**. One explicit guard:
+
+- **Review floor query** (`index.ts:320`): add `intake_status = 'active'` (or `is null` for legacy safety) so a queued word can never be pulled as a review target.
+  
+- **New bucket:** leave as-is. Re-surfacing a queued (or unseen-foundation) word as a discovery ("new") word in an article is _good_ — it drives the exposure that reading contributes — and it never grants active scheduling. (Optional later: dedupe against the queue; deferred.)
+  
+
+_(The flashcard deck (#70) and due-word feed (#72) don't exist yet; they'll read_ `intake_status='active'` _from day one — this design just guarantees the column is there and correct.)_
+
+* * *
+## 6. Acceptance criteria + verification
+| Criterion (from the issue) | Verification |
+| --- | --- |
+| New words enter active study only at the daily cap | Read an article with >cap new words → after the daily pass, exactly `cap` new `active` words; the rest stay `queued`. |
+| Promotion is lowest-level-most-frequent first | Unit-test `promoteIntakeQueue` fixture: N5-common promotes before N5-rare before N4 before N3. |
+| Important **unread** words still enter the queue (c1) | With an empty local queue, the daily pass still promotes `cap` unseen-foundation words from `get_intake_candidates`, lowest-level-most-common first. |
+| The LLM never sees a word before promotion | Queued word never appears in the review palette (server query filters `intake_status='active'`); confirmed via a process-article dry-run. |
+| Backlog waits in a visible, ordered queue | Encountered-queued words persist with exposure counts; the unseen-foundation preview is queryable (surfaced in #73's dashboard later). |
+| Reading a queued word records exposure but starts no interval | Read-past OR lookup a queued word → `timesSeen++`, `lastSeenTs` bumped, but `stability`/`due_at` stay null, no `srs_review_log` row, still `queued` (D3b). |
+| Existing schedules preserved (D2) | v7 migration + SQL backfill leave every already-scheduled word `active` with its schedule intact. |
+
+**Tests:** `promoteIntakeQueue` (with an injected candidate-fetch stub) and the intake gate are pure over `(wordDatabase, candidates, now, cap)` → a standalone `scripts/` runner in the spirit of `test-srs.mjs`: foundation-first ordering across both sources, cap respected, queued-word read/lookup = exposure-only (no promotion, D3b), manual-set promotes.
+
+* * *
+## 7. Build order
+1. `database/24_intake_queue.sql` — columns + backfill + index + `new_words_per_day` + `get_intake_candidates` RPC (authored; applied by hand).
+  
+2. `wordPriority.ts` — no change (`compareIntake` exists); add a `WordData → WordSignal` mapper if not already present.
+  
+3. `store.ts` — `WordData` fields, persist v7, the intake gate in `applyDifficultyEvent`, `promoteWord`, async `promoteIntakeQueue` (merges local queue + RPC candidates), `newWordsPerDay` + setter.
+  
+4. `api.ts` / `jmdict.ts` — extend upsert/fetch payloads (`intake_status`, `promoted_at`, `new_words_per_day`) + `fetchIntakeCandidates` wrapper.
+  
+5. `App.tsx` — `await promoteIntakeQueue` alongside `checkDailyKanji`.
+  
+6. `Settings.tsx` — "New words per day" control (default 3).
+  
+7. `process-article` — `intake_status='active'` guard on the review query.
+  
+8. Standalone `scripts/` test runner; browser-test the encounter/pull → queue → daily-promote → schedule loop end to end.
+  
+
+* * *
+## 8. Out of scope (explicit handoffs)
+- **Flashcard deck reading the active/due set** → #70.
+  
+- **Feeding _due_ active words into article generation** (rewiring `compareStuck` → `compareByDue`) → #72.
+  
+- **Queue-health dashboard** (queued/active/due counts, daily-goal, unseen-foundation preview) → #73.
+  
+- **Retroactive queueing of the existing long tail** (D2 alternative) → optional opt-in follow-up, not this PR.
+  
+
+* * *
+
+---
+comments:
+  c1:
+    by: user
+    at: "2026-07-12T01:37:41.381Z"
+  c2:
+    by: user
+    at: "2026-07-12T01:37:41.381Z"
+  c3:
+    by: user
+    at: "2026-07-12T01:37:41.381Z"
+  c4:
+    by: user
+    at: "2026-07-12T01:37:41.381Z"
+  r1:
+    body: "Resolved D1's gap — added an unseen-foundation queue source (get_unseen_common_words / new get_intake_candidates), merged at promotion time. Stays client-side."
+    by: AI
+    at: "2026-07-12T02:00:00.000Z"
+    re: c1
+  r2:
+    body: "D3b applied — no lookup fast-track. Manual mastery-set flagged as the one remaining non-cap promotion path; open to gating it by the cap too if preferred."
+    by: AI
+    at: "2026-07-12T02:00:00.000Z"
+    re: c4
+</content>

--- a/docs/word-mastery-loop-plan.md
+++ b/docs/word-mastery-loop-plan.md
@@ -18,11 +18,12 @@
 
 **Legend:** 🟢 cheap / high-leverage · 🟡 medium · 🔴 large · ✅ done · [/] in progress · [ ] not started
 
-**📍 You are here (2026-07-05):**
+**📍 You are here (2026-07-11):**
 - **Phase A is complete** — #39 (canonical entry-id keying, PR #90), #37 (JMDict sense display), and #41 (sync/hydration, done across #85-88 + the ungraded-local merge fix) all shipped. Word tracking is now one record per canonical `entry_id`, and the Progress page / server sync agree.
 - **Phase B is complete and deployed** — the shared Word Priority Metric (#69) and all three consumers shipped: prefer confirmed-familiar backbone (#25), JLPT-proximity + stretch words (#22), and the topic-independent review floor (#51). Article word-selection now reads one shared scorer — and, post-#39, on de-fragmented data.
 - **Phase C is complete** — models pinned + upgraded to `gemini-3.5-flash` (#64 ✅); the **eval harness (#65 ✅)** ships — `scripts/eval-article-rewrite.mjs` scores rewrites on a frozen golden set (`scripts/eval-fixtures/`) via the extracted, shared prompt module, with EVAL-001 as an automated regression. Its verdict: **flash beats/ties `gemini-3.1-pro-preview` on every axis at ~half latency/cost → stay on flash**. The **prompt restructure (#66 ✅)** then closed the one remaining gap: a surgical GOLDEN-RULE anti-fabrication edit lifted factual fidelity **4.00 → 5.00** at equal-or-lower cost, measured against the harness (see [`phase-c-eval-notes.md`](./phase-c-eval-notes.md)).
-- Goals 4–5's remainder (eval/prompt, then the real SRS engine + flashcards) are the open frontier: **Phase C** (#65/#66) can run anytime; **Phase D** (#67 FSRS engine + #68 intake queue) is the next big build, with **Phase E** (flashcards) on top.
+- **Phase D is underway** — the **FSRS scheduling engine (#67 ✅, PR #94)** shipped: words now carry a real `due_at`/stability schedule (`ts-fsrs`, FSRS-6, retention 0.85) seeded from `difficulty`, and in-context reads advance it (design in [`fsrs-engine-design-67.md`](./fsrs-engine-design-67.md)). Its **#68 intake queue** (foundation-first promotion + daily new-word cap) is the next big build — the remaining half of Phase D.
+- Goals 5's remainder (the flashcard deck on top of the engine) is the open frontier after #68: **Phase E** (flashcards, #70–#73) closes the loop.
 
 > **➡️ NEXT UP: Phase D #68 (intake queue).** #67 (FSRS engine) shipped 2026-07-11 — words now carry a real `due_at`/stability schedule seeded from `difficulty`, and in-context reads advance it (see [`fsrs-engine-design-67.md`](./fsrs-engine-design-67.md)). The frontier is now the foundation-first intake queue + daily new-word cap that gates words into that schedule.
 >

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test:srs": "node scripts/test-srs.mjs"
+    "test:srs": "node scripts/test-srs.mjs",
+    "test:intake": "node scripts/test-intake.mjs"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/scripts/test-intake.mjs
+++ b/scripts/test-intake.mjs
@@ -1,0 +1,94 @@
+/**
+ * Standalone test runner for the intake-queue selection logic (#68).
+ *
+ *   node scripts/test-intake.mjs
+ *
+ * No test framework (matches test-srs.mjs / the eval-harness style): src/services/
+ * intake.ts is pure, so we bundle it with esbuild and assert on the foundation-first
+ * ordering + promotion selection with fixed inputs. Exits non-zero on any failure.
+ *
+ * What it locks in:
+ *   • compareIntakeItem: easiest JLPT level first, then most common, then encountered
+ *   • selectPromotions: respects the daily cap; cap<=0 promotes nothing
+ *   • foundation-first: N5-common < N5-rare < N4 < N3
+ *   • important UNSEEN words still promote when the local queue is empty (c1)
+ *   • dedupe by entryId prefers the local encountered record over a virtual candidate
+ */
+import esbuild from 'esbuild';
+import { pathToFileURL } from 'node:url';
+import { rmSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+const TMP = path.join('scripts', '.tmp-intake-bundle.mjs');
+
+let passed = 0;
+let failed = 0;
+function check(name, cond, detail = '') {
+  if (cond) {
+    passed++;
+    console.log(`  \x1b[32m✓\x1b[0m ${name}`);
+  } else {
+    failed++;
+    console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? `  — ${detail}` : ''}`);
+  }
+}
+
+// Helpers to build IntakeItems tersely.
+const local = (entryId, jlptLevel, freqRank, timesSeen = 1) =>
+  ({ key: `k:${entryId}`, entryId, jlptLevel, freqRank, timesSeen });
+const virtual = (entryId, jlptLevel, freqRank) =>
+  ({ key: null, entryId, jlptLevel, freqRank, timesSeen: 0, candidate: { entryId, jlptLevel, freqRank, word: entryId, reading: '', meaning: '' } });
+
+async function main() {
+  mkdirSync('scripts', { recursive: true });
+  await esbuild.build({
+    entryPoints: ['src/services/intake.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    outfile: TMP,
+    logLevel: 'silent',
+  });
+  const { compareIntakeItem, selectPromotions } = await import(pathToFileURL(TMP).href);
+
+  console.log('\ncompareIntakeItem — foundation-first');
+  const n5c = local('n5c', 5, 1);
+  const n5r = local('n5r', 5, 100);
+  const n4 = local('n4', 4, 1);
+  const n3 = local('n3', 3, 1);
+  const shuffled = [n3, n5r, n4, n5c];
+  const order = [...shuffled].sort(compareIntakeItem).map((i) => i.entryId);
+  check('N5-common < N5-rare < N4 < N3', JSON.stringify(order) === JSON.stringify(['n5c', 'n5r', 'n4', 'n3']), order.join(','));
+
+  check('easier level (higher number) sorts first', compareIntakeItem(local('a', 5, 1), local('b', 4, 1)) < 0);
+  check('within a level, lower freq_rank (more common) first', compareIntakeItem(local('a', 5, 1), local('b', 5, 2)) < 0);
+  check('null freq_rank sorts after a ranked word', compareIntakeItem(local('a', 5, 5), local('b', 5, null)) < 0);
+  check('null level sorts last', compareIntakeItem(local('a', null, 1), local('b', 1, 999)) > 0);
+
+  console.log('\ncompareIntakeItem — encountered edges out never-seen at equal level+freq');
+  check('higher timesSeen first on a tie', compareIntakeItem(local('seen', 5, 1, 5), virtual('unseen', 5, 1)) < 0);
+
+  console.log('\nselectPromotions — daily cap');
+  const pool = [n3, n4, n5r, n5c];
+  check('cap 2 returns exactly 2', selectPromotions(pool, [], 2).length === 2);
+  check('cap 2 returns the two easiest/most-common', JSON.stringify(selectPromotions(pool, [], 2).map((i) => i.entryId)) === JSON.stringify(['n5c', 'n5r']));
+  check('cap 0 promotes nothing', selectPromotions(pool, [], 0).length === 0);
+  check('cap larger than pool returns whole pool', selectPromotions(pool, [], 99).length === 4);
+
+  console.log('\nselectPromotions — unseen-foundation words enter when queue is empty (c1)');
+  const cands = [virtual('cB', 4, 1), virtual('cA', 5, 1), virtual('cC', 5, 50)];
+  const fromEmpty = selectPromotions([], cands, 2).map((i) => i.entryId);
+  check('promotes top-2 unseen candidates foundation-first', JSON.stringify(fromEmpty) === JSON.stringify(['cA', 'cC']), fromEmpty.join(','));
+  check('promoted candidates carry their materialisation payload', selectPromotions([], cands, 1)[0].candidate?.word === 'cA');
+
+  console.log('\nselectPromotions — dedupe by entryId prefers the local record');
+  const merged = selectPromotions([local('dup', 5, 1)], [virtual('dup', 5, 1)], 5);
+  check('a colliding entryId appears once', merged.filter((i) => i.entryId === 'dup').length === 1);
+  check('the surviving record is the local (encountered) one', merged.find((i) => i.entryId === 'dup')?.key !== null);
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  try { rmSync(TMP); } catch { /* ignore */ }
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -345,7 +345,11 @@ function App() {
         loadedCacheForUser.current = session.user.id;
         loadGlobalCache(session.user.id);
       }
-      useAppStore.getState().syncSrsWithSupabase(session.user.id);
+      // Sync first (hydrates remote progress + the new-words/day preference), then run
+      // the daily intake promotion (#68) so it sees the up-to-date queue + cap.
+      useAppStore.getState().syncSrsWithSupabase(session.user.id)
+        .then(() => useAppStore.getState().promoteIntakeQueue(Date.now()))
+        .catch((e) => console.warn('[app] SRS sync / intake promotion failed:', e));
     }
   }, [isOnboarded, session, checkDailyKanji, checkMidnightReset]);
 

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -122,13 +122,13 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     const surface = details?.word ?? token.lemma ?? token.text ?? key;
     if (!existing) {
       saveWordDefinition(key, details
-        ? { reading: details.reading, meaning: details.meaning, surface, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id }
+        ? { reading: details.reading, meaning: details.meaning, surface, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, freqRank: details.freqRank, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id }
         : { reading: '...', meaning: 'Implicitly parsed context', surface, jmdictEntryId: token.jmdict_entry_id });
     } else if (details && existing.jlptLevel == null && details.jlptLevel != null) {
       // Self-heal: the word was first stored before enrichment linked it (so it had
       // no JLPT and sat in Progress's "Other"). Now that we have dictionary details,
       // patch in the level and full definition.
-      saveWordDefinition(key, { reading: details.reading, meaning: details.meaning, surface, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id });
+      saveWordDefinition(key, { reading: details.reading, meaning: details.meaning, surface, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, freqRank: details.freqRank, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id });
     }
     recordWordSeen(key, true);
     // Count the read either way, but only seed a difficulty when the word is

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -33,6 +33,7 @@ export function Settings() {
     studyMode, setStudyMode,
     readingIntensity, setReadingIntensity,
     targetParagraphs, setTargetParagraphs,
+    newWordsPerDay, setNewWordsPerDay,
     readerFontSize, setReaderFontSize,
     readerFontWeight, setReaderFontWeight
   } = useAppStore();
@@ -200,6 +201,36 @@ export function Settings() {
             </div>
           </div>
         ))}
+      </div>
+
+      {/* New Words Per Day (#68 — intake pacing) */}
+      <div style={{ backgroundColor: 'var(--bg-card)', padding: '1.5rem', borderRadius: '16px', marginBottom: '1.5rem' }}>
+        <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-muted)', letterSpacing: '0.1em', marginBottom: '0.5rem', textTransform: 'uppercase' }}>
+          New Words Per Day
+        </label>
+        <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: '1.4rem' }}>
+          How many new words graduate into active study each day, easiest and most common first — so the foundation gets built before harder words. Words you meet while reading wait in a queue until their turn. Set to 0 to pause new words.
+        </p>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ fontSize: '0.95rem', fontWeight: 600, color: 'var(--text-main)' }}>New words / day</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexShrink: 0 }}>
+            <button
+              onClick={() => setNewWordsPerDay(newWordsPerDay - 1)}
+              disabled={newWordsPerDay <= 0}
+              aria-label="Decrease new words per day"
+              style={stepperBtnStyle(newWordsPerDay <= 0)}
+            >−</button>
+            <span style={{ minWidth: '1.5rem', textAlign: 'center', fontSize: '1.05rem', fontWeight: 700, color: 'var(--text-main)', fontVariantNumeric: 'tabular-nums' }}>
+              {newWordsPerDay}
+            </span>
+            <button
+              onClick={() => setNewWordsPerDay(newWordsPerDay + 1)}
+              disabled={newWordsPerDay >= 50}
+              aria-label="Increase new words per day"
+              style={stepperBtnStyle(newWordsPerDay >= 50)}
+            >+</button>
+          </div>
+        </div>
       </div>
 
       {/* 3. Vocab Use */}

--- a/src/components/WordModal.tsx
+++ b/src/components/WordModal.tsx
@@ -16,6 +16,8 @@ export interface WordDetails {
   jlptLevel?: number | null;
   /** True when jlptLevel was inferred (kanji/frequency) rather than an official tag. */
   jlptDerived?: boolean;
+  /** JMDict freq_rank (1 = most common; null = rare/unranked). Feeds intake ordering (#68). */
+  freqRank?: number | null;
 }
 
 interface Props {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -481,6 +481,9 @@ export async function fetchUserWordProgress(userId: string): Promise<Record<stri
         reps: row.reps ?? 0,
         lapses: row.lapses ?? 0,
         srsStatus: row.srs_status ?? null,
+        // Intake queue (#68) — 'queued' waits; 'active' is on the FSRS schedule.
+        intakeStatus: row.intake_status ?? null,
+        promotedTs: row.promoted_at ? new Date(row.promoted_at).getTime() : null,
       };
     });
 
@@ -523,7 +526,12 @@ function srsColumns(p: SrsSyncFields): Record<string, unknown> {
 export async function upsertWordProgressToSupabase(
   userId: string,
   wordId: string,
-  progress: { mastery: string; difficulty?: number | null; timesSeen: number; streak: number; lastSeenTs: number } & SrsSyncFields
+  progress: { mastery: string; difficulty?: number | null; timesSeen: number; streak: number; lastSeenTs: number }
+    & SrsSyncFields
+    // Intake queue (#68). Present-only, like the SRS fields: a caller that just touches
+    // difficulty (a normal grade) omits these, so an upsert never nulls a word's
+    // intake_status/promoted_at. Set them only when promoting (queued → active).
+    & { intakeStatus?: string | null; promotedTs?: number | null }
 ) {
   const { error } = await supabase
     .from('user_word_progress')
@@ -536,6 +544,10 @@ export async function upsertWordProgressToSupabase(
       streak: progress.streak,
       last_seen_at: new Date(progress.lastSeenTs).toISOString(),
       ...srsColumns(progress),
+      ...(progress.intakeStatus !== undefined ? { intake_status: progress.intakeStatus } : {}),
+      ...(progress.promotedTs !== undefined
+        ? { promoted_at: progress.promotedTs == null ? null : new Date(progress.promotedTs).toISOString() }
+        : {}),
     });
 
   if (error) console.error(`Error syncing progress for ${wordId}:`, error);
@@ -653,6 +665,7 @@ export async function upsertUserPreferences(
     target_paragraphs_full?: number;
     target_paragraphs_partial?: number;
     target_paragraphs_snippet?: number;
+    new_words_per_day?: number;
   }
 ) {
   const { error } = await supabase

--- a/src/services/intake.ts
+++ b/src/services/intake.ts
@@ -1,0 +1,83 @@
+// Word intake queue selection (#68) — the pure, foundation-first promotion logic.
+//
+// Encountering a word no longer grades it on sight. Instead words WAIT in an intake
+// queue (unscheduled) until a daily cap promotes the top `cap` of them into active
+// FSRS scheduling (src/services/srs.ts). Promotion order is FOUNDATION-FIRST: easiest
+// JLPT level first, then most common in normal text — so the common N5/N4 backbone is
+// mastered before harder/rarer words ever enter active study.
+//
+// The queue has two sources (see docs/intake-queue-design-68.md, D1):
+//   1. Encountered-queued — words the user bumped into while reading (a local
+//      `user_word_progress` row with intake_status='queued').
+//   2. Unseen-foundation — important common words at/below the user's level they have
+//      NOT read yet, pulled on demand from the get_intake_candidates RPC. Virtual:
+//      not stored until promoted, so we never materialise a huge backlog.
+//
+// This module is intentionally pure (no store/Supabase/clock access) so the ordering
+// is unit-testable with a standalone runner, mirroring how srs.ts is tested.
+
+/** A virtual unseen-foundation candidate row from the get_intake_candidates RPC. */
+export interface IntakeCandidate {
+  entryId: string;
+  jlptLevel: number | null;
+  freqRank: number | null;
+  word: string;
+  reading: string;
+  meaning: string;
+}
+
+/**
+ * One word competing for promotion. `key` is the store key of an already-encountered
+ * queued record, or null for a virtual unseen-foundation candidate (materialised into
+ * a record only if it wins a promotion slot). `candidate` carries the display fields
+ * needed to build that record.
+ */
+export interface IntakeItem {
+  key: string | null;
+  entryId: string;
+  jlptLevel: number | null;
+  freqRank: number | null;
+  timesSeen: number;
+  candidate?: IntakeCandidate;
+}
+
+/**
+ * Foundation-first promotion order. Mirrors `_shared/wordPriority.ts:compareIntake`
+ * (kept as a small local copy rather than imported across the Vite/Deno module
+ * boundary, exactly as srs.ts mirrors the SQL seed): easiest JLPT level first (higher
+ * number), then most common (lowest freq_rank; nulls last). Unknown level sorts last.
+ * Tiebreak: a word the user has actually encountered (higher timesSeen) edges out a
+ * never-seen candidate at the same level+frequency.
+ */
+export function compareIntakeItem(a: IntakeItem, b: IntakeItem): number {
+  const la = a.jlptLevel ?? Number.NEGATIVE_INFINITY; // unknown level = hardest, last
+  const lb = b.jlptLevel ?? Number.NEGATIVE_INFINITY;
+  if (la !== lb) return lb - la; // easier (higher number) first
+  const fa = a.freqRank ?? Number.POSITIVE_INFINITY;
+  const fb = b.freqRank ?? Number.POSITIVE_INFINITY;
+  if (fa !== fb) return fa - fb; // most common (lowest rank) first
+  return (b.timesSeen ?? 0) - (a.timesSeen ?? 0); // encountered edges out never-seen
+}
+
+/**
+ * Choose up to `cap` words to promote this cycle, foundation-first. Merges the two
+ * queue sources and de-dupes by entryId — a locally-queued word and an unseen
+ * candidate can name the same entry, in which case the local (encountered) record
+ * wins so we promote in place instead of creating a duplicate. Returns [] for cap<=0.
+ */
+export function selectPromotions(
+  queued: IntakeItem[],
+  candidates: IntakeItem[],
+  cap: number,
+): IntakeItem[] {
+  if (cap <= 0) return [];
+  const byId = new Map<string, IntakeItem>();
+  for (const item of [...queued, ...candidates]) {
+    const existing = byId.get(item.entryId);
+    // Prefer a real encountered record (key != null) over a virtual candidate.
+    if (!existing || (existing.key == null && item.key != null)) {
+      byId.set(item.entryId, item);
+    }
+  }
+  return Array.from(byId.values()).sort(compareIntakeItem).slice(0, cap);
+}

--- a/src/services/jmdict.ts
+++ b/src/services/jmdict.ts
@@ -9,6 +9,7 @@
 import { supabase } from './supabase';
 import { alignReading, hasKanji } from './furigana';
 import type { CoarsePos } from './tokenizer';
+import type { IntakeCandidate } from './intake';
 
 export interface JMDictResult {
   entryId: string;
@@ -293,8 +294,8 @@ export async function fetchJlptByEntryIds(
  */
 export async function fetchDetailsByEntryIds(
   ids: string[],
-): Promise<Map<string, { word: string; reading: string; meaning: string; jlptLevel: number | null; jlptDerived: boolean; pos: string[]; furiganaMap: { kanji: string; kana: string }[]; jmdictEntryId: string }>> {
-  const out = new Map<string, { word: string; reading: string; meaning: string; jlptLevel: number | null; jlptDerived: boolean; pos: string[]; furiganaMap: { kanji: string; kana: string }[]; jmdictEntryId: string }>();
+): Promise<Map<string, { word: string; reading: string; meaning: string; jlptLevel: number | null; jlptDerived: boolean; freqRank: number | null; pos: string[]; furiganaMap: { kanji: string; kana: string }[]; jmdictEntryId: string }>> {
+  const out = new Map<string, { word: string; reading: string; meaning: string; jlptLevel: number | null; jlptDerived: boolean; freqRank: number | null; pos: string[]; furiganaMap: { kanji: string; kana: string }[]; jmdictEntryId: string }>();
   const unique = [...new Set(ids.filter(Boolean))];
   if (unique.length === 0) return out;
 
@@ -432,7 +433,7 @@ function summarizeSenses(senses: JMDictResult['senses'], limit = 4): string {
 export function jmdictToWordDetails(
   word: string,
   result: JMDictResult
-): { reading: string; meaning: string; jmdictEntryId: string; pos: string[]; jlptLevel: number | null; jlptDerived: boolean; furiganaMap: { kanji: string; kana: string }[] } {
+): { reading: string; meaning: string; jmdictEntryId: string; pos: string[]; jlptLevel: number | null; jlptDerived: boolean; freqRank: number | null; furiganaMap: { kanji: string; kana: string }[] } {
   const reading = result.readings[0] || '';
   const meaning = summarizeSenses(result.senses);
   const pos = [...new Set(result.senses.flatMap(s => s.pos))];
@@ -451,6 +452,7 @@ export function jmdictToWordDetails(
     pos,
     jlptLevel,
     jlptDerived,
+    freqRank: result.freqRank ?? null,
     furiganaMap,
   };
 }
@@ -533,6 +535,58 @@ export async function fetchUnseenCommonWords(
     reading: r.reading || '',
     meaning: r.meaning || '',
     rank: r.rank,
+  }));
+}
+
+/**
+ * Fetch unseen-foundation intake candidates (#68): important common words at or
+ * BELOW the user's JLPT level that they have not yet tracked, ordered foundation-first
+ * (easiest level first, then most common). This is the "important words the user hasn't
+ * read yet" half of the intake queue — merged with locally-queued encountered words by
+ * store.promoteIntakeQueue before the daily cap picks the top few.
+ *
+ * Backed by the `get_intake_candidates` RPC (database/24): a sibling of
+ * get_unseen_common_words that scans all levels ≥ p_user_jlpt in one call, excludes
+ * already-tracked words by canonical entry_id (#39), and returns entry_id + level so a
+ * promoted word can be canonically keyed and ordered by compareIntake.
+ */
+export async function fetchIntakeCandidates(
+  userJlpt: number,
+  seenIds: string[],
+  limit = 50,
+): Promise<IntakeCandidate[]> {
+  let data: unknown;
+  let error: unknown;
+  try {
+    ({ data, error } = await withTimeout(
+      supabase.rpc('get_intake_candidates', {
+        p_user_jlpt: userJlpt,
+        p_seen_ids: seenIds,
+        p_limit: limit,
+      }),
+      LOOKUP_TIMEOUT_MS,
+      'get_intake_candidates',
+    ));
+  } catch (e) {
+    console.warn('get_intake_candidates timed out or failed:', e);
+    return [];
+  }
+  if (error || !data) return [];
+
+  return (data as Array<{
+    entry_id: string;
+    jlpt_level: number | null;
+    freq_rank: number | null;
+    word: string;
+    reading: string | null;
+    meaning: string | null;
+  }>).map((r) => ({
+    entryId: r.entry_id,
+    jlptLevel: r.jlpt_level ?? null,
+    freqRank: r.freq_rank ?? null,
+    word: r.word,
+    reading: r.reading || '',
+    meaning: r.meaning || '',
   }));
 }
 

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -4,6 +4,7 @@ import { rtkKanjiList } from '../data/rtkKanji';
 import { NewsArticle } from './api';
 import { supabase } from './supabase';
 import { schedule, ratingForReaderEvent, seedSrsFromDifficulty, type SrsState, type SrsStatus } from './srs';
+import { selectPromotions, type IntakeItem } from './intake';
 
 export type MasteryLevel = 'unseen' | 'hard' | 'medium' | 'easy';
 
@@ -46,6 +47,30 @@ export function seedDifficulty(jlptLevel: number | null | undefined, userLevel: 
   if (userLevel == null) return 5;      // unknown user level => neutral
   const delta = userLevel - jlptLevel;  // >0 => word harder than the user
   return clampDifficulty(6 + delta * 2);
+}
+
+// Promote a word from the intake queue into active FSRS scheduling (#68). Seeds an
+// initial schedule from `difficulty`, anchored at `now` (a freshly promoted word
+// becomes due ~one interval from promotion), and stamps it `active`. Pure: the caller
+// persists + syncs the returned record. Used by the daily promotion pass and by an
+// explicit manual mastery-set (the two paths that graduate a queued word).
+function activateWord(w: WordData, difficulty: number, now: number): WordData {
+  const srs = seedSrsFromDifficulty(difficulty, now);
+  return {
+    ...w,
+    difficulty,
+    mastery: bucketForDifficulty(difficulty),
+    intakeStatus: 'active',
+    promotedTs: now,
+    stability: srs.stability,
+    fsrsDifficulty: srs.fsrsDifficulty,
+    dueAt: srs.dueAt,
+    lastReviewedTs: srs.lastReviewedAt,
+    intervalDays: (srs.dueAt - srs.lastReviewedAt) / 86_400_000,
+    reps: srs.reps,
+    lapses: srs.lapses,
+    srsStatus: srs.status,
+  };
 }
 
 /**
@@ -143,6 +168,13 @@ export interface WordData {
   reps?: number | null;
   lapses?: number | null;
   srsStatus?: SrsStatus | null;
+  // Intake queue (#68). `queued` = encountered/candidate, exposure recorded but NOT on
+  // a schedule; `active` = promoted into FSRS scheduling. A word is promoted only by the
+  // daily new-word cap (foundation-first) or an explicit manual mastery-set. Undefined
+  // on legacy records until the v7 migration stamps them.
+  freqRank?: number | null;       // JMDict freq_rank (1 = most common); for compareIntake
+  intakeStatus?: 'queued' | 'active';
+  promotedTs?: number | null;     // ms epoch — when it entered active study
 }
 
 interface AppState {
@@ -156,6 +188,10 @@ interface AppState {
   // Target article length (paragraphs) by source fullness. Length follows how
   // much real source material the article was built from; JLPT drives complexity.
   targetParagraphs: { full: number; partial: number; snippet: number };
+  // Intake queue (#68): the Anki-style daily cap on how many new words graduate from
+  // the queue into active study, and when the last promotion pass ran (daily gate).
+  newWordsPerDay: number;
+  lastIntakePromotionTs: number | null;
 
   wordDatabase: Record<string, WordData>;
   studyKanji: string[];
@@ -177,6 +213,7 @@ interface AppState {
   setFuriganaMode: (mode: 'always' | 'never' | 'dynamic') => void;
   setReadingIntensity: (intensity: 'leisure' | 'balanced' | 'intensive') => void;
   setTargetParagraphs: (kind: 'full' | 'partial' | 'snippet', value: number) => void;
+  setNewWordsPerDay: (n: number) => void;
   setCurrentArticle: (article: NewsArticle | null) => void;
   saveProcessedArticle: (id: string, article: NewsArticle) => void;
   setArticlesCache: (cache: Record<string, NewsArticle>) => void;
@@ -194,6 +231,7 @@ interface AppState {
   setWordMastery: (word: string, level: MasteryLevel) => void;
   mergeWordRecords: (fromKey: string, toKey: string) => void;
   checkDailyKanji: () => void;
+  promoteIntakeQueue: (now: number) => Promise<void>;
   syncSrsWithSupabase: (userId: string) => Promise<void>;
   backfillWordProgress: () => Promise<void>;
 }
@@ -209,6 +247,8 @@ export const useAppStore = create<AppState>()(
       furiganaMode: 'dynamic',
       readingIntensity: 'balanced',
       targetParagraphs: { full: 5, partial: 4, snippet: 3 },
+      newWordsPerDay: 3,
+      lastIntakePromotionTs: null,
       wordDatabase: {},
       studyKanji: [],
       lastRtkUpdateTs: null,
@@ -265,6 +305,13 @@ export const useAppStore = create<AppState>()(
           if (uid) import('./api').then(m => m.upsertUserPreferences(uid, { [column]: v }));
         });
       },
+      setNewWordsPerDay: (n) => {
+        const v = Math.max(0, Math.min(50, Math.round(n)));
+        set({ newWordsPerDay: v });
+        currentUserId().then((uid) => {
+          if (uid) import('./api').then(m => m.upsertUserPreferences(uid, { new_words_per_day: v }));
+        });
+      },
 
       setFuriganaMode: (mode) => set({ furiganaMode: mode }),
       setCurrentArticle: (article) => set({ currentArticle: article }),
@@ -313,9 +360,10 @@ export const useAppStore = create<AppState>()(
           isOnboarded: false, 
           jlptLevel: null, 
           rtkLevel: null, 
-          wordDatabase: {}, 
-          studyKanji: [], 
-          lastRtkUpdateTs: null 
+          wordDatabase: {},
+          studyKanji: [],
+          lastRtkUpdateTs: null,
+          lastIntakePromotionTs: null,
         });
         
         // Wipe Supabase data
@@ -334,7 +382,8 @@ export const useAppStore = create<AppState>()(
       
       saveWordDefinition: (word, def) =>
         set((state) => {
-          const current = state.wordDatabase[word] || { reading: '', meaning: '', mastery: 'unseen', timesSeen: 0, uniqueDaysSeen: [], lastSeenTs: 0 };
+          // New words enter the intake queue (#68) — 'queued', not yet scheduled.
+          const current = state.wordDatabase[word] || { reading: '', meaning: '', mastery: 'unseen', timesSeen: 0, uniqueDaysSeen: [], lastSeenTs: 0, intakeStatus: 'queued' as const };
           // Strip undefined values so partial saves don't erase cached fields (e.g. grammarNote)
           const cleanDef = Object.fromEntries(Object.entries(def).filter(([, v]) => v !== undefined));
           return {
@@ -365,8 +414,10 @@ export const useAppStore = create<AppState>()(
       recordWordSeen: (word: string, withoutLookup = false) => 
         set((state) => {
           const today = new Date().toISOString().split('T')[0];
-          const current = state.wordDatabase[word] || { reading: '', meaning: '', mastery: 'unseen', timesSeen: 0, uniqueDaysSeen: [], lastSeenTs: 0, streak: 0 };
-          const newDays = current.uniqueDaysSeen.includes(today) 
+          // A word first met while reading enters the intake queue (#68) as 'queued':
+          // exposure is recorded here, but it waits for daily promotion before scheduling.
+          const current = state.wordDatabase[word] || { reading: '', meaning: '', mastery: 'unseen', timesSeen: 0, uniqueDaysSeen: [], lastSeenTs: 0, streak: 0, intakeStatus: 'queued' as const };
+          const newDays = current.uniqueDaysSeen.includes(today)
             ? current.uniqueDaysSeen 
             : [...current.uniqueDaysSeen, today];
             
@@ -420,6 +471,14 @@ export const useAppStore = create<AppState>()(
         set((state) => {
           const current = state.wordDatabase[word];
           if (!current) return {}; // word must be saved first
+
+          // Intake gate (#68): a queued word is not yet on a schedule. Reading past it
+          // or looking it up records exposure (recordWordSeen, fired separately) but
+          // does NOT grade or schedule it — it waits for daily promotion, foundation-
+          // first. Only `active` words advance. (A stability-bearing legacy row with no
+          // intake_status is treated as active so grandfathered schedules still tick.)
+          const isActive = current.intakeStatus === 'active' || current.stability != null;
+          if (!isActive) return {};
 
           const today = new Date().toISOString().split('T')[0];
           if (current.lastAdjustedDay === today) {
@@ -531,23 +590,44 @@ export const useAppStore = create<AppState>()(
       // prevents passive sees later that day from overriding the user's call.
       setWordMastery: (word: string, level: MasteryLevel) =>
         set((state) => {
-          const current = state.wordDatabase[word] || { reading: '', meaning: '', mastery: 'unseen', timesSeen: 0, uniqueDaysSeen: [], lastSeenTs: 0, streak: 0 };
+          const current = state.wordDatabase[word] || { reading: '', meaning: '', mastery: 'unseen', timesSeen: 0, uniqueDaysSeen: [], lastSeenTs: 0, streak: 0, intakeStatus: 'queued' as const };
           const today = new Date().toISOString().split('T')[0];
+          const now = Date.now();
           const difficulty = level === 'unseen' ? null : difficultyForBucket(level);
-          const updatedWord: WordData = { ...current, mastery: level, difficulty, lastAdjustedDay: today, lastAdjustReason: 'manual' };
+
+          // Explicit manual classification promotes a queued word into active study
+          // (#68, D3): opening the modal and declaring a word's difficulty is a direct
+          // statement of knowledge — unlike a passive read or a lookup, which only
+          // signal "I don't know it" and never fast-track promotion. Setting 'unseen'
+          // is not a promotion. Seeds the schedule from the chosen difficulty.
+          const shouldActivate = difficulty != null && current.intakeStatus !== 'active' && current.stability == null;
+          const base = shouldActivate ? activateWord(current, difficulty, now) : current;
+          const updatedWord: WordData = { ...base, mastery: level, difficulty, lastAdjustedDay: today, lastAdjustReason: 'manual' };
 
           // Sync to Supabase
           currentUserId().then((uid) => {
             if (uid && updatedWord.jmdictEntryId) {
               import('./api').then(m => {
-                const syncData = {
+                m.upsertWordProgressToSupabase(uid, updatedWord.jmdictEntryId!, {
                   mastery: updatedWord.mastery,
                   difficulty,
                   timesSeen: updatedWord.timesSeen,
                   streak: updatedWord.streak,
-                  lastSeenTs: updatedWord.lastSeenTs
-                };
-                m.upsertWordProgressToSupabase(uid, updatedWord.jmdictEntryId!, syncData);
+                  lastSeenTs: updatedWord.lastSeenTs,
+                  // On promotion, persist the freshly-seeded schedule + intake status.
+                  ...(shouldActivate ? {
+                    intakeStatus: 'active',
+                    promotedTs: updatedWord.promotedTs,
+                    stability: updatedWord.stability,
+                    fsrsDifficulty: updatedWord.fsrsDifficulty,
+                    dueAt: updatedWord.dueAt,
+                    lastReviewedTs: updatedWord.lastReviewedTs,
+                    intervalDays: updatedWord.intervalDays,
+                    reps: updatedWord.reps,
+                    lapses: updatedWord.lapses,
+                    srsStatus: updatedWord.srsStatus,
+                  } : {}),
+                });
                 m.logStudyEventToSupabase(uid, updatedWord.jmdictEntryId!, 'mastery_change', { level, difficulty });
               });
             }
@@ -579,6 +659,7 @@ export const useAppStore = create<AppState>()(
               partial: remotePrefs.target_paragraphs_partial ?? state.targetParagraphs.partial,
               snippet: remotePrefs.target_paragraphs_snippet ?? state.targetParagraphs.snippet,
             },
+            newWordsPerDay: remotePrefs.new_words_per_day ?? state.newWordsPerDay,
           }));
         }
 
@@ -740,8 +821,12 @@ export const useAppStore = create<AppState>()(
 
             // 2. Seed a difficulty for seen-but-ungraded words → out of "Ungraded".
             //    Treat the past encounter as a read-past 'skip' (seed - 1), matching
-            //    first contact in applyDifficultyEvent.
-            if (next.difficulty == null && current.timesSeen >= 1) {
+            //    first contact in applyDifficultyEvent. Post-#68 this only applies to
+            //    ACTIVE words: a queued word is intentionally ungraded (it waits for
+            //    daily promotion), so backfill must not grade it on sight and re-open
+            //    the every-word-on-sight floodgate the intake queue exists to close.
+            const isActive = next.intakeStatus === 'active' || next.stability != null;
+            if (isActive && next.difficulty == null && current.timesSeen >= 1) {
               next.difficulty = clampDifficulty(seedDifficulty(next.jlptLevel ?? null, state.jlptLevel) - 1);
               next.mastery = bucketForDifficulty(next.difficulty);
               next.lastAdjustReason = 'skip';
@@ -795,11 +880,130 @@ export const useAppStore = create<AppState>()(
             lastRtkUpdateTs: now
           });
         }
+      },
+
+      // Daily intake promotion (#68). Graduates up to `newWordsPerDay` words from the
+      // intake queue into active FSRS scheduling, foundation-first (easiest level first,
+      // then most common). The queue draws from TWO sources — words the user has met
+      // while reading (local 'queued' records) and important common words at/below their
+      // level they haven't read yet (the get_intake_candidates RPC) — so the common
+      // backbone gets built even when articles skip it. Gated to once per 24h, mirroring
+      // checkDailyKanji; call it on app open alongside that pass.
+      promoteIntakeQueue: async (now: number) => {
+        const state = get();
+        if (state.lastIntakePromotionTs && now - state.lastIntakePromotionTs < 86400000) return;
+        // Stamp immediately so a re-entrant call (e.g. a double mount) can't double-promote.
+        set({ lastIntakePromotionTs: now });
+
+        const cap = state.newWordsPerDay ?? 3;
+        if (cap <= 0) return; // 0 = new words paused
+
+        // Source 1: words already encountered and waiting in the local queue.
+        const queuedItems: IntakeItem[] = Object.entries(state.wordDatabase)
+          .filter(([, w]) => w.intakeStatus === 'queued')
+          .map(([key, w]) => ({
+            key,
+            entryId: w.jmdictEntryId ?? key,
+            jlptLevel: w.jlptLevel ?? null,
+            freqRank: w.freqRank ?? null,
+            timesSeen: w.timesSeen ?? 0,
+          }));
+
+        // Source 2: important unseen-foundation words (virtual, server-sourced). Needs a
+        // session + a known level; skipped in dev/no-auth (queue then = local words only).
+        let candidateItems: IntakeItem[] = [];
+        const uid = await currentUserId();
+        const userJlpt = state.jlptLevel;
+        if (uid && userJlpt != null) {
+          try {
+            const seenIds = Object.values(get().wordDatabase)
+              .map((w) => w.jmdictEntryId)
+              .filter((id): id is string => !!id);
+            const { fetchIntakeCandidates } = await import('./jmdict');
+            const cands = await fetchIntakeCandidates(userJlpt, seenIds, cap + 20);
+            candidateItems = cands.map((c) => ({
+              key: null,
+              entryId: c.entryId,
+              jlptLevel: c.jlptLevel,
+              freqRank: c.freqRank,
+              timesSeen: 0,
+              candidate: c,
+            }));
+          } catch (e) {
+            console.warn('[store] intake candidate fetch failed:', e);
+          }
+        }
+
+        const winners = selectPromotions(queuedItems, candidateItems, cap);
+        if (winners.length === 0) return;
+
+        const toSync: WordData[] = [];
+        set((s) => {
+          const db = { ...s.wordDatabase };
+          for (const win of winners) {
+            let key: string;
+            let record: WordData;
+            if (win.key != null && db[win.key]) {
+              key = win.key;
+              record = db[key];
+            } else if (win.candidate) {
+              // Materialise a virtual unseen-foundation word, keyed by entry_id (#39).
+              key = win.entryId;
+              record = db[key] ?? {
+                reading: win.candidate.reading,
+                meaning: win.candidate.meaning,
+                surface: win.candidate.word,
+                jmdictEntryId: win.candidate.entryId,
+                jlptLevel: win.candidate.jlptLevel,
+                freqRank: win.candidate.freqRank,
+                mastery: 'unseen',
+                timesSeen: 0,
+                uniqueDaysSeen: [],
+                lastSeenTs: 0,
+                streak: 0,
+                intakeStatus: 'queued',
+              };
+            } else {
+              continue;
+            }
+            if (record.intakeStatus === 'active') continue; // already promoted; skip
+            const difficulty = record.difficulty ?? clampDifficulty(seedDifficulty(record.jlptLevel ?? null, s.jlptLevel));
+            const activated = activateWord(record, difficulty, now);
+            db[key] = activated;
+            toSync.push(activated);
+          }
+          return { wordDatabase: db };
+        });
+
+        // Persist promotions (schedule + intake status). Best-effort per row.
+        if (uid && toSync.length > 0) {
+          const { upsertWordProgressToSupabase } = await import('./api');
+          for (const w of toSync) {
+            if (!w.jmdictEntryId) continue;
+            upsertWordProgressToSupabase(uid, w.jmdictEntryId, {
+              mastery: w.mastery,
+              difficulty: w.difficulty ?? null,
+              timesSeen: w.timesSeen,
+              streak: w.streak,
+              lastSeenTs: w.lastSeenTs || now,
+              intakeStatus: 'active',
+              promotedTs: w.promotedTs,
+              stability: w.stability,
+              fsrsDifficulty: w.fsrsDifficulty,
+              dueAt: w.dueAt,
+              lastReviewedTs: w.lastReviewedTs,
+              intervalDays: w.intervalDays,
+              reps: w.reps,
+              lapses: w.lapses,
+              srsStatus: w.srsStatus,
+            }).catch(() => { /* best-effort */ });
+          }
+        }
       }
     }),
     {
       name: 'yugen-storage',
-      version: 6,
+      version: 7,
       // A persist write throws QuotaExceededError once localStorage fills up. That
       // exception used to propagate out of store actions (markArticleRead,
       // recordWordSeen, ...) and abort the tap handler — silently breaking article
@@ -832,6 +1036,8 @@ export const useAppStore = create<AppState>()(
         furiganaMode: state.furiganaMode,
         readingIntensity: state.readingIntensity,
         targetParagraphs: state.targetParagraphs,
+        newWordsPerDay: state.newWordsPerDay,
+        lastIntakePromotionTs: state.lastIntakePromotionTs,
         wordDatabase: state.wordDatabase,
         studyKanji: state.studyKanji,
         lastRtkUpdateTs: state.lastRtkUpdateTs,
@@ -930,6 +1136,22 @@ export const useAppStore = create<AppState>()(
               lapses: s.lapses,
               srsStatus: s.status,
             };
+          });
+          state = { ...state, wordDatabase };
+        }
+        // v7: intake queue (#68). Grandfather (D2) — stamp every existing word's
+        // intake_status so today's graded-on-sight words keep their schedule: a word
+        // already scheduled/graded is 'active'; an ungraded one becomes 'queued' (it
+        // now waits for daily promotion instead of being graded on next read). Mirrors
+        // the SQL backfill in database/24_intake_queue.sql. Non-destructive: no
+        // schedules touched. New words created after this migration default to 'queued'.
+        if (version < 7 && state?.wordDatabase) {
+          const wordDatabase = { ...state.wordDatabase };
+          Object.keys(wordDatabase).forEach((key) => {
+            const w = wordDatabase[key];
+            if (!w || w.intakeStatus) return;
+            const active = w.stability != null || w.difficulty != null;
+            wordDatabase[key] = { ...w, intakeStatus: active ? 'active' : 'queued' };
           });
           state = { ...state, wordDatabase };
         }

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -321,6 +321,10 @@ Deno.serve(async (req) => {
         .select('word_id, mastery_level, difficulty, times_seen, last_seen_at')
         .eq('user_id', userId)
         .in('mastery_level', ['hard', 'medium'])
+        // Intake gate (#68): never surface a word that's still queued (waiting for daily
+        // promotion) as a review target. `is null` keeps pre-migration rows eligible, so
+        // this is safe to deploy before database/24 is applied by hand.
+        .or('intake_status.is.null,intake_status.eq.active')
         .limit(200);
       const stuckSignals: WordSignal[] = (stuckRows as any[] ?? []).map((r) => ({
         entryId: r.word_id,


### PR DESCRIPTION
Closes #68. Phase D, second half of the Word Mastery Loop — the intake queue that gates words into the FSRS engine (#67).

## What & why
Today the app grades **every** dictionary-linked word on sight (seeds difficulty + a full FSRS schedule on first read), which floods a new/returning user with hundreds of "active" words. This PR adds a **foundation-first intake queue**: encountered words *wait* (exposure recorded, no schedule) until a **daily new-word cap** promotes the top few — lowest JLPT level first, most-common-in-normal-text first.

The queue draws from **two sources** (per review feedback): words the user has met while reading **and** important common words at/below their level they haven't read yet (`get_intake_candidates` RPC) — so the common backbone gets built even when articles skip it.

## Key behavior changes
- **Intake gate** (`store.ts`): first contact no longer grades/schedules. New words enter as `intake_status='queued'`; only the daily cap (or an explicit manual mastery-set) promotes into FSRS scheduling.
- **No lookup fast-track** (D3b): a lookup on a queued word signals "I don't know it", not intent to learn — it records exposure and stays queued.
- **Daily cap default 3/day**, configurable 0–50 in Settings (0 = pause).
- **Grandfather** (D2): existing scheduled/graded words are stamped `active` — no schedules yanked. Only words seen *after* this PR flow through the gate.

## Changes
- `database/24_intake_queue.sql` — columns + grandfather backfill, `new_words_per_day` pref, `get_intake_candidates` RPC (**applied by hand ✅**)
- `src/services/intake.ts` — pure foundation-first selection (`compareIntakeItem`, `selectPromotions`)
- `store.ts` — intake gate, `promoteIntakeQueue` daily pass (runs after sync on app open), v6→v7 grandfather migration, `newWordsPerDay` pref; `freqRank` threaded through enrichment for ordering
- `process-article` — `intake_status='active' OR is null` guard on the review floor (deploy-safe before the migration)
- `Settings.tsx` — "New Words Per Day" stepper

## Testing
- `npm run test:intake` — 14/14 (foundation-first ordering, cap, unseen-foundation source, dedupe)
- `npm run test:srs` — 18/18 (regression)
- `npm run build` clean (tsc + vite); **zero new lint errors** (55 pre-existing problems on both `main` and this branch)

## Notes
- Design + decisions: `docs/intake-queue-design-68.md`
- The *visible* payoff (a due deck) arrives with **#70** — promoted `active` words currently feed the article review palette and advance on reading, which is the intended #68 foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)