### PR TITLE
Study-pacing flood fix: flashcards augment reading

### DIFF
--- a/docs/study-pacing-flood-fix.md
+++ b/docs/study-pacing-flood-fix.md
@@ -1,0 +1,76 @@
+# Study-pacing flood fix — findings & recommendation
+
+**Symptom:** opening the Study tab for the first time shows **1206 cards due** (deck reads local `wordDatabase`; server has more — see below). Expected: a gentle, paced deck.
+
+## Root cause
+
+Not the intake queue. The FSRS seed migration (`database/23_fsrs_scheduling.sql`, mirrored client-side in `store.ts` v6 persist migration) anchored every already-graded word's due date at:
+
+```
+dueAt = last_seen_at + interval(difficulty)      ← anchored in the PAST
+```
+
+Because the whole back-catalog was seeded at once from old `last_seen_at` timestamps, every word's interval had already elapsed → everything came due simultaneously. Compounding it: FSRS's seed-on-sight (`#67`) had already auto-graded a `difficulty` onto **every dictionary word ever read**, and the `#68` intake queue **grandfathered all of them as `active`** (design decision D2, `docs/intake-queue-design-68.md:56`). So the "active study" pool is really "every word I've ever read," not "words I chose to study."
+
+## Real data (audit — `scripts/audit-reseed.cjs`, read-only, service role)
+
+| metric | value |
+|---|---|
+| total `user_word_progress` rows | **2626** |
+| active (deck-eligible pool) | 2626 |
+| **due right now** | **1400** |
+| never deliberately promoted (grandfathered) | 2620 / 2626 |
+| difficulty 7–10 (auto-"hard", mostly seen once/twice) | **1243** |
+
+The difficulty 7–10 mass is the load driver: seed-on-sight marks any word above your JLPT level as hard → tiny seeded interval → slams due immediately.
+
+## Why the original plan (send `timesSeen ≤ 1` to the queue, forward-reseed the rest) isn't enough
+
+It still leaves **1667 words active → ~162 reviews/day** steady-state. A daily cap wouldn't save it: if true demand (162/day) exceeds the cap, the overdue pile grows forever ("review hell"). **A cap only works if the active pool is small enough that demand ≤ cap.**
+
+## Policy sweep (forward-reseed, conservative estimate, 3-day interval floor)
+
+`rev/day` = steady-state review demand Σ(1/interval). `cap OK?` = smallest daily cap that ≥ demand (sustainable — the pile drains).
+
+| policy | active | queue | rev/day | median interval | sustainable cap |
+|---|---:|---:|---:|---:|---|
+| A. `timesSeen≥2` (original plan) | 1667 | 959 | ~162 | 25d | >50/day ❌ |
+| B. `timesSeen≥2 AND difficulty≤6` | 1002 | 1624 | ~22 | 57d | 30/day |
+| **C. `timesSeen≥3 AND difficulty≤5`** | **729** | **1897** | **~11** | **90d** | **20/day** ✅ |
+| D. `timesSeen≥5 AND difficulty≤5` | 567 | 2059 | ~6 | 115d | 10/day |
+| E. `difficulty≤4 AND timesSeen≥3` | 635 | 1991 | ~7 | 98d | 10/day |
+
+**The "easy N5 words I already know" you were worried about are safe under B–E:** `difficulty≤4` words are overwhelmingly N5 (332) / N4 (187). Forward-reseeding gives them 90–115-day intervals, so they surface rarely — they neither flood the deck nor get dragged back through the 3/day queue.
+
+## Decision (settled with the user): Policy F — "flashcards augment reading"
+
+The guiding principle: **flashcards serve reading, not the reverse.** They drill words you *need but haven't mastered*; they don't mirror everything you've read. That yields a clean split by the app's own mastery buckets:
+
+- **Easy (difficulty ≤ 3)** → stay on the FSRS schedule but **forward-reseeded far out** (`seedForwardFromHistory`: anchored at now, stretched by exposure history). Reading pushes them further, so they rarely surface. Maintenance, not drilling. → **683 words, ~10 rev/day, 98-day median interval.**
+- **Medium+ (difficulty ≥ 4)** → back to the intake **queue**, dripping into active study at the daily cap (3/day, foundation-first). → 1943 words, a prioritized reservoir (not a backlog to force-drain).
+- **Graduate when easy** — automatic: a drilled word that grades down to easy naturally earns a long interval and joins the far-out pool. No extra code.
+
+### Why no hard daily review cap (reversed from an earlier draft)
+
+We considered an Anki-style N/day ceiling. **Rejected:** a hard cap that hides genuinely-due cards doesn't reduce work, it *defers* it into an invisible backlog — the exact "review hell" we're avoiding. The right cap is a **small natural inflow**, achieved by (a) the reseed keeping the active pool tiny and far-out, and (b) the pre-due window below. The deck shows *every* genuinely-due card. (The `reviewCap` primitive in `deck.ts` remains as a latent, default-**off** safety valve — nothing wires it.)
+
+### Pre-due surfacing window (the primary inflow reducer)
+
+A word becomes reviewable in the **reader** for a window *before* it's due, proportional to its interval (`PREDUE_FRACTION = 0.12` → a 2-month card gets ~a week; clamped to 1–21 days). `process-article` surfaces in-window words (most-urgent first) into the article's review slots; reading past one advances FSRS and pushes `due_at` out, so **it may never reach the flashcard deck.** Long-interval words enter their window early enough (in absolute days) to actually be reinforced. Implemented in `_shared/wordPriority.ts` (`preDueUrgency` / `selectPreDueFloor`) + `process-article/index.ts`.
+
+### What "Rebalance Flashcard Deck" does (Settings → Advanced — one-shot, self-hides)
+
+This is a **one-time correction**, not a recurring knob: the flood is a legacy artifact of #67 seed-on-sight + #68 grandfather, and it can't recur (new words enter the queue; reading no longer auto-activates). The button lives in Advanced Settings and **disappears once run** (gated on `lastStudyPacingResetTs`).
+
+1. For each **active** word: easy → forward-reseed far out; medium+ → `queued` + cleared schedule (difficulty/mastery kept for re-promotion).
+2. Clears `lastIntakePromotionTs` so the next open promotes a fresh batch; stamps `lastStudyPacingResetTs`.
+3. Batched Supabase sync (writes nulls, so cleared schedules persist cross-device).
+
+## Status of implementation — ✅ built & tested (branch `feat/reader-flashcard-synergy-71`)
+
+- ✅ Read-only audit + policy sweep (`scripts/audit-reseed.cjs`).
+- ✅ Forward-reseed estimator (`srs.ts: seedForwardFromHistory`); reclassification policy (`pacing.ts`); latent review-cap primitive (`deck.ts`).
+- ✅ `resetStudyPacing` store action + `resetStudyPacingBatch` sync + Settings "Rebalance Flashcard Deck" button (with confirm). **Nothing runs until you click it** — no live data was mutated.
+- ✅ Pre-due surfacing window (`wordPriority.ts` + `process-article/index.ts`).
+- ✅ Tests: `test-srs` (36), `test-deck` (32), `test-pacing` (15), `test-wordpriority` (25), `test-intake` (14) all green; frontend `tsc` clean.
+- ⏳ Not done: apply nothing to prod yet. To activate: deploy `process-article` (`supabase functions deploy process-article`), then click **Settings → Rebalance Flashcard Deck**. No new DB column needed (reuses existing `user_word_progress` scheduling columns).

--- a/docs/task.md
+++ b/docs/task.md
@@ -198,3 +198,25 @@
   - Verified: 18/18 tests, tsc -b, full vite build (ts-fsrs bundles), 0 new lint.
   - [ ] APPLY (your step): run database/23_fsrs_scheduling.sql in the Supabase SQL
         editor, then `vacuum analyze public.user_word_progress;`.
+- [/] Study-pacing flood fix — "flashcards augment reading" (see docs/study-pacing-flood-fix.md)
+  - Symptom: Study tab opened to ~1400 due at once. Cause: #67 seed anchored due_at
+    at last_seen_at, so the whole seed-on-sight back-catalog came due together; #68's
+    D2 grandfather kept it all `active`. NOT a queue-cap bug.
+  - Model (Policy F): easy (difficulty ≤ 3) → stay active, forward-reseeded FAR OUT;
+    medium+ → back to the intake queue (drip 3/day). No hard review cap (it only hides
+    genuinely-due cards); the natural cap is small inflow via the reseed + pre-due window.
+  - [x] audit-reseed.cjs — read-only policy sweep over real data (683 easy→SRS ~10/day,
+        1943→queue).
+  - [x] srs.ts — seedForwardFromHistory / estimateStability (now-anchored, exposure-boosted,
+        deterministic spread).
+  - [x] pacing.ts — decidePacing (Policy F) + isActiveForPacing + spreadFractionForKey.
+  - [x] store.resetStudyPacing + api.resetStudyPacingBatch (batched, writes nulls);
+        Settings → "Rebalance Flashcard Deck" button (confirm-gated).
+  - [x] deck.ts — latent, default-OFF reviewCap primitive (dueShown vs due).
+  - [x] Pre-due surfacing window: wordPriority.ts (preDueUrgency / selectPreDueFloor,
+        window = 12% of interval, 1–21d) + process-article/index.ts (interval_days, floor
+        by pre-due urgency).
+  - Verified: test-srs 36, test-deck 32, test-pacing 15, test-wordpriority 25,
+        test-intake 14 — all green; tsc clean; 0 new lint.
+  - [ ] ACTIVATE (your step): deploy process-article, then Settings → Rebalance Flashcard
+        Deck. No new DB column (reuses user_word_progress scheduling columns).

--- a/scripts/audit-reseed.cjs
+++ b/scripts/audit-reseed.cjs
@@ -1,0 +1,210 @@
+/**
+ * Read-only audit for the forward-reseed plan (study-pacing flood fix).
+ *
+ * Pulls the user's user_word_progress rows, classifies each active word as
+ * "stays active" (genuine exposure) vs "→ queue" (no real history), estimates
+ * the forward-anchored FSRS interval each active word would get, and predicts
+ * steady-state reviews/day + initial-ramp load. Breaks down by JLPT level so we
+ * can see the "easy N5 words I already know" cohort.
+ *
+ * READ ONLY — no writes. Usage: node scripts/audit-reseed.cjs [email]
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { createClient } = require('@supabase/supabase-js');
+
+// ─── Load .env (mirror scripts/enrich_jlpt.cjs) ──────────────
+const envPath = path.resolve(__dirname, '..', '.env');
+if (fs.existsSync(envPath)) {
+  fs.readFileSync(envPath, 'utf8').split('\n').forEach((line) => {
+    const t = line.trim();
+    if (!t || t.startsWith('#')) return;
+    const i = t.indexOf('=');
+    if (i === -1) return;
+    const k = t.slice(0, i).trim();
+    let v = t.slice(i + 1).trim();
+    // Values may be nested-quoted, e.g. "'https://...'": strip repeatedly.
+    while (v.length >= 2 && ((v.startsWith("'") && v.endsWith("'")) || (v.startsWith('"') && v.endsWith('"')))) {
+      v = v.slice(1, -1);
+    }
+    process.env[k] = v;
+  });
+}
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('❌ Missing VITE_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env');
+  process.exit(1);
+}
+const EMAIL = process.argv[2] || 'kpdevoe@gmail.com';
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+
+// ─── Seed math (mirror src/services/srs.ts) ──────────────────
+const SEED_S_MIN = 0.5, SEED_S_MAX = 21, SEED_K = 1.5;
+const clamp = (n, lo, hi) => Math.min(hi, Math.max(lo, n));
+function seedStability(difficulty) {
+  const d = clamp(difficulty, 1, 10);
+  return SEED_S_MAX * Math.pow((10 - d) / 9, SEED_K) + SEED_S_MIN;
+}
+// FSRS-6 first interval at request_retention 0.85 ≈ 1.906 * S (per database/23 comment).
+const intervalFromStability = (S) => 1.906 * S;
+
+// Forward-reseed stability estimate: base(difficulty) boosted by spaced exposure.
+// distinctDays isn't stored server-side; times_seen is the proxy. We report a RANGE:
+//   optimistic  = exposures grew memory a lot  (longer intervals → LOWER load)
+//   conservative= exposures grew memory little (shorter intervals → HIGHER load)
+function estStability(difficulty, timesSeen, boostK) {
+  const base = seedStability(difficulty ?? 6);
+  const exposures = Math.max(0, (timesSeen ?? 0) - 1);
+  return base * (1 + boostK * exposures);
+}
+
+async function resolveUserId(email) {
+  for (let page = 1; page <= 20; page++) {
+    const { data, error } = await sb.auth.admin.listUsers({ page, perPage: 200 });
+    if (error) throw error;
+    const hit = (data.users || []).find((u) => (u.email || '').toLowerCase() === email.toLowerCase());
+    if (hit) return hit.id;
+    if (!data.users || data.users.length < 200) break;
+  }
+  return null;
+}
+
+async function fetchAllProgress(userId) {
+  const rows = [];
+  const PAGE = 1000;
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await sb
+      .from('user_word_progress')
+      .select('word_id, difficulty, times_seen, streak, stability, due_at, reps, intake_status, promoted_at')
+      .eq('user_id', userId)
+      .range(from, from + PAGE - 1);
+    if (error) throw error;
+    rows.push(...(data || []));
+    if (!data || data.length < PAGE) break;
+  }
+  return rows;
+}
+
+async function fetchJlpt(wordIds) {
+  const map = new Map();
+  const CHUNK = 400;
+  for (let i = 0; i < wordIds.length; i += CHUNK) {
+    const chunk = wordIds.slice(i, i + CHUNK);
+    const { data, error } = await sb.from('jmdict_entries').select('id, jlpt_level').in('id', chunk);
+    if (error) throw error;
+    (data || []).forEach((r) => map.set(String(r.id), r.jlpt_level ?? null));
+  }
+  return map;
+}
+
+function bucket(map, key) { map.set(key, (map.get(key) || 0) + 1); }
+function fmt(map, order) {
+  return (order || [...map.keys()]).map((k) => `${k}: ${map.get(k) || 0}`).join('  ');
+}
+
+(async () => {
+  console.log(`\n🔍 Auditing forward-reseed for ${EMAIL}\n${'─'.repeat(60)}`);
+  const userId = await resolveUserId(EMAIL);
+  if (!userId) { console.error(`❌ No auth user for ${EMAIL}`); process.exit(1); }
+
+  const rows = await fetchAllProgress(userId);
+  const now = Date.now();
+  console.log(`Total user_word_progress rows: ${rows.length}`);
+
+  // Active = the pool the deck draws from (intake_status='active' OR has a schedule).
+  const active = rows.filter((r) => r.intake_status === 'active' || r.stability != null);
+  const dueNow = active.filter((r) => r.due_at && new Date(r.due_at).getTime() <= now);
+  const grandfathered = active.filter((r) => !r.promoted_at); // seed-on-sight, never promoted
+  console.log(`Active words: ${active.length}   (due right now: ${dueNow.length},  grandfathered/never-promoted: ${grandfathered.length})`);
+
+  // Classification under the plan: timesSeen<=1 → back to queue; else stays active.
+  const staysActive = active.filter((r) => (r.times_seen ?? 0) >= 2);
+  const toQueue = active.filter((r) => (r.times_seen ?? 0) < 2);
+  console.log(`\nUnder the plan:`);
+  console.log(`  → stay active (times_seen ≥ 2): ${staysActive.length}`);
+  console.log(`  → back to queue (times_seen ≤ 1): ${toQueue.length}  (drain at 3/day = ${Math.ceil(toQueue.length / 3)} days)`);
+
+  // Exposure & difficulty distributions (active pool).
+  const seenDist = new Map(), diffDist = new Map();
+  for (const r of active) {
+    const ts = r.times_seen ?? 0;
+    const b = ts <= 1 ? '0-1' : ts <= 4 ? '2-4' : ts <= 9 ? '5-9' : ts <= 24 ? '10-24' : '25+';
+    bucket(seenDist, b);
+    bucket(diffDist, String(r.difficulty ?? 'null'));
+  }
+  console.log(`\ntimes_seen distribution (active):  ${fmt(seenDist, ['0-1', '2-4', '5-9', '10-24', '25+'])}`);
+  console.log(`difficulty distribution (active):  ${fmt(diffDist, ['1','2','3','4','5','6','7','8','9','10','null'])}`);
+
+  // ── Policy sweep ───────────────────────────────────────────
+  // Each policy decides which active words STAY active (become forward-scheduled
+  // flashcards); the rest go to the queue. For each we compute the steady-state
+  // review demand Σ(1/interval). A daily cap C is only SUSTAINABLE if demand ≤ C —
+  // otherwise the overdue pile grows without bound. We use the conservative boost
+  // (k=0.2 → higher demand) as the planning number, and add a floor on the seeded
+  // interval to model "seed-on-sight difficulty is unreliable, don't slam hard
+  // words due-now" (raises min interval → fewer daily reviews).
+  const K_PLAN = 0.2;         // conservative exposure→stability boost
+  const MIN_INTERVAL_D = 3;   // floor: never seed a re-seeded word due in < 3 days
+
+  function demand(pool) {
+    let perDay = 0; const iv = [];
+    for (const r of pool) {
+      const S = estStability(r.difficulty, r.times_seen, K_PLAN);
+      const I = Math.max(MIN_INTERVAL_D, intervalFromStability(S));
+      iv.push(I); perDay += 1 / I;
+    }
+    iv.sort((a, b) => a - b);
+    return { perDay, median: iv.length ? iv[Math.floor(iv.length / 2)] : 0 };
+  }
+
+  const POLICIES = [
+    { name: 'A. timesSeen≥2 (original plan)',        keep: (r) => (r.times_seen ?? 0) >= 2 },
+    { name: 'B. timesSeen≥2 AND difficulty≤6',       keep: (r) => (r.times_seen ?? 0) >= 2 && (r.difficulty ?? 6) <= 6 },
+    { name: 'C. timesSeen≥3 AND difficulty≤5',       keep: (r) => (r.times_seen ?? 0) >= 3 && (r.difficulty ?? 6) <= 5 },
+    { name: 'D. timesSeen≥5 AND difficulty≤5',       keep: (r) => (r.times_seen ?? 0) >= 5 && (r.difficulty ?? 6) <= 5 },
+    { name: 'E. "known" only: diff≤4 AND seen≥3',    keep: (r) => (r.difficulty ?? 6) <= 4 && (r.times_seen ?? 0) >= 3 },
+    { name: 'F. USER MODEL: easy(diff≤3)→SRS, else→queue', keep: (r) => (r.difficulty ?? 6) <= 3 },
+  ];
+
+  console.log(`\nPOLICY SWEEP  (planning boost k=${K_PLAN}, min interval ${MIN_INTERVAL_D}d)`);
+  console.log(`${'─'.repeat(78)}`);
+  console.log('policy'.padEnd(38) + 'active'.padStart(7) + 'queue'.padStart(7) + '  rev/day'.padStart(9) + '  medIv'.padStart(7) + '  cap OK?');
+  for (const p of POLICIES) {
+    const keep = active.filter(p.keep);
+    const q = active.length - keep.length;
+    const d = demand(keep);
+    // Sustainable cap = smallest of {10,20,30,50} that ≥ demand (else "none <50").
+    const ok = [10, 20, 30, 50].find((c) => c >= d.perDay);
+    console.log(
+      p.name.padEnd(38) +
+      String(keep.length).padStart(7) +
+      String(q).padStart(7) +
+      `~${d.perDay.toFixed(0)}`.padStart(9) +
+      `${d.median.toFixed(0)}d`.padStart(7) +
+      `  ${ok ? `${ok}/day` : '>50/day'}`
+    );
+  }
+
+  // JLPT breakdown of the full active pool (the "easy N5 I already know" cohort).
+  try {
+    const jlpt = await fetchJlpt([...new Set(active.map((r) => String(r.word_id)))]);
+    const byLevelKnown = new Map(), byLevelAll = new Map();
+    for (const r of active) {
+      const lv = jlpt.get(String(r.word_id));
+      const key = lv == null ? 'none' : `N${lv}`;
+      bucket(byLevelAll, key);
+      if ((r.difficulty ?? 6) <= 4) bucket(byLevelKnown, key); // "already easy for me"
+    }
+    console.log(`\nActive by JLPT (all):        ${fmt(byLevelAll, ['N5', 'N4', 'N3', 'N2', 'N1', 'none'])}`);
+    console.log(`Active by JLPT (diff≤4=easy): ${fmt(byLevelKnown, ['N5', 'N4', 'N3', 'N2', 'N1', 'none'])}`);
+  } catch (e) {
+    console.log(`\n(JLPT breakdown skipped: ${e.message})`);
+  }
+
+  console.log(`\n${'─'.repeat(78)}`);
+  console.log(`"cap OK?" = smallest daily cap whose ceiling ≥ steady-state demand (sustainable — pile drains).`);
+  console.log(`If demand > cap, the overdue pile GROWS every day: the cap must exceed true demand.\n`);
+})().catch((e) => { console.error('❌', e.message); process.exit(1); });

--- a/scripts/test-deck.mjs
+++ b/scripts/test-deck.mjs
@@ -134,6 +134,24 @@ async function main() {
   const dualDc = deckCounts([due('x', 2, { reps: 0, promotedTs: NOW - DAY })], NOW);
   check('a word both due AND new counts once, as due', dualDc.due === 1 && dualDc.new === 0, JSON.stringify(dualDc));
 
+  // Daily review cap (study-pacing flood fix) — bounds surfaced reviews, keeps new cards.
+  console.log('\nselectDeck — reviewCap bounds reviews, most-overdue kept');
+  const many = [due('a', 1), due('b', 5), due('c', 3), due('d', 10), fresh('n1'), fresh('n2')];
+  const capped = selectDeck(many, NOW, { reviewCap: 2 });
+  const cappedReviews = capped.filter((c) => c.kind === 'review');
+  const cappedNews = capped.filter((c) => c.kind === 'new');
+  check('cap limits reviews to 2', cappedReviews.length === 2, JSON.stringify(cappedReviews.map((c) => c.key)));
+  check('most-overdue reviews survive the cap', cappedReviews[0].key === 'd' && cappedReviews[1].key === 'b', JSON.stringify(cappedReviews.map((c) => c.key)));
+  check('new cards unaffected by review cap', cappedNews.length === 2);
+  check('reviewCap 0 hides all reviews, keeps new', selectDeck(many, NOW, { reviewCap: 0 }).every((c) => c.kind === 'new'));
+  check('no cap → all reviews (legacy)', selectDeck(many, NOW).filter((c) => c.kind === 'review').length === 4);
+
+  console.log('\ndeckCounts — dueShown reflects the cap, due stays the true backlog');
+  const capDc = deckCounts(many, NOW, { reviewCap: 2 });
+  check('due = true backlog (4)', capDc.due === 4, JSON.stringify(capDc));
+  check('dueShown = min(due, cap) = 2', capDc.dueShown === 2, JSON.stringify(capDc));
+  check('no cap → dueShown === due', deckCounts(many, NOW).dueShown === 4);
+
   console.log(`\n${passed} passed, ${failed} failed`);
   try { rmSync(TMP); } catch { /* ignore */ }
   if (failed > 0) process.exit(1);

--- a/scripts/test-pacing.mjs
+++ b/scripts/test-pacing.mjs
@@ -1,0 +1,78 @@
+/**
+ * Standalone test runner for study-pacing reclassification (the flood fix).
+ *
+ *   node scripts/test-pacing.mjs
+ *
+ * No framework (matches test-deck.mjs / test-srs.mjs): src/services/pacing.ts is
+ * pure (imports srs.ts → ts-fsrs), so we bundle with esbuild and assert. Exits
+ * non-zero on any failure.
+ *
+ * Locks in Policy F:
+ *   • easy (difficulty ≤ 3) → keep-active, forward-reseeded far out
+ *   • medium+ (difficulty ≥ 4) → requeue
+ *   • null difficulty → treated as medium → requeue
+ *   • queued / unscheduled words are not "active" (caller skips them)
+ *   • exposure history stretches an easy word's interval
+ *   • spreadFraction is deterministic per key
+ */
+import esbuild from 'esbuild';
+import { pathToFileURL } from 'node:url';
+import { rmSync } from 'node:fs';
+import path from 'node:path';
+
+const TMP = path.join('scripts', '.tmp-pacing-bundle.mjs');
+const NOW = 1_000_000_000_000;
+const DAY = 86_400_000;
+
+let passed = 0, failed = 0;
+function check(name, cond, detail = '') {
+  if (cond) { passed++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  else { failed++; console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? `  — ${detail}` : ''}`); }
+}
+
+async function main() {
+  await esbuild.build({
+    entryPoints: ['src/services/pacing.ts'],
+    bundle: true, format: 'esm', outfile: TMP, platform: 'node', logLevel: 'silent',
+  });
+  const { decidePacing, isActiveForPacing, spreadFractionForKey, EASY_MAX_DIFFICULTY } =
+    await import(pathToFileURL(TMP).href);
+
+  const inp = (o) => ({ key: 'k', difficulty: 5, distinctExposures: 1, intakeStatus: 'active', stability: 10, ...o });
+
+  console.log('isActiveForPacing — only scheduled/active words qualify');
+  check('active status → active', isActiveForPacing(inp({ intakeStatus: 'active', stability: null })));
+  check('has stability → active', isActiveForPacing(inp({ intakeStatus: undefined, stability: 5 })));
+  check('queued → not active', !isActiveForPacing(inp({ intakeStatus: 'queued', stability: null })));
+  check('unscheduled + no status → not active', !isActiveForPacing(inp({ intakeStatus: undefined, stability: null })));
+
+  console.log('\ndecidePacing — easy stays active far-out, medium+ requeues');
+  const easy = decidePacing(inp({ key: 'easy', difficulty: 2, distinctExposures: 3 }), NOW);
+  check('easy (diff 2) → keep-active', easy.action === 'keep-active');
+  check('easy re-seeded into the future', easy.action === 'keep-active' && easy.srs.dueAt > NOW,
+    easy.action === 'keep-active' ? `+${Math.round((easy.srs.dueAt - NOW) / DAY)}d` : easy.action);
+  check('EASY_MAX_DIFFICULTY is the app easy bucket (3)', EASY_MAX_DIFFICULTY === 3);
+  check('diff 3 (boundary) → keep-active', decidePacing(inp({ difficulty: 3 }), NOW).action === 'keep-active');
+  check('diff 4 (medium) → requeue', decidePacing(inp({ difficulty: 4 }), NOW).action === 'requeue');
+  check('diff 9 (hard) → requeue', decidePacing(inp({ difficulty: 9 }), NOW).action === 'requeue');
+  check('null difficulty → treated medium → requeue', decidePacing(inp({ difficulty: null }), NOW).action === 'requeue');
+
+  console.log('\ndecidePacing — exposure history stretches the easy interval');
+  const once = decidePacing(inp({ key: 'a', difficulty: 2, distinctExposures: 1 }), NOW);
+  const many = decidePacing(inp({ key: 'a', difficulty: 2, distinctExposures: 20 }), NOW);
+  check('more distinct exposures → farther-out due date',
+    many.srs.dueAt - NOW > (once.srs.dueAt - NOW) * 2,
+    `once=+${Math.round((once.srs.dueAt - NOW) / DAY)}d many=+${Math.round((many.srs.dueAt - NOW) / DAY)}d`);
+
+  console.log('\nspreadFractionForKey — deterministic, in [0,1)');
+  check('deterministic for a key', spreadFractionForKey('hello') === spreadFractionForKey('hello'));
+  check('different keys differ', spreadFractionForKey('hello') !== spreadFractionForKey('world'));
+  const f = spreadFractionForKey('anything');
+  check('in [0,1)', f >= 0 && f < 1, String(f));
+
+  console.log(`\n\x1b[1m${passed} passed, ${failed} failed\x1b[0m\n`);
+}
+
+main()
+  .catch((e) => { console.error(e); failed++; })
+  .finally(() => { try { rmSync(TMP, { force: true }); } catch { /* ignore */ } process.exit(failed > 0 ? 1 : 0); });

--- a/scripts/test-srs.mjs
+++ b/scripts/test-srs.mjs
@@ -49,7 +49,7 @@ async function main() {
     logLevel: 'silent',
   });
   const srs = await import(pathToFileURL(TMP).href);
-  const { schedule, ratingForReaderEvent, readerEventMayAdvance, seedSrsFromDifficulty, seedStability, REQUEST_RETENTION } = srs;
+  const { schedule, ratingForReaderEvent, readerEventMayAdvance, seedSrsFromDifficulty, seedStability, REQUEST_RETENTION, seedForwardFromHistory, estimateStability } = srs;
 
   console.log('\nFSRS scheduler (#67) — request_retention', REQUEST_RETENTION);
 
@@ -131,6 +131,26 @@ async function main() {
   check('hard word due soon', hard.dueAt - T0 < 3 * DAY, `+${Math.round((hard.dueAt - T0) / DAY)}d`);
   check('seeded words enter as review', hard.status === 'review' && easy.status === 'review',
     `hard=${hard.status} easy=${easy.status}`);
+
+  // Forward re-seed (study-pacing flood fix) — anchored at now, boosted by exposure.
+  console.log('\nseedForwardFromHistory — forward-anchored, exposure-boosted, spread');
+  const fwdOnce = seedForwardFromHistory(9, 1, T0);          // hard, seen once
+  const fwdMany = seedForwardFromHistory(9, 20, T0);         // same word, seen across 20 days
+  check('anchored at now, never in the past', fwdOnce.dueAt >= T0 && fwdMany.dueAt >= T0,
+    `once=+${Math.round((fwdOnce.dueAt - T0) / DAY)}d many=+${Math.round((fwdMany.dueAt - T0) / DAY)}d`);
+  check('respects the min-interval floor (hard/once not due <3d)', fwdOnce.dueAt - T0 >= 3 * DAY,
+    `+${Math.round((fwdOnce.dueAt - T0) / DAY)}d`);
+  check('exposure history lengthens the interval a lot', fwdMany.dueAt - T0 > (fwdOnce.dueAt - T0) * 3,
+    `once=+${Math.round((fwdOnce.dueAt - T0) / DAY)}d many=+${Math.round((fwdMany.dueAt - T0) / DAY)}d`);
+  check('estimateStability grows with distinct exposures', estimateStability(5, 10) > estimateStability(5, 1));
+  check('reps 0 / status review (never actually graded)', fwdMany.reps === 0 && fwdMany.status === 'review');
+  // Deterministic spread: same inputs + spreadFraction → same due date; extremes differ.
+  const sLo = seedForwardFromHistory(5, 5, T0, { spreadFraction: 0 });
+  const sHi = seedForwardFromHistory(5, 5, T0, { spreadFraction: 1 });
+  const sLo2 = seedForwardFromHistory(5, 5, T0, { spreadFraction: 0 });
+  check('spread is deterministic for a given fraction', sLo.dueAt === sLo2.dueAt);
+  check('spread fans a cohort across days (0 vs 1 differ)', sLo.dueAt < sHi.dueAt,
+    `lo=+${Math.round((sLo.dueAt - T0) / DAY)}d hi=+${Math.round((sHi.dueAt - T0) / DAY)}d`);
 
   console.log(`\n\x1b[1m${passed} passed, ${failed} failed\x1b[0m\n`);
 }

--- a/scripts/test-wordpriority.mjs
+++ b/scripts/test-wordpriority.mjs
@@ -41,6 +41,7 @@ const sig = (entryId, o = {}) => ({
   isCommon: false,
   dueAt: o.dueAt ?? null,
   stability: o.stability ?? null,
+  intervalDays: o.intervalDays ?? null,
   difficulty: o.difficulty ?? null,
   timesSeen: o.timesSeen ?? null,
   lastSeenAt: o.lastSeenAt ?? null,
@@ -56,7 +57,7 @@ async function main() {
     outfile: TMP,
     logLevel: 'silent',
   });
-  const { compareByDue, compareStuck } = await import(pathToFileURL(TMP).href);
+  const { compareByDue, compareStuck, preDueUrgency, selectPreDueFloor, preDueWindowDays } = await import(pathToFileURL(TMP).href);
 
   console.log('\ncompareByDue — genuinely-due words first (#72)');
   // Two overdue words, one future, one never-scheduled. Expect: most-overdue → later
@@ -91,6 +92,44 @@ async function main() {
   const hard = sig('hard', { lastSeenAt: '2026-07-01T00:00:00.000Z', difficulty: 9 });
   const easy = sig('easy', { lastSeenAt: '2026-07-01T00:00:00.000Z', difficulty: 3 });
   check('same last-seen → hardest first', [easy, hard].sort(compareStuck)[0].entryId === 'hard');
+
+  // ── Pre-due surfacing window (flashcards augment reading) ──────────────────
+  const NOW_MS = Date.parse('2026-07-12T00:00:00.000Z');
+  const inDays = (d) => new Date(NOW_MS + d * 86_400_000).toISOString();
+
+  console.log('\npreDueWindowDays — proportional to interval, clamped');
+  check('~a week for a 2-month card', Math.round(preDueWindowDays(sig('x', { intervalDays: 60 }))) === 7,
+    String(preDueWindowDays(sig('x', { intervalDays: 60 }))));
+  check('tiny interval floored to ≥1 day', preDueWindowDays(sig('x', { intervalDays: 3 })) === 1);
+  check('huge interval capped at 21 days', preDueWindowDays(sig('x', { intervalDays: 365 })) === 21);
+  check('falls back to stability when no interval', preDueWindowDays(sig('x', { stability: 30 })) > 0);
+  check('unscheduled → null window', preDueWindowDays(sig('x', {})) === null);
+
+  console.log('\npreDueUrgency — 0 at window start, 1 at due, >1 overdue, null before window');
+  // 60-day card → 7-day window. Due in 10 days → not yet in window.
+  check('due beyond its window → null (not surfaced)', preDueUrgency(sig('x', { intervalDays: 60, dueAt: inDays(10) }), NOW_MS) === null);
+  // Due in 3 days, 7-day window → in window, urgency ~0.57.
+  const u = preDueUrgency(sig('x', { intervalDays: 60, dueAt: inDays(3) }), NOW_MS);
+  check('inside window → urgency in (0,1)', u > 0 && u < 1, String(u));
+  check('exactly due → urgency ~1', Math.abs(preDueUrgency(sig('x', { intervalDays: 60, dueAt: inDays(0) }), NOW_MS) - 1) < 0.01);
+  check('overdue → urgency > 1', preDueUrgency(sig('x', { intervalDays: 60, dueAt: inDays(-5) }), NOW_MS) > 1);
+  check('unscheduled (no dueAt) → null', preDueUrgency(sig('x', { intervalDays: 60, dueAt: null }), NOW_MS) === null);
+  // No interval signal: only urgent once actually due.
+  check('no-interval word not urgent before due', preDueUrgency(sig('x', { dueAt: inDays(2) }), NOW_MS) === null);
+  check('no-interval word urgent once due', preDueUrgency(sig('x', { dueAt: inDays(-1) }), NOW_MS) > 0);
+
+  console.log('\nselectPreDueFloor — most-urgent in-window words first, capped');
+  // Long-interval word gets its window EARLY (absolute days) vs a short one.
+  const pdLong = sig('long', { intervalDays: 120, dueAt: inDays(10) });   // 14d window → in window now
+  const pdShort = sig('short', { intervalDays: 5, dueAt: inDays(3) });     // 1d window → NOT in window
+  const pdOverdue = sig('overdue', { intervalDays: 30, dueAt: inDays(-2) }); // overdue → most urgent
+  const pdNotYet = sig('notYet', { intervalDays: 30, dueAt: inDays(20) });   // due far off → excluded
+  const picked = selectPreDueFloor([pdLong, pdShort, pdOverdue, pdNotYet], NOW_MS, 2).map((s) => s.entryId);
+  check('overdue word surfaces first', picked[0] === 'overdue', picked.join(','));
+  check('long-interval word in its early window is included', picked.includes('long'), picked.join(','));
+  check('short-card not-yet-in-window excluded', !picked.includes('short'), picked.join(','));
+  check('due-far-off word excluded', !picked.includes('notYet'), picked.join(','));
+  check('respects the limit', picked.length === 2, picked.join(','));
 
   console.log(`\n\x1b[1m${passed} passed, ${failed} failed\x1b[0m\n`);
 }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -35,7 +35,8 @@ export function Settings() {
     targetParagraphs, setTargetParagraphs,
     newWordsPerDay, setNewWordsPerDay,
     readerFontSize, setReaderFontSize,
-    readerFontWeight, setReaderFontWeight
+    readerFontWeight, setReaderFontWeight,
+    lastStudyPacingResetTs
   } = useAppStore();
 
   const intensityOptions = ['leisure', 'balanced', 'intensive'] as const;
@@ -167,72 +168,6 @@ export function Settings() {
         </p>
       </div>
 
-      {/* 3. Article Length */}
-      <div style={{ backgroundColor: 'var(--bg-card)', padding: '1.5rem', borderRadius: '16px', marginBottom: '1.5rem' }}>
-        <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-muted)', letterSpacing: '0.1em', marginBottom: '0.5rem', textTransform: 'uppercase' }}>
-          Article Length
-        </label>
-        <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: '1.4rem' }}>
-          Target paragraphs by how much real source text each article was built from. Full-text sources support longer reads; thin snippets stay short to avoid padding. Your JLPT level still sets the difficulty.
-        </p>
-
-        {lengthRows.map(({ kind, label, hint }) => (
-          <div key={kind} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: kind === 'snippet' ? 0 : '1.1rem' }}>
-            <div style={{ marginRight: '1rem' }}>
-              <div style={{ fontSize: '0.95rem', fontWeight: 600, color: 'var(--text-main)' }}>{label}</div>
-              <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)', lineHeight: 1.4 }}>{hint}</div>
-            </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexShrink: 0 }}>
-              <button
-                onClick={() => setTargetParagraphs(kind, targetParagraphs[kind] - 1)}
-                disabled={targetParagraphs[kind] <= 1}
-                aria-label={`Decrease ${label} length`}
-                style={stepperBtnStyle(targetParagraphs[kind] <= 1)}
-              >−</button>
-              <span style={{ minWidth: '1.5rem', textAlign: 'center', fontSize: '1.05rem', fontWeight: 700, color: 'var(--text-main)', fontVariantNumeric: 'tabular-nums' }}>
-                {targetParagraphs[kind]}
-              </span>
-              <button
-                onClick={() => setTargetParagraphs(kind, targetParagraphs[kind] + 1)}
-                disabled={targetParagraphs[kind] >= 10}
-                aria-label={`Increase ${label} length`}
-                style={stepperBtnStyle(targetParagraphs[kind] >= 10)}
-              >+</button>
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {/* New Words Per Day (#68 — intake pacing) */}
-      <div style={{ backgroundColor: 'var(--bg-card)', padding: '1.5rem', borderRadius: '16px', marginBottom: '1.5rem' }}>
-        <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-muted)', letterSpacing: '0.1em', marginBottom: '0.5rem', textTransform: 'uppercase' }}>
-          New Words Per Day
-        </label>
-        <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: '1.4rem' }}>
-          How many new words graduate into active study each day, easiest and most common first — so the foundation gets built before harder words. Words you meet while reading wait in a queue until their turn. Set to 0 to pause new words.
-        </p>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <div style={{ fontSize: '0.95rem', fontWeight: 600, color: 'var(--text-main)' }}>New words / day</div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexShrink: 0 }}>
-            <button
-              onClick={() => setNewWordsPerDay(newWordsPerDay - 1)}
-              disabled={newWordsPerDay <= 0}
-              aria-label="Decrease new words per day"
-              style={stepperBtnStyle(newWordsPerDay <= 0)}
-            >−</button>
-            <span style={{ minWidth: '1.5rem', textAlign: 'center', fontSize: '1.05rem', fontWeight: 700, color: 'var(--text-main)', fontVariantNumeric: 'tabular-nums' }}>
-              {newWordsPerDay}
-            </span>
-            <button
-              onClick={() => setNewWordsPerDay(newWordsPerDay + 1)}
-              disabled={newWordsPerDay >= 50}
-              aria-label="Increase new words per day"
-              style={stepperBtnStyle(newWordsPerDay >= 50)}
-            >+</button>
-          </div>
-        </div>
-      </div>
-
       {/* 3. Vocab Use */}
       <div style={{ backgroundColor: 'var(--bg-card)', padding: '1.5rem', borderRadius: '16px', marginBottom: '1.5rem' }}>
         <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-muted)', letterSpacing: '0.1em', marginBottom: '1.5rem', textTransform: 'uppercase' }}>
@@ -348,6 +283,72 @@ export function Settings() {
         </p>
       </div>
 
+      {/* Article Length */}
+      <div style={{ backgroundColor: 'var(--bg-card)', padding: '1.5rem', borderRadius: '16px', marginBottom: '1.5rem' }}>
+        <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-muted)', letterSpacing: '0.1em', marginBottom: '0.5rem', textTransform: 'uppercase' }}>
+          Article Length
+        </label>
+        <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: '1.4rem' }}>
+          Target paragraphs by how much real source text each article was built from. Full-text sources support longer reads; thin snippets stay short to avoid padding. Your JLPT level still sets the difficulty.
+        </p>
+
+        {lengthRows.map(({ kind, label, hint }) => (
+          <div key={kind} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: kind === 'snippet' ? 0 : '1.1rem' }}>
+            <div style={{ marginRight: '1rem' }}>
+              <div style={{ fontSize: '0.95rem', fontWeight: 600, color: 'var(--text-main)' }}>{label}</div>
+              <div style={{ fontSize: '0.78rem', color: 'var(--text-muted)', lineHeight: 1.4 }}>{hint}</div>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexShrink: 0 }}>
+              <button
+                onClick={() => setTargetParagraphs(kind, targetParagraphs[kind] - 1)}
+                disabled={targetParagraphs[kind] <= 1}
+                aria-label={`Decrease ${label} length`}
+                style={stepperBtnStyle(targetParagraphs[kind] <= 1)}
+              >−</button>
+              <span style={{ minWidth: '1.5rem', textAlign: 'center', fontSize: '1.05rem', fontWeight: 700, color: 'var(--text-main)', fontVariantNumeric: 'tabular-nums' }}>
+                {targetParagraphs[kind]}
+              </span>
+              <button
+                onClick={() => setTargetParagraphs(kind, targetParagraphs[kind] + 1)}
+                disabled={targetParagraphs[kind] >= 10}
+                aria-label={`Increase ${label} length`}
+                style={stepperBtnStyle(targetParagraphs[kind] >= 10)}
+              >+</button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* New Words Per Day (#68 — intake pacing) */}
+      <div style={{ backgroundColor: 'var(--bg-card)', padding: '1.5rem', borderRadius: '16px', marginBottom: '1.5rem' }}>
+        <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-muted)', letterSpacing: '0.1em', marginBottom: '0.5rem', textTransform: 'uppercase' }}>
+          New Words Per Day
+        </label>
+        <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: '1.4rem' }}>
+          How many new words graduate into active study each day, easiest and most common first — so the foundation gets built before harder words. Words you meet while reading wait in a queue until their turn. Set to 0 to pause new words.
+        </p>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ fontSize: '0.95rem', fontWeight: 600, color: 'var(--text-main)' }}>New words / day</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flexShrink: 0 }}>
+            <button
+              onClick={() => setNewWordsPerDay(newWordsPerDay - 1)}
+              disabled={newWordsPerDay <= 0}
+              aria-label="Decrease new words per day"
+              style={stepperBtnStyle(newWordsPerDay <= 0)}
+            >−</button>
+            <span style={{ minWidth: '1.5rem', textAlign: 'center', fontSize: '1.05rem', fontWeight: 700, color: 'var(--text-main)', fontVariantNumeric: 'tabular-nums' }}>
+              {newWordsPerDay}
+            </span>
+            <button
+              onClick={() => setNewWordsPerDay(newWordsPerDay + 1)}
+              disabled={newWordsPerDay >= 50}
+              aria-label="Increase new words per day"
+              style={stepperBtnStyle(newWordsPerDay >= 50)}
+            >+</button>
+          </div>
+        </div>
+      </div>
+
       <style>{`
         details[open] .advanced-chevron {
           transform: rotate(-180deg);
@@ -436,6 +437,38 @@ export function Settings() {
               style={{ width: '100%', accentColor: 'var(--text-main)' }}
             />
           </div>
+          {/* Rebalance Flashcard Deck — one-time study-pacing correction (the #67
+              seed-on-sight flood). Self-hides once run: the queue + pre-due window keep
+              the deck healthy afterward, so it's a one-shot, not a recurring knob. */}
+          {lastStudyPacingResetTs == null && (
+            <>
+              <div style={{ width: '40px', height: '2px', backgroundColor: 'var(--border-light)', margin: '2rem 0' }} />
+              <div style={{ marginBottom: '1.5rem' }}>
+                <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-main)', marginBottom: '0.75rem' }}>
+                  Rebalance Flashcard Deck
+                </label>
+                <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: '1.2rem' }}>
+                  A one-time cleanup so flashcards augment reading instead of flooding you. Words you already find easy stay scheduled but pushed far out (reading keeps them fresh); harder words move back into the queue to drip in a few per day. Nothing is deleted. You only need to run this once.
+                </p>
+                <button
+                  onClick={async () => {
+                    if (!window.confirm('Rebalance your flashcard deck? Easy words get pushed far out; harder words return to the daily queue. Nothing is deleted. This is a one-time cleanup.')) return;
+                    const { useAppStore } = await import('../services/store');
+                    const r = await useAppStore.getState().resetStudyPacing();
+                    window.alert(`Study pacing reset.\n\n${r.keptActive} easy words kept on a far-out schedule.\n${r.requeued} words moved back to the queue (a few graduate into flashcards each day).`);
+                  }}
+                  style={{
+                    width: '100%', padding: '0.9rem', borderRadius: '12px', backgroundColor: 'transparent',
+                    color: 'var(--text-main)', border: '2px solid var(--border-light)', fontWeight: 700,
+                    fontSize: '0.9rem', cursor: 'pointer', letterSpacing: '0.03em',
+                  }}
+                >
+                  Rebalance Flashcard Deck
+                </button>
+              </div>
+            </>
+          )}
+
           {/* 5. Danger Zone */}
           <div style={{ padding: '1.5rem', borderRadius: '16px', border: '1px solid #ff444433', backgroundColor: '#ff444408', marginTop: '4rem', marginBottom: '1.5rem' }}>
             <h3 style={{ fontSize: '0.85rem', fontWeight: 900, color: '#ff4444', letterSpacing: '0.1em', textTransform: 'uppercase', marginBottom: '1rem' }}>Danger Zone</h3>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -621,6 +621,67 @@ export async function upsertWordProgressBatch(
   if (error) console.error('Error batch-syncing word progress:', error);
 }
 
+/** A word's full re-classified state after a study-pacing reset (forward-reseed / re-queue). */
+export interface PacingResetRow {
+  wordId: string;
+  mastery: string;
+  difficulty: number | null;
+  timesSeen: number;
+  streak: number;
+  lastSeenTs: number;
+  intakeStatus: string | null;
+  promotedTs: number | null;
+  stability: number | null;
+  fsrsDifficulty: number | null;
+  dueAt: number | null;          // ms epoch
+  lastReviewedTs: number | null; // ms epoch
+  intervalDays: number | null;
+  reps: number | null;
+  lapses: number | null;
+  srsStatus: string | null;
+}
+
+/**
+ * Persist a study-pacing reset (the flood fix) — one bulk write per chunk. UNLIKE the
+ * present-only upserts elsewhere, this one WRITES nulls: re-queuing a word must clear
+ * its synthetic schedule (stability/due_at/… → null), and forward-reseeding writes a
+ * fresh schedule, so every scheduling column is set explicitly. Chunked so a 2000+
+ * word back-catalog is a handful of round-trips, not one giant payload. See
+ * docs/study-pacing-flood-fix.md.
+ */
+export async function resetStudyPacingBatch(userId: string, rows: PacingResetRow[]) {
+  const CHUNK = 500;
+  for (let i = 0; i < rows.length; i += CHUNK) {
+    const payload = rows.slice(i, i + CHUNK)
+      .filter((r) => r.wordId)
+      .map((r) => {
+        const ts = Number.isFinite(r.lastSeenTs) && r.lastSeenTs > 0 ? r.lastSeenTs : Date.now();
+        return {
+          user_id: userId,
+          word_id: r.wordId,
+          mastery_level: r.mastery,
+          difficulty: r.difficulty,
+          times_seen: r.timesSeen ?? 0,
+          streak: r.streak ?? 0,
+          last_seen_at: new Date(ts).toISOString(),
+          intake_status: r.intakeStatus,
+          promoted_at: r.promotedTs == null ? null : new Date(r.promotedTs).toISOString(),
+          stability: r.stability,
+          fsrs_difficulty: r.fsrsDifficulty,
+          due_at: r.dueAt == null ? null : new Date(r.dueAt).toISOString(),
+          last_reviewed_at: r.lastReviewedTs == null ? null : new Date(r.lastReviewedTs).toISOString(),
+          interval_days: r.intervalDays,
+          reps: r.reps ?? 0,
+          lapses: r.lapses ?? 0,
+          srs_status: r.srsStatus,
+        };
+      });
+    if (payload.length === 0) continue;
+    const { error } = await supabase.from('user_word_progress').upsert(payload);
+    if (error) { console.error('Error syncing study-pacing reset:', error); return; }
+  }
+}
+
 export async function logStudyEventToSupabase(
   userId: string, 
   wordId: string, 

--- a/src/services/deck.ts
+++ b/src/services/deck.ts
@@ -99,14 +99,26 @@ export function isEligible(e: DeckEntry): boolean {
   return e.jlptLevel != null;
 }
 
+/** Options for deck assembly. */
+export interface DeckOptions {
+  /**
+   * Daily review ceiling (Anki-style). When set to a non-negative number, only the
+   * `reviewCap` MOST-OVERDUE reviews are surfaced; the rest defer to a later day.
+   * New cards are unaffected (#68 already paces them upstream). Omit / null = no cap
+   * (legacy behaviour). This is the one hard guarantee on daily load: without it, a
+   * back-catalog reseed can put review demand permanently above what a user can clear.
+   */
+  reviewCap?: number | null;
+}
+
 /**
- * Build today's ordered deck: all due reviews (most overdue first), then all new
- * cards (foundation-first). A word that is both due AND new counts once, as a
- * review (it's already scheduled and urgent). No session cap — #68 paces new
- * words upstream and hiding genuinely-due reviews would be wrong. Level-less words
- * are excluded (isEligible).
+ * Build today's ordered deck: due reviews (most overdue first), then new cards
+ * (foundation-first). A word that is both due AND new counts once, as a review
+ * (it's already scheduled and urgent). New words are paced upstream by #68; due
+ * reviews are bounded by `reviewCap` (opt-in) so a large scheduled backlog can't
+ * flood a session. Level-less words are excluded (isEligible).
  */
-export function selectDeck(entries: DeckEntry[], now: number): DeckCard[] {
+export function selectDeck(entries: DeckEntry[], now: number, opts: DeckOptions = {}): DeckCard[] {
   const reviews: DeckCard[] = [];
   const news: DeckCard[] = [];
   for (const e of entries) {
@@ -116,12 +128,16 @@ export function selectDeck(entries: DeckEntry[], now: number): DeckCard[] {
   }
   reviews.sort(compareDue);
   news.sort(compareNew);
-  return [...reviews, ...news];
+  const capped = opts.reviewCap != null && opts.reviewCap >= 0
+    ? reviews.slice(0, opts.reviewCap)   // keep the most-overdue `reviewCap`
+    : reviews;
+  return [...capped, ...news];
 }
 
 /** Deck-health tallies for the study dashboard (#73). */
 export interface DeckCounts {
-  due: number;       // active, scheduled, and come due (would head the deck)
+  due: number;       // active, scheduled, and come due (total backlog)
+  dueShown: number;  // reviews actually surfaced today after `reviewCap` (≤ due)
   new: number;       // promoted but never studied (reps 0) — Anki "new"
   learning: number;  // active + scheduled but neither due nor new (mid-interval)
   active: number;    // total words in FSRS scheduling (due + new + learning)
@@ -130,11 +146,13 @@ export interface DeckCounts {
 /**
  * Count the deck's health straight from the SAME predicates selectDeck uses, so the
  * dashboard's due/new/learning numbers always agree with what STUDY actually shows
- * (a word that is both due and new counts once, as due — mirroring the deck). Pure:
- * the caller projects its WordData into DeckEntry and passes the clock.
+ * (a word that is both due and new counts once, as due — mirroring the deck). When a
+ * `reviewCap` is set, `due` stays the true backlog while `dueShown` is what STUDY
+ * surfaces today — the dashboard can show "N due (M today)". Pure: the caller
+ * projects its WordData into DeckEntry and passes the clock.
  */
-export function deckCounts(entries: DeckEntry[], now: number): DeckCounts {
-  const c: DeckCounts = { due: 0, new: 0, learning: 0, active: 0 };
+export function deckCounts(entries: DeckEntry[], now: number, opts: DeckOptions = {}): DeckCounts {
+  const c: DeckCounts = { due: 0, dueShown: 0, new: 0, learning: 0, active: 0 };
   for (const e of entries) {
     if (!isEligible(e) || !isActive(e)) continue;
     c.active++;
@@ -142,5 +160,8 @@ export function deckCounts(entries: DeckEntry[], now: number): DeckCounts {
     else if (isNewCard(e)) c.new++;
     else c.learning++;
   }
+  c.dueShown = opts.reviewCap != null && opts.reviewCap >= 0
+    ? Math.min(c.due, opts.reviewCap)
+    : c.due;
   return c;
 }

--- a/src/services/pacing.ts
+++ b/src/services/pacing.ts
@@ -1,0 +1,68 @@
+// Study-pacing reclassification (the flood fix) — the pure "where does each word
+// belong" policy, applied one-time by store.resetStudyPacing and unit-testable in
+// isolation (mirrors deck.ts / srs.ts). See docs/study-pacing-flood-fix.md.
+//
+// The model (Policy F): flashcards AUGMENT reading, they don't mirror it. So of the
+// back-catalog that #67 seed-on-sight dumped into active scheduling:
+//   • EASY words (difficulty ≤ 3 — the app's own 'easy' mastery bucket) stay on the
+//     FSRS schedule but are re-seeded FAR OUT (seedForwardFromHistory: anchored at
+//     now, stretched by exposure history). Reading pushes them further, so they
+//     rarely surface as flashcards — maintenance, not drilling.
+//   • MEDIUM+ words go back to the intake QUEUE, to drip into active study at the
+//     daily cap (foundation-first). Drilling is reserved for what you're learning.
+// A word that later grades down to easy naturally earns a long interval and joins
+// the far-out pool — the "graduate when easy" step is automatic in FSRS, no code.
+
+import { seedForwardFromHistory, type SrsState } from './srs';
+
+/** The app's `mastery==='easy'` boundary (bucketForDifficulty: difficulty ≤ 3). */
+export const EASY_MAX_DIFFICULTY = 3;
+
+/** Fields the pacing decision reads from a word (projected from WordData by the caller). */
+export interface PacingInput {
+  key: string;
+  difficulty: number | null;
+  distinctExposures: number;              // uniqueDaysSeen.length — the real spacing signal
+  intakeStatus?: 'queued' | 'active';
+  stability?: number | null;
+}
+
+export type PacingDecision =
+  | { action: 'keep-active'; srs: SrsState }  // easy → far-out forward-reseed
+  | { action: 'requeue' };                    // medium+ → back to the queue
+
+/**
+ * Deterministic [0,1) spread fraction from a word key (FNV-1a hash). Feeds
+ * seedForwardFromHistory's jitter so an identical-stability cohort fans across days
+ * instead of piling onto one — without a clock or RNG (resume-safe, testable).
+ */
+export function spreadFractionForKey(key: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < key.length; i++) {
+    h ^= key.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return ((h >>> 0) % 100000) / 100000;
+}
+
+/** Active = currently in FSRS scheduling. Mirrors deck.isActive so the two agree. */
+export function isActiveForPacing(i: PacingInput): boolean {
+  if (i.intakeStatus === 'queued') return false;
+  return i.intakeStatus === 'active' || i.stability != null;
+}
+
+/**
+ * Reclassify ONE active word under Policy F. Only meaningful for active words
+ * (caller gates with isActiveForPacing). A null/unknown difficulty is treated as
+ * medium (6) — no evidence of ease → it belongs in the queue, not the far-out pool.
+ */
+export function decidePacing(i: PacingInput, now: number): PacingDecision {
+  const difficulty = i.difficulty ?? 6;
+  if (difficulty <= EASY_MAX_DIFFICULTY) {
+    const srs = seedForwardFromHistory(difficulty, i.distinctExposures, now, {
+      spreadFraction: spreadFractionForKey(i.key),
+    });
+    return { action: 'keep-active', srs };
+  }
+  return { action: 'requeue' };
+}

--- a/src/services/srs.ts
+++ b/src/services/srs.ts
@@ -208,3 +208,68 @@ export function seedSrsFromDifficulty(difficulty: number, lastSeenAt: number): S
     status: 'review',
   };
 }
+
+// ── Re-seeding the back-catalog forward (study-pacing flood fix) ──────────────
+// The original seed anchored `dueAt` at `last_seen_at` — for a back-catalog seeded
+// all at once, every interval had already elapsed, so the whole history came due
+// simultaneously (see docs/study-pacing-flood-fix.md). The forward re-seed fixes
+// two things: it anchors at `now` (nothing is retroactively overdue), and it boosts
+// stability by real EXPOSURE history — a word met across many distinct days is far
+// more established than a once-seen word at the same `difficulty`, so it earns a
+// long interval and rarely resurfaces instead of joining a daily flood.
+
+/** Multiplier applied to the ±spread window, so an identical-stability cohort doesn't all land on one day. */
+const RESEED_SPREAD = 0.15;      // ±15%
+/** How much each distinct spaced exposure grows stability (conservative default; see audit). */
+const RESEED_BOOST_K = 0.2;
+/** Never re-seed a word due sooner than this — seed-on-sight `difficulty` is unreliable. */
+const RESEED_MIN_INTERVAL_D = 3;
+
+export interface ReseedOptions {
+  boostK?: number;          // exposure→stability growth (default RESEED_BOOST_K)
+  minIntervalDays?: number; // floor on the seeded interval (default RESEED_MIN_INTERVAL_D)
+  spreadFraction?: number;  // 0..1 deterministic jitter (e.g. hash of the word key); 0.5 = no shift
+}
+
+/**
+ * Estimated stability (days) for a re-seeded word: the difficulty seed grown by how
+ * many distinct times it was seen. `distinctExposures` is the count of separate
+ * study/read days (WordData.uniqueDaysSeen.length), the real spacing signal.
+ */
+export function estimateStability(difficulty: number, distinctExposures: number, boostK = RESEED_BOOST_K): number {
+  const base = seedStability(difficulty);
+  const extra = Math.max(0, (distinctExposures ?? 0) - 1);
+  return base * (1 + boostK * extra);
+}
+
+/**
+ * Build a forward-anchored `SrsState` from a word's `difficulty` + exposure history.
+ * `dueAt = now + interval(S_est)`, floored and jittered so a large cohort spreads
+ * across days instead of piling onto one. Deterministic: pass `spreadFraction` (a
+ * stable per-word value) rather than reading a clock or RNG. Enters as `review`,
+ * `reps: 0` (never actually graded) — mirroring seedSrsFromDifficulty's lifecycle.
+ */
+export function seedForwardFromHistory(
+  difficulty: number,
+  distinctExposures: number,
+  now: number,
+  opts: ReseedOptions = {},
+): SrsState {
+  const boostK = opts.boostK ?? RESEED_BOOST_K;
+  const minInterval = opts.minIntervalDays ?? RESEED_MIN_INTERVAL_D;
+  const stability = estimateStability(difficulty, distinctExposures, boostK);
+  const fsrsDifficulty = clamp(difficulty, 1, 10);
+  const base = Math.max(minInterval, scheduler.next_interval(stability, 0));
+  // spreadFraction 0.5 → no shift; 0 → −RESEED_SPREAD; 1 → +RESEED_SPREAD.
+  const jitter = opts.spreadFraction == null ? 1 : 1 + RESEED_SPREAD * (2 * clamp(opts.spreadFraction, 0, 1) - 1);
+  const intervalDays = Math.max(minInterval, base * jitter);
+  return {
+    stability,
+    fsrsDifficulty,
+    dueAt: now + intervalDays * DAY_MS,
+    lastReviewedAt: now,
+    reps: 0,
+    lapses: 0,
+    status: 'review',
+  };
+}

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -4,6 +4,7 @@ import { rtkKanjiList } from '../data/rtkKanji';
 import { NewsArticle } from './api';
 import { supabase } from './supabase';
 import { schedule, ratingForReaderEvent, readerEventMayAdvance, seedSrsFromDifficulty, type SrsState, type SrsStatus, type Rating, type AdjustReason } from './srs';
+import { decidePacing, isActiveForPacing } from './pacing';
 import { selectPromotions, type IntakeItem } from './intake';
 
 export type MasteryLevel = 'unseen' | 'hard' | 'medium' | 'easy';
@@ -205,6 +206,8 @@ interface AppState {
   studyKanji: string[];
   lastRtkUpdateTs: number | null;
   lastResetTs: number | null;
+  // Study-pacing flood fix: when the one-time forward-reseed / re-queue last ran.
+  lastStudyPacingResetTs: number | null;
   currentArticle: NewsArticle | null;
   articlesCache: Record<string, NewsArticle>;
   processingArticles: string[];
@@ -237,6 +240,7 @@ interface AppState {
   recordWordSeen: (word: string, withoutLookup?: boolean) => void;
   applyDifficultyEvent: (word: string, event: 'skip' | 'click', jlptLevel?: number | null) => void;
   reviewWord: (word: string, rating: Rating, now: number) => void;
+  resetStudyPacing: () => Promise<{ keptActive: number; requeued: number }>;
   setWordMastery: (word: string, level: MasteryLevel) => void;
   mergeWordRecords: (fromKey: string, toKey: string) => void;
   checkDailyKanji: () => void;
@@ -279,6 +283,7 @@ export const useAppStore = create<AppState>()(
       studyKanji: [],
       lastRtkUpdateTs: null,
       lastResetTs: null,
+      lastStudyPacingResetTs: null,
       currentArticle: null,
       articlesCache: {},
       processingArticles: [],
@@ -770,6 +775,101 @@ export const useAppStore = create<AppState>()(
           };
         }),
 
+      // One-time study-pacing reset (the flood fix). Reclassifies the whole active
+      // back-catalog under Policy F (see services/pacing.ts + docs/study-pacing-flood-fix.md):
+      // easy words (difficulty ≤ 3) are kept active but forward-reseeded FAR OUT so they
+      // rarely surface as flashcards; medium+ words go back to the intake queue to drip in
+      // at the daily cap. Clears lastIntakePromotionTs so the next open promotes a fresh
+      // batch. Syncs every touched row to Supabase (writing nulls to clear cleared
+      // schedules). Idempotent-ish: re-running just re-applies the same rule.
+      resetStudyPacing: async () => {
+        const now = Date.now();
+        const touched: WordData[] = [];
+        set((state) => {
+          const db = { ...state.wordDatabase };
+          for (const [key, w] of Object.entries(db)) {
+            if (!w) continue;
+            const input = {
+              key,
+              difficulty: w.difficulty ?? null,
+              distinctExposures: w.uniqueDaysSeen?.length ?? (w.timesSeen ? 1 : 0),
+              intakeStatus: w.intakeStatus,
+              stability: w.stability ?? null,
+            };
+            if (!isActiveForPacing(input)) continue; // queued/unscheduled words already paced
+            const decision = decidePacing(input, now);
+            let next: WordData;
+            if (decision.action === 'keep-active') {
+              const s = decision.srs;
+              next = {
+                ...w,
+                intakeStatus: 'active',
+                mastery: bucketForDifficulty(w.difficulty ?? 3),
+                stability: s.stability,
+                fsrsDifficulty: s.fsrsDifficulty,
+                dueAt: s.dueAt,
+                lastReviewedTs: s.lastReviewedAt,
+                intervalDays: (s.dueAt - s.lastReviewedAt) / 86_400_000,
+                reps: s.reps,
+                lapses: s.lapses,
+                srsStatus: s.status,
+              };
+            } else {
+              // Medium+ → back to the queue. Clear the synthetic schedule but KEEP
+              // difficulty/mastery (the learning signal; re-promotion re-seeds from it).
+              next = {
+                ...w,
+                intakeStatus: 'queued',
+                promotedTs: null,
+                stability: null,
+                fsrsDifficulty: null,
+                dueAt: null,
+                lastReviewedTs: null,
+                intervalDays: null,
+                reps: 0,
+                lapses: 0,
+                srsStatus: null,
+              };
+            }
+            db[key] = next;
+            touched.push(next);
+          }
+          return { wordDatabase: db, lastStudyPacingResetTs: now, lastIntakePromotionTs: null };
+        });
+
+        // Persist every touched row (entry-id-backed only), batched. Writes nulls so a
+        // re-queued word's cleared schedule sticks server-side (cross-device + rehydrate).
+        const uid = await currentUserId();
+        if (uid && touched.length > 0) {
+          const { resetStudyPacingBatch } = await import('./api');
+          const rows = touched
+            .filter((w) => w.jmdictEntryId)
+            .map((w) => ({
+              wordId: w.jmdictEntryId!,
+              mastery: w.mastery,
+              difficulty: w.difficulty ?? null,
+              timesSeen: w.timesSeen,
+              streak: w.streak,
+              lastSeenTs: w.lastSeenTs || now,
+              intakeStatus: w.intakeStatus ?? null,
+              promotedTs: w.promotedTs ?? null,
+              stability: w.stability ?? null,
+              fsrsDifficulty: w.fsrsDifficulty ?? null,
+              dueAt: w.dueAt ?? null,
+              lastReviewedTs: w.lastReviewedTs ?? null,
+              intervalDays: w.intervalDays ?? null,
+              reps: w.reps ?? 0,
+              lapses: w.lapses ?? 0,
+              srsStatus: w.srsStatus ?? null,
+            }));
+          await resetStudyPacingBatch(uid, rows).catch((e) =>
+            console.warn('[store] study-pacing reset sync failed:', e));
+        }
+
+        const keptActive = touched.filter((w) => w.intakeStatus === 'active').length;
+        return { keptActive, requeued: touched.length - keptActive };
+      },
+
       syncSrsWithSupabase: async (userId) => {
         const { fetchUserWordProgress, fetchUserPreferences } = await import('./api');
 
@@ -1172,6 +1272,7 @@ export const useAppStore = create<AppState>()(
         studyKanji: state.studyKanji,
         lastRtkUpdateTs: state.lastRtkUpdateTs,
         lastResetTs: state.lastResetTs,
+        lastStudyPacingResetTs: state.lastStudyPacingResetTs,
         dismissedArticleIds: state.dismissedArticleIds,
         readArticleIds: state.readArticleIds,
         readerFontSize: state.readerFontSize,

--- a/supabase/functions/_shared/wordPriority.ts
+++ b/supabase/functions/_shared/wordPriority.ts
@@ -62,6 +62,9 @@ export interface WordSignal {
   dueAt?: string | null;
   /** FSRS stability in days; lower = more fragile memory. null = unscheduled. (#67) */
   stability?: number | null;
+  /** FSRS scheduled interval in days (`user_word_progress.interval_days`). Drives the
+   * proportional pre-due surfacing window. null = unscheduled / legacy. */
+  intervalDays?: number | null;
 }
 
 /**
@@ -203,6 +206,67 @@ export function compareByDue(a: WordSignal, b: WordSignal): number {
   const sb = b.stability ?? Number.POSITIVE_INFINITY;
   if (sa !== sb) return sa - sb; // more fragile (lower stability) first
   return compareStuck(a, b);
+}
+
+// ── Pre-due surfacing window (flashcards augment reading) ────────────────────
+// A word shouldn't wait until it's due to be reviewable in the reader. For a window
+// BEFORE due — proportional to its interval — the article generator gets chances to
+// weave it in; reading past it advances the schedule and pushes due_at out, so it may
+// never reach the flashcard deck. The window scales with the interval (a 2-month card
+// gets ~a week; a 3-day card gets ~a day), so long-interval words start surfacing far
+// enough ahead to actually be reinforced. See docs/study-pacing-flood-fix.md.
+
+/** Fraction of a word's interval spent in its pre-due window (~a week for a 2-month card). */
+export const PREDUE_FRACTION = 0.12;
+/** Floor/ceiling on the window so tiny intervals still get a day and huge ones don't open weeks early. */
+export const PREDUE_MIN_WINDOW_DAYS = 1;
+export const PREDUE_MAX_WINDOW_DAYS = 21;
+const PREDUE_DAY_MS = 86_400_000;
+
+function clampNum(n: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/** The pre-due window width (days) for a word, from its interval (or stability fallback). */
+export function preDueWindowDays(w: WordSignal): number | null {
+  const iv = w.intervalDays ?? (w.stability != null ? 1.9 * w.stability : null);
+  if (iv == null || iv <= 0) return null;
+  return clampNum(PREDUE_FRACTION * iv, PREDUE_MIN_WINDOW_DAYS, PREDUE_MAX_WINDOW_DAYS);
+}
+
+/**
+ * How deep a word is into its pre-due window at `nowMs`: 0 = just entered, 1 = exactly
+ * due, >1 = overdue. `null` = not yet in window (don't surface for pre-due review) or
+ * unscheduled. Higher = more urgent to surface before it becomes a flashcard. A word
+ * with a due date but no interval signal only becomes "urgent" once actually due.
+ */
+export function preDueUrgency(w: WordSignal, nowMs: number): number | null {
+  if (!w.dueAt) return null;
+  const dueMs = Date.parse(w.dueAt);
+  if (Number.isNaN(dueMs)) return null;
+  const windowDays = preDueWindowDays(w);
+  if (windowDays == null) return dueMs <= nowMs ? (nowMs - dueMs) / PREDUE_DAY_MS : null;
+  const windowMs = windowDays * PREDUE_DAY_MS;
+  const startMs = dueMs - windowMs;
+  if (nowMs < startMs) return null; // not yet in its window
+  return (nowMs - startMs) / windowMs;
+}
+
+/**
+ * Pick the review-floor words to surface for pre-due reinforcement: those currently in
+ * their pre-due window (or overdue), most-urgent first, capped at `limit`. Unlike a
+ * plain soonest-due sort, this respects each word's PROPORTIONAL window, so a
+ * long-interval word gets surfaced early enough (in absolute days) to be reinforced
+ * before it falls due. Words not yet in window are excluded — surfacing them wastes the
+ * reader's few review slots on cards that aren't at risk yet.
+ */
+export function selectPreDueFloor(signals: WordSignal[], nowMs: number, limit: number): WordSignal[] {
+  return signals
+    .map((w) => ({ w, u: preDueUrgency(w, nowMs) }))
+    .filter((x): x is { w: WordSignal; u: number } => x.u !== null)
+    .sort((a, b) => b.u - a.u) // most urgent (deepest into window / most overdue) first
+    .slice(0, Math.max(0, limit))
+    .map((x) => x.w);
 }
 
 /**

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -1,7 +1,7 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { GoogleGenAI } from 'https://esm.sh/@google/genai';
 import { GEMINI_FLASH, GROQ_GENERAL as GROQ_MODEL } from '../_shared/models.ts';
-import { classifyBucket, compareByProximity, compareKnown, compareStuck, compareByDue, type WordSignal } from '../_shared/wordPriority.ts';
+import { classifyBucket, compareByProximity, compareKnown, selectPreDueFloor, type WordSignal } from '../_shared/wordPriority.ts';
 import { buildRewritePrompt } from '../_shared/rewritePrompt.ts';
 
 const corsHeaders = {
@@ -313,14 +313,15 @@ Deno.serve(async (req) => {
     // story orphan (seen once, topic never recurs) and never drift easier. Reserve a
     // couple of review slots for the user's most-stuck hard/medium words and blend them
     // in regardless of topic. Post-#67 the FSRS engine gives every active word a real
-    // `due_at`, so #72 routes these slots by true due-date order (compareByDue): genuinely
-    // due words surface first, falling back to the old staleness heuristic (compareStuck)
-    // for words that share a due date or aren't scheduled yet.
+    // `due_at` + `interval_days`, so these slots route by the PRE-DUE window
+    // (selectPreDueFloor): words entering their proportional window before due surface
+    // first (most urgent first), giving reading a chance to reinforce them before they
+    // reach the flashcard deck. Words not yet in-window are skipped.
     const stuckFloor = Math.min(STUCK_REVIEW_FLOOR, Math.max(1, targetReview));
     try {
       const { data: stuckRows } = await supabase
         .from('user_word_progress')
-        .select('word_id, mastery_level, difficulty, times_seen, last_seen_at, due_at, stability')
+        .select('word_id, mastery_level, difficulty, times_seen, last_seen_at, due_at, stability, interval_days')
         .eq('user_id', userId)
         .in('mastery_level', ['hard', 'medium'])
         // Intake gate (#68): never surface a word that's still queued (waiting for daily
@@ -337,13 +338,16 @@ Deno.serve(async (req) => {
         difficulty: r.difficulty ?? null,
         timesSeen: r.times_seen ?? null,
         lastSeenAt: r.last_seen_at ?? null,
-        // #72: real FSRS schedule so compareByDue can rank genuinely-due words first.
+        // #72: real FSRS schedule so the review floor can rank by true due-date.
         dueAt: r.due_at ?? null,
         stability: r.stability ?? null,
+        intervalDays: r.interval_days ?? null,
       }));
-      // #72: due-date order (due words first), staleness only as a tiebreaker/fallback.
-      stuckSignals.sort(compareByDue);
-      const stuckIds = stuckSignals.slice(0, stuckFloor).map((s) => s.entryId);
+      // Pre-due surfacing window: reinforce words approaching due (proportional to their
+      // interval) so reading can push them out before they hit the flashcard deck. Only
+      // in-window / overdue words qualify, most-urgent first — spending the reader's few
+      // review slots on cards actually at risk, not ones due months out.
+      const stuckIds = selectPreDueFloor(stuckSignals, Date.now(), stuckFloor).map((s) => s.entryId);
       if (stuckIds.length > 0) {
         // Resolve surface forms (kanji preferred, kana fallback), preserving stuck order.
         const [{ data: kanjiRows }, { data: kanaRows }] = await Promise.all([


### PR DESCRIPTION
## Problem

Opening the Study tab surfaced **~1,400 cards due at once**. Root cause is *not* the intake queue — it's the FSRS seed: #67 anchored `due_at` at `last_seen_at`, so the entire **seed-on-sight back-catalog came due together**, and #68's D2 grandfather kept all of it `active`. A read-only audit of real data confirmed 2,626 tracked words, 1,400 due, 2,620 never deliberately promoted.

## Reframe — Policy F: flashcards serve reading, not the reverse

- **Easy words (difficulty ≤ 3)** stay scheduled but **forward-reseeded far out** (anchored at *now*, stretched by exposure history). Reading pushes them further, so they rarely surface.
- **Medium+ words** go back to the intake **queue**, dripping in at the daily cap (3/day, foundation-first).
- **Graduate when easy** is automatic in FSRS — no extra code.

**No hard review cap.** A cap that hides genuinely-due cards just defers work into an invisible backlog ("review hell"). The real cap is *small inflow*, via the reseed + the pre-due window below. (A latent, default-**off** `reviewCap` primitive stays in `deck.ts` as a safety valve.)

## Pre-due surfacing window

The reader now surfaces a word for a window **before** it's due — proportional to its interval (~12%, clamped 1–21 days; a 2-month card gets ~a week). Reading past it advances FSRS and pushes `due_at` out, so it may **never reach the flashcard deck**. Flashcards become the fallback for words reading didn't reinforce in time.

## One-time correction

The flood is a legacy artifact and can't recur (new words enter the queue; reading no longer auto-activates). So the fix is a **self-hiding one-shot** in Settings → Advanced ("Rebalance Flashcard Deck"), gated on `lastStudyPacingResetTs` — not a recurring knob.

## Changes

| area | change |
|---|---|
| `src/services/srs.ts` | `seedForwardFromHistory` / `estimateStability` |
| `src/services/pacing.ts` *(new)* | `decidePacing` — Policy F split + deterministic spread |
| `src/services/store.ts` | `resetStudyPacing` action |
| `src/services/api.ts` | `resetStudyPacingBatch` (batched, writes nulls) |
| `src/services/deck.ts` | latent, default-off `reviewCap` |
| `_shared/wordPriority.ts` + `process-article/index.ts` | pre-due window (`selectPreDueFloor`) |
| `src/components/Settings.tsx` | reorganized page; one-shot Rebalance in Advanced |
| `scripts/audit-reseed.cjs` *(new)* | read-only data audit + policy sweep |

## Testing

- `test-srs` 36 · `test-deck` 32 · `test-pacing` 15 · `test-wordpriority` 25 · `test-intake` 14 — **all green**
- `tsc --noEmit` clean · no new lint

Full analysis in `docs/study-pacing-flood-fix.md`.

## Activation (not automatic)

1. Deploy `process-article` (turns on the pre-due window).
2. Settings → Advanced → **Rebalance Flashcard Deck** (one-time; audit predicts ~683 easy kept far-out, ~1,943 to the queue). No new DB column — reuses existing `user_word_progress` scheduling columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)