### PR TITLE
feat: flashcard study UI wired to the FSRS engine (#70)

### DIFF
--- a/docs/flashcard-ui-design-70.md
+++ b/docs/flashcard-ui-design-70.md
@@ -1,0 +1,104 @@
+# #70 — Flashcard study UI (Phase E)
+
+**Goal:** A zen-minimalist flashcard deck that lets the user study *due* words on a real schedule. Each **Again / Hard / Good / Easy** rating reschedules the word through the FSRS engine (#67) and writes a `srs_review_log` row — closing the last leg of the Word Mastery Loop (read ⇄ schedule ⇄ **deck** ⇄ article selection).
+
+Part of [`word-mastery-loop-plan.md`](./word-mastery-loop-plan.md) Phase E. Depends on #67 (FSRS engine) + #68 (intake queue), both shipped.
+
+---
+
+## What already exists (so #70 is small)
+
+The engine was built to be flashcard-ready. **No DB migration is needed:**
+
+- `src/services/srs.ts:schedule(state, rating, now)` — the pure scheduler. Ratings `1|2|3|4` map 1:1 to Again/Hard/Good/Easy. Deterministic (`enable_fuzz=false`, injected `now`), so we can *preview* the interval each button would assign by calling it four times.
+- `database/23_fsrs_scheduling.sql` — the `srs_review_log.source` check already whitelists **`'flashcard'`** alongside `reader_skip`/`reader_click`.
+- `src/services/api.ts:logSrsReviewToSupabase(...)` — already accepts `source: 'flashcard'`.
+- `WordData` already carries the full schedule (`stability`, `dueAt`, `srsStatus`, `reps`, …) and the intake status (`intakeStatus`, `promotedTs`).
+- `store.applyDifficultyEvent` is the exact template for the new rating action — it seeds `priorSrs`, calls `schedule()`, updates the word, and fires the upsert + review-log writes.
+
+So #70 is: **one pure deck-selector module, one store action, one component, three lines of tab wiring.**
+
+---
+
+## Deck source (the core question)
+
+The issue says *"Deck source = due today (engine) + new-word intake (queue)."* Concretely, a word is in today's deck if either:
+
+1. **Due review** — it's `active` and its schedule has come due: `dueAt != null && dueAt <= now`.
+2. **New card** — it was just promoted from the intake queue but never actually studied: `intakeStatus === 'active' && promotedTs != null && (reps ?? 0) === 0`.
+
+Why `reps === 0` for "new": `seedSrsFromDifficulty` seeds a promoted word with a *future* `dueAt` (an easy N5 word doesn't need studying today for *recall* purposes), so a freshly promoted word would never surface under rule 1 for days. But #68's daily cap **is** the "new cards today" limit (Anki-style) — a promoted word is meant to be studyable now. `reps === 0` cleanly means "the scheduler has never advanced this word" (reading or a prior flashcard both bump `reps`), and `promotedTs != null` excludes *grandfathered* known words (the #68 migration set `intake_status='active'` but left `promoted_at` null), so we don't dump a returning user's entire back-catalog into "new."
+
+`active` = `intakeStatus === 'active' || stability != null` (the same legacy-safe check the store already uses). **Queued words never appear** — they're not scheduled yet.
+
+### Ordering
+
+- **Due reviews first**, most-overdue first (`dueAt` ascending) — urgency.
+- **Then new cards, foundation-first** — easiest JLPT level first, then most common (`freqRank`). This is exactly `intake.ts:compareIntakeItem`, which is already pure and client-side, so the deck reuses it rather than re-deriving the order.
+
+**No session cap.** #68 already paces how many new words become active per day, and due reviews are whatever the schedule produced. Capping again would hide genuinely-due work. (Anki caps *new*, not reviews; our new-cap lives upstream in #68.)
+
+The deck is snapshotted at mount (capture `now` once) so cards don't reshuffle underfoot as each rating reschedules them out.
+
+---
+
+## Rating → reschedule (the store action)
+
+New action `reviewWord(key, rating, now)`, modeled on `applyDifficultyEvent`:
+
+1. Build `priorSrs` from the stored schedule, or seed it from `difficulty` if the word somehow isn't scheduled yet (same fallback as the reader path).
+2. `const sched = schedule(priorSrs, rating, now)` → write `stability/fsrsDifficulty/dueAt/lastReviewedTs/intervalDays/reps/lapses/srsStatus` back onto the word.
+3. **Also nudge the coarse `difficulty`/`mastery`** — a flashcard is the strongest, most explicit difficulty signal we get. Map `Again +2, Hard +1, Good −1, Easy −2` (clamped 1–10), then `mastery = bucketForDifficulty(difficulty)`, so the Progress page reflects study. This mirrors how reader skip/click already nudge the coarse signal, and keeps the LLM palette (which reads `difficulty`) honest. *(See D3 — open for review.)*
+4. Sync: `upsertWordProgressToSupabase(...)` with the SRS + difficulty fields, and `logSrsReviewToSupabase(..., { rating, source: 'flashcard', stabilityBefore/After, difficultyBefore/After, scheduledDays, elapsedDays })`.
+5. Does **not** touch `lastAdjustedDay` (the reader's once-per-day passive-read dedup) — an explicit flashcard grade is intentional and independent of passive-read throttling.
+
+---
+
+## The component — `src/components/Flashcards.tsx`
+
+Zen-minimalist, matching the existing typography-first aesthetic (Shippori Mincho serif, no heavy chrome, existing CSS vars).
+
+- **Front:** the word only — kanji/surface, large serif, *no furigana* (that's the answer). A muted "tap to reveal" affordance.
+- **Reveal:** reading (kana) + meaning, plus the grammar note if present. Framer Motion cross-fade/flip (already a dep, used in `Feed.tsx`).
+- **Rating row (post-reveal):** **Again / Hard / Good / Easy**, each labeled with the interval that rating would assign (e.g. `Good · 4d`), computed by calling `schedule()` four times against the current card — Anki-style, and cheap since the scheduler is pure. On tap → `reviewWord` → advance.
+- **Header:** `n / total` progress + a thin progress bar.
+- **Empty / done states:** a calm "You're all caught up — nothing due today" (deck empty) and a "Deck complete" summary after the last card. No nagging.
+- Reads `wordDatabase` from the store; deck computed via `useMemo` on mount.
+
+---
+
+## Tab wiring (3 edits)
+
+- `src/App.tsx:20` — extend `activeTab` union to `'news' | 'progress' | 'settings' | 'flashcards'`; add `{activeTab === 'flashcards' && <Flashcards />}` to the content switch (App.tsx:653).
+- `src/components/BottomNav.tsx` — widen the `Props` union and add a `{ id: 'flashcards', label: 'STUDY', icon: Layers }` entry (lucide `Layers` = a deck). Four tabs at 80px fit the 600px max width.
+
+---
+
+## Pure module + test (established pattern)
+
+Following `intake.ts` + `scripts/test-intake.mjs`:
+
+- `src/services/deck.ts` — pure `selectDeck(entries, now)` returning ordered keys, plus `isDue` / `isNewCard` predicates. No store/clock/Supabase access.
+- `scripts/test-deck.mjs` + `package.json` `test:deck` — esbuild-bundle and assert: due-before-new ordering, most-overdue-first, foundation-first among new, queued excluded, grandfathered-known (promotedTs null, reps 0) excluded from "new", not-yet-due active excluded.
+
+---
+
+## Acceptance (from the issue)
+
+> A user can study a due deck; each rating reschedules the word and writes a review-log row.
+
+Verified by: `npm run test:deck` (green) + a browser pass (open the STUDY tab, rate a card, confirm it leaves the deck, `dueAt` moved, and a `flashcard` `srs_review_log` row was written).
+
+---
+
+## Open decisions (please review)
+
+**D1 — Deck membership = due ∪ new-unstudied?** Recommended as specced above. Alternative: due-only (simpler, but freshly-promoted words wouldn't appear for days — defeats "study new words").
+
+**D2 — Ordering: due-first, then new foundation-first, no session cap?** Recommended. Alternative: interleave new among reviews, or cap the session (rejected — #68 already paces new words).
+
+**D3 — Should a flashcard rating also nudge the coarse `difficulty`/`mastery`, or *only* the FSRS schedule?** Recommended: nudge (Again+2/Hard+1/Good−1/Easy−2), so Progress + the LLM palette reflect study. Alternative: FSRS-only (keeps the two difficulty signals fully separate, but then a word you keep failing on flashcards still looks "easy" to the article generator).
+
+**D4 — Front shows the word (kanji, no furigana); reveal shows reading + meaning (+ grammar)?** Recommended. This is recognition→recall (see the Japanese, produce the reading/meaning). Alternative: reverse (meaning→word) or a furigana toggle — deferrable.
+
+**D5 — Show the per-button next-interval preview (Anki-style)?** Recommended (cheap, pure). Alternative: hide it for a cleaner face.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test:srs": "node scripts/test-srs.mjs",
-    "test:intake": "node scripts/test-intake.mjs"
+    "test:intake": "node scripts/test-intake.mjs",
+    "test:deck": "node scripts/test-deck.mjs"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/scripts/test-deck.mjs
+++ b/scripts/test-deck.mjs
@@ -1,0 +1,126 @@
+/**
+ * Standalone test runner for the flashcard deck-selection logic (#70).
+ *
+ *   node scripts/test-deck.mjs
+ *
+ * No test framework (matches test-srs.mjs / test-intake.mjs): src/services/deck.ts
+ * is pure, so we bundle it with esbuild and assert on membership + ordering with
+ * fixed inputs. Exits non-zero on any failure.
+ *
+ * What it locks in:
+ *   • due reviews (dueAt <= now) come before new cards
+ *   • due reviews are ordered most-overdue-first
+ *   • new cards are ordered foundation-first (easiest level, then most common)
+ *   • queued words never appear
+ *   • grandfathered known words (promotedTs null, reps 0) are NOT "new"
+ *   • not-yet-due active words (future dueAt, reps>0) are excluded
+ *   • a word that is both due and new appears once, as a review
+ */
+import esbuild from 'esbuild';
+import { pathToFileURL } from 'node:url';
+import { rmSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+const TMP = path.join('scripts', '.tmp-deck-bundle.mjs');
+const NOW = 1_000_000_000_000; // fixed clock
+const DAY = 86_400_000;
+
+let passed = 0;
+let failed = 0;
+function check(name, cond, detail = '') {
+  if (cond) {
+    passed++;
+    console.log(`  \x1b[32m✓\x1b[0m ${name}`);
+  } else {
+    failed++;
+    console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? `  — ${detail}` : ''}`);
+  }
+}
+
+// Terse builders. Defaults describe a plain active, scheduled word.
+const entry = (key, over) => ({
+  key,
+  jlptLevel: 5,
+  freqRank: 1,
+  dueAt: NOW + DAY,     // not due by default
+  reps: 1,              // already studied by default
+  stability: 10,
+  intakeStatus: 'active',
+  promotedTs: null,
+  ...over,
+});
+// A due review: overdue by `days`.
+const due = (key, days, over) => entry(key, { dueAt: NOW - days * DAY, ...over });
+// A new card: promoted, never studied, seeded future due.
+const fresh = (key, over) => entry(key, { dueAt: NOW + 30 * DAY, reps: 0, promotedTs: NOW - DAY, ...over });
+
+async function main() {
+  mkdirSync('scripts', { recursive: true });
+  await esbuild.build({
+    entryPoints: ['src/services/deck.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    outfile: TMP,
+    logLevel: 'silent',
+  });
+  const { selectDeck, isDue, isNewCard } = await import(pathToFileURL(TMP).href);
+
+  console.log('\nmembership');
+  check('a due active word is due', isDue(due('d', 1), NOW));
+  check('a future-due active word is NOT due', !isDue(entry('f'), NOW));
+  check('a queued word is never due', !isDue(entry('q', { intakeStatus: 'queued', dueAt: NOW - DAY }), NOW));
+  check('a queued word is never new', !isNewCard(fresh('qn', { intakeStatus: 'queued' })));
+  check('a promoted unstudied word is new', isNewCard(fresh('n')));
+  check('a grandfathered known word (promotedTs null, reps 0) is NOT new',
+    !isNewCard(entry('g', { reps: 0, promotedTs: null })));
+  check('a promoted-but-studied word (reps>0) is NOT new', !isNewCard(fresh('s', { reps: 3 })));
+  check('a legacy stability-only row counts as active (due)',
+    isDue({ key: 'L', jlptLevel: 5, freqRank: 1, dueAt: NOW - DAY, reps: 1, stability: 8, promotedTs: null }, NOW));
+
+  console.log('\nselectDeck — reviews before new, each internally ordered');
+  const deck = selectDeck([
+    fresh('newN4', { jlptLevel: 4, freqRank: 1 }),
+    due('review2', 1),
+    fresh('newN5common', { jlptLevel: 5, freqRank: 1 }),
+    due('review1', 5),                 // most overdue
+    fresh('newN5rare', { jlptLevel: 5, freqRank: 500 }),
+    entry('notdue'),                   // future due, studied → excluded
+    entry('queued', { intakeStatus: 'queued', dueAt: NOW - DAY }), // excluded
+  ], NOW);
+  const order = deck.map((c) => c.key);
+  check('excludes not-due and queued words', deck.length === 5, order.join(','));
+  check('all reviews precede all new cards',
+    JSON.stringify(order) === JSON.stringify(['review1', 'review2', 'newN5common', 'newN5rare', 'newN4']),
+    order.join(','));
+  check('reviews are most-overdue-first', order.indexOf('review1') < order.indexOf('review2'));
+  check('new cards are foundation-first (N5-common < N5-rare < N4)',
+    order.indexOf('newN5common') < order.indexOf('newN5rare') &&
+    order.indexOf('newN5rare') < order.indexOf('newN4'));
+  check('every card is tagged with a kind',
+    deck.every((c) => c.kind === 'review' || c.kind === 'new'));
+
+  console.log('\nselectDeck — a word both due AND new counts once, as a review');
+  const dual = selectDeck([due('x', 2, { reps: 0, promotedTs: NOW - DAY })], NOW);
+  check('appears exactly once', dual.length === 1);
+  check('classified as a review (already scheduled + urgent)', dual[0].kind === 'review');
+
+  console.log('\nselectDeck — level-less words are excluded (un-enriched junk)');
+  const withJunk = selectDeck([
+    due('good', 2),
+    due('nolevel_due', 2, { jlptLevel: null }),   // due but no JLPT → excluded
+    fresh('nolevel_new', { jlptLevel: null }),      // new but no JLPT → excluded
+  ], NOW);
+  check('a due word with no JLPT is dropped', !withJunk.some((c) => c.key === 'nolevel_due'));
+  check('a new word with no JLPT is dropped', !withJunk.some((c) => c.key === 'nolevel_new'));
+  check('the JLPT-rated word survives', withJunk.length === 1 && withJunk[0].key === 'good');
+
+  console.log('\nselectDeck — empty deck when nothing is due or new');
+  check('all-future/studied → empty', selectDeck([entry('a'), entry('b')], NOW).length === 0);
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  try { rmSync(TMP); } catch { /* ignore */ }
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Onboarding } from './components/Onboarding'
 import { BottomNav } from './components/BottomNav'
 import { Settings } from './components/Settings'
 import { Progress } from './components/Progress'
+import { Flashcards } from './components/Flashcards'
 import { LandingPage } from './components/LandingPage'
 import { useAppStore } from './services/store'
 import { supabase } from './services/supabase'
@@ -17,7 +18,7 @@ if (DEV_MODE) console.log('%c🛠 DEV MODE ACTIVE', 'color: #4a5d23; font-weight
 function App() {
   const isOnboarded = useAppStore(state => state.isOnboarded);
   const checkDailyKanji = useAppStore(state => state.checkDailyKanji);
-  const [activeTab, setActiveTab] = useState<'news' | 'progress' | 'settings'>('news');
+  const [activeTab, setActiveTab] = useState<'news' | 'flashcards' | 'progress' | 'settings'>('news');
   const [showNav, setShowNav] = useState(true);
   const [session, setSession] = useState<any>(null);
   const [isInitializing, setIsInitializing] = useState(true);
@@ -650,6 +651,7 @@ function App() {
             <Reader key={activeArticle?.id} initialArticle={activeArticle} onComplete={handleFinishArticle} />
           )
         )}
+        {activeTab === 'flashcards' && <Flashcards />}
         {activeTab === 'progress' && <Progress />}
         {activeTab === 'settings' && <Settings />}
       </main>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,14 +1,17 @@
-import { Newspaper, BarChart2, Settings } from 'lucide-react';
+import { Newspaper, Layers, BarChart2, Settings } from 'lucide-react';
+
+type Tab = 'news' | 'flashcards' | 'progress' | 'settings';
 
 interface Props {
-  activeTab: 'news' | 'progress' | 'settings';
-  onChange: (tab: 'news' | 'progress' | 'settings') => void;
+  activeTab: Tab;
+  onChange: (tab: Tab) => void;
   isVisible?: boolean;
 }
 
 export function BottomNav({ activeTab, onChange, isVisible = true }: Props) {
   const tabs = [
     { id: 'news', label: 'NEWS', icon: Newspaper },
+    { id: 'flashcards', label: 'STUDY', icon: Layers },
     { id: 'progress', label: 'PROGRESS', icon: BarChart2 },
     { id: 'settings', label: 'SETTINGS', icon: Settings }
   ] as const;

--- a/src/components/Flashcards.tsx
+++ b/src/components/Flashcards.tsx
@@ -1,0 +1,339 @@
+import { useMemo, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ChevronDown } from 'lucide-react';
+import { useAppStore, WordData } from '../services/store';
+import { selectDeck, DeckEntry } from '../services/deck';
+import { schedule, seedSrsFromDifficulty, type Rating, type SrsState } from '../services/srs';
+import { seedDemoDeck } from '../services/devSeed';
+
+const DEV_MODE = import.meta.env.VITE_DEV_MODE === 'true';
+
+// Flashcard study UI (#70) — the deck view for the Word Mastery Loop. Reads the due
+// deck from the store (selectDeck), shows a zen front/reveal card, and each
+// Again/Hard/Good/Easy grade calls store.reviewWord → advances the FSRS schedule
+// (#67) and writes a `flashcard` review-log row. The deck is SNAPSHOTTED at mount
+// (tab open) so grading a card doesn't reshuffle the pile underfoot.
+
+const RATINGS: { rating: Rating; label: string; bg: string }[] = [
+  { rating: 1, label: 'Again', bg: 'var(--accent-danger)' },
+  { rating: 2, label: 'Hard', bg: '#efe4cb' },
+  { rating: 3, label: 'Good', bg: 'var(--accent-primary)' },
+  { rating: 4, label: 'Easy', bg: 'var(--accent-success)' },
+];
+
+// A card carries the full word plus which source (due review / new) put it here.
+interface Card {
+  key: string;
+  word: WordData;
+  kind: 'review' | 'new';
+}
+
+// Prior FSRS state for a word, or a seed from `difficulty` if it isn't scheduled
+// yet — mirrors store.reviewWord so the per-button interval preview matches what a
+// grade will actually assign.
+function priorSrsFor(w: WordData, now: number): SrsState {
+  const baseDifficulty = w.difficulty ?? 5;
+  return w.stability != null && w.dueAt != null
+    ? {
+        stability: w.stability,
+        fsrsDifficulty: w.fsrsDifficulty ?? baseDifficulty,
+        dueAt: w.dueAt,
+        lastReviewedAt: w.lastReviewedTs ?? w.lastSeenTs ?? now,
+        reps: w.reps ?? 0,
+        lapses: w.lapses ?? 0,
+        status: (w.srsStatus ?? 'review') as SrsState['status'],
+      }
+    : seedSrsFromDifficulty(baseDifficulty, w.lastSeenTs ?? now);
+}
+
+// Snapshot the current due deck from the store: map every word to a DeckEntry,
+// run selectDeck, and rehydrate each surviving key back to its full WordData.
+function buildDeck(): Card[] {
+  const db = useAppStore.getState().wordDatabase;
+  const now = Date.now();
+  const entries: DeckEntry[] = Object.entries(db).map(([key, w]) => ({
+    key,
+    jlptLevel: w.jlptLevel ?? null,
+    freqRank: w.freqRank ?? null,
+    dueAt: w.dueAt ?? null,
+    reps: w.reps ?? null,
+    stability: w.stability ?? null,
+    intakeStatus: w.intakeStatus,
+    promotedTs: w.promotedTs ?? null,
+  }));
+  return selectDeck(entries, now).map((c) => ({ key: c.key, word: db[c.key], kind: c.kind }));
+}
+
+// Human-friendly interval label, Anki-style ("10m" / "3d" / "2mo" / "1.4y").
+function formatInterval(days: number): string {
+  if (days < 1) {
+    const mins = Math.max(1, Math.round(days * 24 * 60));
+    return mins < 60 ? `${mins}m` : `${Math.round(days * 24)}h`;
+  }
+  if (days < 30) return `${Math.round(days)}d`;
+  if (days < 365) return `${Math.round(days / 30)}mo`;
+  return `${(days / 365).toFixed(1)}y`;
+}
+
+export function Flashcards() {
+  const reviewWord = useAppStore((s) => s.reviewWord);
+
+  // Snapshot the deck once, at mount. Flashcards mounts when the tab opens, so this
+  // is "the deck as of opening STUDY" and stays stable while the user works through it.
+  const [cards, setCards] = useState<Card[]>(buildDeck);
+
+  const [index, setIndex] = useState(0);
+  const [revealed, setRevealed] = useState(false);
+
+  // Dev-only: seed a demo deck, then rebuild the snapshot in place (no reload).
+  function seedAndReload() {
+    seedDemoDeck();
+    setCards(buildDeck());
+    setIndex(0);
+    setRevealed(false);
+  }
+  const total = cards.length;
+  const card = cards[index];
+
+  // Interval each rating would assign, previewed against the current card's schedule.
+  const previews = useMemo(() => {
+    if (!card) return {} as Record<Rating, string>;
+    const now = Date.now();
+    const prior = priorSrsFor(card.word, now);
+    const out = {} as Record<Rating, string>;
+    for (const { rating } of RATINGS) out[rating] = formatInterval(schedule(prior, rating, now).intervalDays);
+    return out;
+  }, [card]);
+
+  function grade(rating: Rating) {
+    if (!card) return;
+    reviewWord(card.key, rating, Date.now());
+    setRevealed(false);
+    setIndex((i) => i + 1);
+  }
+
+  // ── Empty deck ──────────────────────────────────────────────────────────
+  if (total === 0) {
+    return (
+      <Centered>
+        <p className="serif" style={{ fontSize: '1.5rem', color: 'var(--text-main)', marginBottom: '0.5rem' }}>
+          何もありません
+        </p>
+        <p style={{ color: 'var(--text-muted)', fontSize: '0.9rem' }}>
+          You're all caught up — nothing due today.
+        </p>
+        {DEV_MODE && (
+          <button
+            onClick={seedAndReload}
+            style={{
+              marginTop: '1.5rem',
+              padding: '0.5rem 1rem',
+              border: '1px dashed var(--border-light)',
+              borderRadius: '10px',
+              background: 'none',
+              color: 'var(--text-muted)',
+              fontSize: '0.75rem',
+              letterSpacing: '0.04em',
+              cursor: 'pointer',
+            }}
+          >
+            🛠 Seed demo deck
+          </button>
+        )}
+      </Centered>
+    );
+  }
+
+  // ── Deck complete ───────────────────────────────────────────────────────
+  if (index >= total) {
+    return (
+      <Centered>
+        <p className="serif" style={{ fontSize: '1.5rem', color: 'var(--text-main)', marginBottom: '0.5rem' }}>
+          お疲れさま
+        </p>
+        <p style={{ color: 'var(--text-muted)', fontSize: '0.9rem' }}>
+          Deck complete — {total} {total === 1 ? 'card' : 'cards'} reviewed.
+        </p>
+      </Centered>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '70vh', paddingTop: '0.5rem' }}>
+      {/* Progress */}
+      <div style={{ marginBottom: '1.5rem' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '0.4rem' }}>
+          <span style={{ fontSize: '0.7rem', letterSpacing: '0.08em', color: 'var(--text-muted)', textTransform: 'uppercase' }}>
+            {card.kind === 'new' ? 'New' : 'Review'}
+          </span>
+          <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>{index + 1} / {total}</span>
+        </div>
+        <div style={{ height: '3px', backgroundColor: 'var(--border-light)', borderRadius: '2px', overflow: 'hidden' }}>
+          <motion.div
+            style={{ height: '100%', backgroundColor: 'var(--accent-progress)' }}
+            initial={false}
+            animate={{ width: `${(index / total) * 100}%` }}
+            transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+          />
+        </div>
+      </div>
+
+      {/* Card */}
+      <div
+        onClick={() => !revealed && setRevealed(true)}
+        style={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          textAlign: 'center',
+          cursor: revealed ? 'default' : 'pointer',
+          padding: '1rem',
+        }}
+      >
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={card.key}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -12 }}
+            transition={{ duration: 0.25 }}
+            style={{ width: '100%' }}
+          >
+            {/* Word with furigana above each kanji — hidden until reveal (like the lookup modal). */}
+            <FuriganaWord word={card.word} reveal={revealed} />
+
+            <AnimatePresence>
+              {revealed ? (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: 'auto' }}
+                  transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+                  style={{ overflow: 'hidden' }}
+                >
+                  <div style={{ fontSize: '1.1rem', color: 'var(--text-main)', marginTop: '1.25rem', lineHeight: 1.6, maxWidth: '32ch', marginInline: 'auto' }}>
+                    {card.word.meaning}
+                  </div>
+                  {card.word.grammarNote && (
+                    <div style={{ fontSize: '0.85rem', color: 'var(--text-muted)', marginTop: '1rem', lineHeight: 1.6, maxWidth: '34ch', marginInline: 'auto' }}>
+                      {card.word.grammarNote}
+                    </div>
+                  )}
+                </motion.div>
+              ) : (
+                <motion.div
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 0.4 }}
+                  exit={{ opacity: 0 }}
+                  style={{ marginTop: '2rem', display: 'flex', justifyContent: 'center', color: 'var(--text-muted)' }}
+                >
+                  <ChevronDown size={22} strokeWidth={1.5} />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </motion.div>
+        </AnimatePresence>
+      </div>
+
+      {/* Rating row */}
+      <div style={{ minHeight: '4.5rem', marginTop: '1rem', marginBottom: '1rem' }}>
+        <AnimatePresence>
+          {revealed && (
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.25 }}
+              style={{ display: 'flex', gap: '0.5rem' }}
+            >
+              {RATINGS.map(({ rating, label, bg }) => (
+                <button
+                  key={rating}
+                  onClick={() => grade(rating)}
+                  style={{
+                    flex: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: '0.2rem',
+                    padding: '0.75rem 0.25rem',
+                    border: 'none',
+                    borderRadius: '12px',
+                    backgroundColor: bg,
+                    color: 'var(--text-main)',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <span style={{ fontSize: '0.85rem', fontWeight: 600 }}>{label}</span>
+                  <span style={{ fontSize: '0.7rem', color: 'var(--text-muted)' }}>{previews[rating]}</span>
+                </button>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}
+
+// Furigana segments for the card face. Prefers the word's `furiganaMap` (per-kanji
+// readings from enrichment), heals a map that doesn't cover the whole surface, and
+// falls back to one reading over the whole word — mirroring WordModal so the deck
+// and the lookup modal position furigana the same way.
+function furiganaSegments(w: WordData): { kanji: string; kana: string }[] {
+  const surface = w.surface || w.reading || '';
+  let segments = w.furiganaMap ?? [];
+  const mapped = segments.map((s) => s.kanji).join('');
+  if (mapped !== surface && surface.startsWith(mapped)) {
+    const tail = Array.from(surface.slice(mapped.length)).map((c) => ({ kanji: c, kana: c }));
+    segments = [...segments, ...tail];
+  }
+  if (segments.length > 0) return segments;
+  // No map: one reading over the whole surface (kana shown above the run).
+  return [{ kanji: surface, kana: w.reading || surface }];
+}
+
+// Renders the word with furigana positioned above each kanji (like the lookup
+// modal). The ruby row's height is reserved even when hidden, so revealing the
+// reading doesn't shift the kanji — it just fades in above them.
+function FuriganaWord({ word, reveal }: { word: WordData; reveal: boolean }) {
+  const segments = furiganaSegments(word);
+  return (
+    <div translate="no" style={{ display: 'inline-flex', gap: '0.12em', alignItems: 'flex-end', justifyContent: 'center' }}>
+      {segments.map((s, i) => {
+        const isKana = s.kanji === s.kana; // pure-kana run: nothing to annotate
+        return (
+          <span key={i} style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center' }}>
+            <span
+              style={{
+                height: '1.3rem',
+                fontSize: '1.05rem',
+                lineHeight: 1,
+                color: 'var(--text-muted)',
+                fontFamily: 'var(--font-sans)',
+                fontWeight: 700,
+                letterSpacing: '0.02em',
+                opacity: reveal && !isKana ? 1 : 0,
+                transition: 'opacity 0.3s ease',
+              }}
+            >
+              {s.kana}
+            </span>
+            <span className="serif" style={{ fontSize: '3rem', lineHeight: 1.1, color: 'var(--text-main)' }}>
+              {s.kanji}
+            </span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+// Shared centered layout for the empty / complete states.
+function Centered({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', minHeight: '60vh' }}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -262,7 +262,7 @@ export function Progress() {
               style={{
                 height: '100%',
                 width: `${Math.max(coveragePct, 1.5)}%`,
-                backgroundColor: 'var(--accent-primary)',
+                backgroundColor: 'var(--accent-progress)',
                 borderRadius: '100px',
               }}
             />

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,7 @@
   --accent-primary: #d4e0e8; /* Soft blue */
   --accent-success: #dee5d5; /* Soft green */
   --accent-danger: #fde2da; /* Soft red / coral */
+  --accent-progress: #8fb0c4; /* Muted slate blue — legible on the pale track without shouting */
   --border-light: #e0e0d8;
 
   --font-serif: 'Shippori Mincho', serif;

--- a/src/services/deck.ts
+++ b/src/services/deck.ts
@@ -1,0 +1,120 @@
+// Flashcard deck selection (#70) — the pure "what do I study now" logic.
+//
+// The deck draws from two sources (see docs/flashcard-ui-design-70.md, D1):
+//   1. Due reviews — active words whose FSRS schedule (#67) has come due
+//      (dueAt <= now). Ordered most-overdue first.
+//   2. New cards — words just promoted from the intake queue (#68) but never
+//      actually studied (promotedTs set, reps still 0). A freshly promoted word
+//      is seeded with a FUTURE dueAt, so it would never surface as a "due review"
+//      for days; but #68's daily cap IS the Anki-style "new cards today" limit, so
+//      a promoted word is meant to be studyable now. Ordered foundation-first.
+//
+// `reps === 0` means the scheduler has never advanced this word (a read-past or a
+// prior flashcard both bump reps), and `promotedTs != null` excludes grandfathered
+// known words (the #68 migration set intake_status='active' but left promoted_at
+// null), so a returning user's whole back-catalog doesn't land in "new".
+//
+// Queued words never appear — they aren't scheduled yet.
+//
+// This module is intentionally pure (no store/Supabase/clock access) so the deck
+// ordering is unit-testable with a standalone runner, mirroring intake.ts / srs.ts.
+
+/**
+ * The subset of a word's fields the deck cares about. `key` is the wordDatabase
+ * key (canonical entry_id post-#39). Everything else mirrors WordData.
+ */
+export interface DeckEntry {
+  key: string;
+  jlptLevel: number | null;
+  freqRank: number | null;
+  dueAt: number | null;
+  reps: number | null;
+  stability: number | null;
+  intakeStatus?: 'queued' | 'active';
+  promotedTs: number | null;
+}
+
+/** A card in the deck, tagged with which source put it there (drives ordering). */
+export interface DeckCard extends DeckEntry {
+  kind: 'review' | 'new';
+}
+
+/**
+ * Active = promoted into FSRS scheduling. An explicit `queued` status always wins
+ * (it is unscheduled by definition). A stability-bearing legacy row with NO
+ * intake_status is treated as active so grandfathered schedules still surface.
+ */
+export function isActive(e: DeckEntry): boolean {
+  if (e.intakeStatus === 'queued') return false;
+  return e.intakeStatus === 'active' || e.stability != null;
+}
+
+/** A due review: active and its schedule has come due. */
+export function isDue(e: DeckEntry, now: number): boolean {
+  return isActive(e) && e.dueAt != null && e.dueAt <= now;
+}
+
+/**
+ * A new card: promoted from the intake queue (promotedTs set) but never studied
+ * (reps still 0). Excludes grandfathered known words (promotedTs null) and words
+ * already advanced by reading/flashcards (reps > 0).
+ */
+export function isNewCard(e: DeckEntry): boolean {
+  return isActive(e) && e.promotedTs != null && (e.reps ?? 0) === 0;
+}
+
+/**
+ * Foundation-first order for NEW cards: easiest JLPT level first (higher number),
+ * then most common (lowest freq_rank; nulls last), then a stable key tiebreak.
+ * Mirrors intake.ts:compareIntakeItem so intake and the deck agree on "what's
+ * foundational".
+ */
+function compareNew(a: DeckCard, b: DeckCard): number {
+  const la = a.jlptLevel ?? Number.NEGATIVE_INFINITY; // unknown level = hardest, last
+  const lb = b.jlptLevel ?? Number.NEGATIVE_INFINITY;
+  if (la !== lb) return lb - la; // easier (higher number) first
+  const fa = a.freqRank ?? Number.POSITIVE_INFINITY;
+  const fb = b.freqRank ?? Number.POSITIVE_INFINITY;
+  if (fa !== fb) return fa - fb; // most common (lowest rank) first
+  return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+}
+
+/** Most-overdue-first for DUE reviews; equal due dates fall back to a stable key. */
+function compareDue(a: DeckCard, b: DeckCard): number {
+  const da = a.dueAt ?? 0;
+  const db = b.dueAt ?? 0;
+  if (da !== db) return da - db; // earlier due (more overdue) first
+  return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+}
+
+/**
+ * A word is deck-eligible only if it has a JLPT level. Words with no JLPT rating
+ * are the un-enriched long tail (kuromoji-parsed fragments, particles, junk that
+ * never resolved to a JMDict entry) — showing them as flashcards is noise. Since
+ * foundation-first ordering is JLPT-based anyway, a level-less word has no place
+ * in the ordering. (Coarse gate for now; a fuller fix would enrich or prune those
+ * rows at the source — see docs/flashcard-ui-design-70.md.)
+ */
+export function isEligible(e: DeckEntry): boolean {
+  return e.jlptLevel != null;
+}
+
+/**
+ * Build today's ordered deck: all due reviews (most overdue first), then all new
+ * cards (foundation-first). A word that is both due AND new counts once, as a
+ * review (it's already scheduled and urgent). No session cap — #68 paces new
+ * words upstream and hiding genuinely-due reviews would be wrong. Level-less words
+ * are excluded (isEligible).
+ */
+export function selectDeck(entries: DeckEntry[], now: number): DeckCard[] {
+  const reviews: DeckCard[] = [];
+  const news: DeckCard[] = [];
+  for (const e of entries) {
+    if (!isEligible(e)) continue;
+    if (isDue(e, now)) reviews.push({ ...e, kind: 'review' });
+    else if (isNewCard(e)) news.push({ ...e, kind: 'new' });
+  }
+  reviews.sort(compareDue);
+  news.sort(compareNew);
+  return [...reviews, ...news];
+}

--- a/src/services/devSeed.ts
+++ b/src/services/devSeed.ts
@@ -1,0 +1,64 @@
+// Dev-only flashcard demo seeder (#70). Populates the store with a small,
+// hand-authored deck so the STUDY tab can be exercised without first reading
+// articles to accrue due words. Gated to VITE_DEV_MODE at the call site
+// (Flashcards.tsx) — never shipped to real users.
+//
+// The words are seeded already `active` and scheduled (4 due reviews + 4 new
+// intake cards) with real per-kanji furiganaMap, mirroring what enrichment +
+// #68 promotion would produce, so the deck, furigana, and FSRS grading all work.
+
+import { useAppStore, type WordData } from './store';
+
+type Seed = Partial<WordData> & { surface: string; reading: string; meaning: string; jlptLevel: number; freqRank: number };
+
+const DAY = 86_400_000;
+
+/** Build the 8 demo words keyed by a stable demo id (prefixed so they're obvious). */
+function demoWords(now: number): Record<string, WordData> {
+  const base = (o: Seed & { dueAt: number; reps: number; promotedTs: number | null }): WordData => ({
+    mastery: 'medium',
+    timesSeen: 4,
+    uniqueDaysSeen: ['2026-07-10'],
+    lastSeenTs: now - 2 * DAY,
+    streak: 1,
+    difficulty: 5,
+    intakeStatus: 'active',
+    stability: 8,
+    fsrsDifficulty: 5,
+    lapses: 0,
+    srsStatus: 'review',
+    lastReviewedTs: now - 2 * DAY,
+    grammarNote: '',
+    furiganaMap: [],
+    ...o,
+  });
+  const review = (o: Seed & { overdueDays: number }): WordData =>
+    base({ ...o, dueAt: now - o.overdueDays * DAY, reps: 3, promotedTs: null });
+  const fresh = (o: Seed): WordData =>
+    base({ ...o, dueAt: now + 14 * DAY, reps: 0, promotedTs: now - DAY });
+
+  return {
+    'demo:経済': review({ surface: '経済', reading: 'けいざい', meaning: 'economy; economics', jlptLevel: 4, freqRank: 10, overdueDays: 6, furiganaMap: [{ kanji: '経', kana: 'けい' }, { kanji: '済', kana: 'ざい' }] }),
+    'demo:影響': review({ surface: '影響', reading: 'えいきょう', meaning: 'influence; effect; impact', jlptLevel: 3, freqRank: 30, overdueDays: 4, grammarNote: 'Often 〜に影響を与える (to have an effect on).', furiganaMap: [{ kanji: '影', kana: 'えい' }, { kanji: '響', kana: 'きょう' }] }),
+    'demo:政府': review({ surface: '政府', reading: 'せいふ', meaning: 'government; administration', jlptLevel: 3, freqRank: 45, overdueDays: 2, furiganaMap: [{ kanji: '政', kana: 'せい' }, { kanji: '府', kana: 'ふ' }] }),
+    'demo:発表': review({ surface: '発表', reading: 'はっぴょう', meaning: 'announcement; presentation', jlptLevel: 3, freqRank: 55, overdueDays: 1, furiganaMap: [{ kanji: '発', kana: 'はっ' }, { kanji: '表', kana: 'ぴょう' }] }),
+    'demo:水': fresh({ surface: '水', reading: 'みず', meaning: 'water', jlptLevel: 5, freqRank: 1, furiganaMap: [{ kanji: '水', kana: 'みず' }] }),
+    'demo:時間': fresh({ surface: '時間', reading: 'じかん', meaning: 'time; hour', jlptLevel: 5, freqRank: 8, furiganaMap: [{ kanji: '時', kana: 'じ' }, { kanji: '間', kana: 'かん' }] }),
+    'demo:会議': fresh({ surface: '会議', reading: 'かいぎ', meaning: 'meeting; conference', jlptLevel: 4, freqRank: 20, furiganaMap: [{ kanji: '会', kana: 'かい' }, { kanji: '議', kana: 'ぎ' }] }),
+    'demo:提案': fresh({ surface: '提案', reading: 'ていあん', meaning: 'proposal; suggestion', jlptLevel: 3, freqRank: 70, grammarNote: 'する-verb: 提案する = to propose.', furiganaMap: [{ kanji: '提', kana: 'てい' }, { kanji: '案', kana: 'あん' }] }),
+  };
+}
+
+/**
+ * Merge the demo deck into the store (persisted like any other words). Reads the
+ * clock here so the module stays free of top-level Date calls. Returns nothing;
+ * the caller re-reads the deck to refresh the view.
+ */
+export function seedDemoDeck(): void {
+  const words = demoWords(Date.now());
+  useAppStore.setState((state) => ({
+    wordDatabase: { ...state.wordDatabase, ...words },
+    jlptLevel: state.jlptLevel ?? 4,
+    isOnboarded: true,
+  }));
+}

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -3,7 +3,7 @@ import { persist, createJSONStorage } from 'zustand/middleware';
 import { rtkKanjiList } from '../data/rtkKanji';
 import { NewsArticle } from './api';
 import { supabase } from './supabase';
-import { schedule, ratingForReaderEvent, seedSrsFromDifficulty, type SrsState, type SrsStatus } from './srs';
+import { schedule, ratingForReaderEvent, seedSrsFromDifficulty, type SrsState, type SrsStatus, type Rating } from './srs';
 import { selectPromotions, type IntakeItem } from './intake';
 
 export type MasteryLevel = 'unseen' | 'hard' | 'medium' | 'easy';
@@ -228,6 +228,7 @@ interface AppState {
   saveWordDefinition: (word: string, def: Partial<WordData>) => void;
   recordWordSeen: (word: string, withoutLookup?: boolean) => void;
   applyDifficultyEvent: (word: string, event: 'skip' | 'click', jlptLevel?: number | null) => void;
+  reviewWord: (word: string, rating: Rating, now: number) => void;
   setWordMastery: (word: string, level: MasteryLevel) => void;
   mergeWordRecords: (fromKey: string, toKey: string) => void;
   checkDailyKanji: () => void;
@@ -629,6 +630,98 @@ export const useAppStore = create<AppState>()(
                   } : {}),
                 });
                 m.logStudyEventToSupabase(uid, updatedWord.jmdictEntryId!, 'mastery_change', { level, difficulty });
+              });
+            }
+          });
+
+          return {
+            wordDatabase: {
+              ...state.wordDatabase,
+              [word]: updatedWord
+            }
+          };
+        }),
+
+      // Flashcard grade (#70). A deliberate review — the strongest, most explicit
+      // difficulty signal we get. It (1) advances the real FSRS schedule, (2) nudges
+      // the coarse difficulty/mastery so the Progress page + the LLM palette reflect
+      // study (D3: Again +2, Hard +1, Good -1, Easy -2), and (3) writes a
+      // `flashcard`-sourced review-log row. Unlike a passive read it bypasses the
+      // daily dedup and is never throttled. Rating: 1=Again 2=Hard 3=Good 4=Easy.
+      reviewWord: (word: string, rating: Rating, now: number) =>
+        set((state) => {
+          const current = state.wordDatabase[word];
+          if (!current) return {};
+
+          // Prior schedule, or a seed from `difficulty` if somehow unscheduled — the
+          // same fallback the reader path uses, so a card is always gradeable.
+          const baseDifficulty = current.difficulty ?? 5;
+          const priorSrs: SrsState =
+            current.stability != null && current.dueAt != null
+              ? {
+                  stability: current.stability,
+                  fsrsDifficulty: current.fsrsDifficulty ?? baseDifficulty,
+                  dueAt: current.dueAt,
+                  lastReviewedAt: current.lastReviewedTs ?? current.lastSeenTs ?? now,
+                  reps: current.reps ?? 0,
+                  lapses: current.lapses ?? 0,
+                  status: (current.srsStatus ?? 'review') as SrsStatus,
+                }
+              : seedSrsFromDifficulty(baseDifficulty, current.lastSeenTs ?? now);
+          const elapsedDays = (now - priorSrs.lastReviewedAt) / 86_400_000;
+          const sched = schedule(priorSrs, rating, now);
+
+          // Coarse difficulty nudge (D3), clamped 1..10, mirroring how reader events
+          // nudge the same signal — a repeatedly-failed card should *look* hard to the
+          // article generator, a repeatedly-easy one easy.
+          const nudge: Record<Rating, number> = { 1: 2, 2: 1, 3: -1, 4: -2 };
+          const difficulty = clampDifficulty(baseDifficulty + nudge[rating]);
+          const mastery = bucketForDifficulty(difficulty);
+
+          const updatedWord: WordData = {
+            ...current,
+            difficulty,
+            mastery,
+            lastAdjustReason: 'manual',
+            lastSeenTs: now,
+            stability: sched.stability,
+            fsrsDifficulty: sched.fsrsDifficulty,
+            dueAt: sched.dueAt,
+            lastReviewedTs: sched.lastReviewedAt,
+            intervalDays: sched.intervalDays,
+            reps: sched.reps,
+            lapses: sched.lapses,
+            srsStatus: sched.status,
+          };
+
+          currentUserId().then((uid) => {
+            if (uid && updatedWord.jmdictEntryId) {
+              import('./api').then(m => {
+                m.upsertWordProgressToSupabase(uid, updatedWord.jmdictEntryId!, {
+                  mastery: updatedWord.mastery,
+                  difficulty,
+                  timesSeen: updatedWord.timesSeen,
+                  streak: updatedWord.streak,
+                  lastSeenTs: updatedWord.lastSeenTs,
+                  stability: sched.stability,
+                  fsrsDifficulty: sched.fsrsDifficulty,
+                  dueAt: sched.dueAt,
+                  lastReviewedTs: sched.lastReviewedAt,
+                  intervalDays: sched.intervalDays,
+                  reps: sched.reps,
+                  lapses: sched.lapses,
+                  srsStatus: sched.status,
+                });
+                m.logSrsReviewToSupabase(uid, updatedWord.jmdictEntryId!, {
+                  rating,
+                  source: 'flashcard',
+                  stabilityBefore: priorSrs.stability,
+                  stabilityAfter: sched.stability,
+                  difficultyBefore: priorSrs.fsrsDifficulty,
+                  difficultyAfter: sched.fsrsDifficulty,
+                  scheduledDays: sched.intervalDays,
+                  elapsedDays,
+                });
               });
             }
           });


### PR DESCRIPTION
**Phase E of the Word Mastery Loop.** A zen-minimalist flashcard deck that studies *due* words on the real FSRS schedule (#67), closing the read ⇄ schedule ⇄ deck ⇄ article-selection loop. Closes #70.

**No DB migration needed** — #67 already provisioned the `flashcard` review source in both `database/23_fsrs_scheduling.sql` and `logSrsReviewToSupabase`. This is pure frontend wiring onto the existing engine.

## What's here
- **`src/services/deck.ts`** (pure) — `selectDeck` = due reviews (most-overdue-first) ∪ newly-promoted-but-unstudied cards (foundation-first). Excludes queued words, grandfathered-known rows, and level-less un-enriched junk (`isEligible`). Tested by **`scripts/test-deck.mjs`** (19 assertions, `npm run test:deck`).
- **`store.reviewWord(key, rating, now)`** — advances the FSRS schedule, nudges the coarse `difficulty`/`mastery` (Again+2/Hard+1/Good−1/Easy−2) so the Progress page + LLM palette reflect study, and writes a `flashcard`-sourced `srs_review_log` row.
- **`src/components/Flashcards.tsx`** — front/reveal card with **furigana above each kanji** (mirroring the lookup modal: segment-healing + whole-reading fallback), a muted chevron reveal hint, **Again/Hard/Good/Easy** with live FSRS interval previews, framer-motion transitions, and empty/complete states.
- **New STUDY tab** (Layers icon) in `BottomNav.tsx` + `App.tsx`.
- **Progress-bar contrast fix** — shared `--accent-progress` var (muted slate blue), used by both the deck bar and the Progress coverage bar (was near-invisible `--accent-primary` on the pale track).
- **`src/services/devSeed.ts`** — a `VITE_DEV_MODE`-only "🛠 Seed demo deck" button on the empty STUDY screen (8 demo cards); gated so it never ships to real users.

## Acceptance (from the issue)
> A user can study a due deck; each rating reschedules the word and writes a review-log row.

Met. Browser-verified end-to-end: foundation-first ordering, Good/Again reschedules (stability grows / lapse counted, due date matches the previewed interval), new cards leave "new" after grading, queued + grandfathered words untouched.

## Checks
- `npm run build` ✓ · `tsc` clean
- `test:srs` 18 · `test:intake` 14 · `test:deck` 19 — all green
- Lint: **55 problems on both this branch and `main`** — zero new

Design doc: `docs/flashcard-ui-design-70.md`.

Follow-ups (Phase E): #71 reader↔flashcard synergy, #72 feed due words to article gen, #73 study dashboard. The plan's "You are here" snapshot will refresh post-merge (repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)