### PR TITLE
feat: input-side difficulty control via concept clusters

### DIFF
--- a/docs/vocab-palette-redesign.md
+++ b/docs/vocab-palette-redesign.md
@@ -1,0 +1,216 @@
+# Vocabulary Palette Redesign — Input-Side Difficulty Control
+**Status:** Approved — implementing **Goal:** Stop articles from being littered with above-level words by fixing what vocabulary we feed the LLM _before_ generation — not by filtering after.
+
+## Decisions (open questions resolved)
+
+1. **Counts** — 8 topics + 8 actions, ≤3 synonyms each.
+2. **Universal glue seed** — none; trust the model at-level, keep the existing thin-palette fallback text.
+3. **Variety** — offer ≤3 synonyms/concept + "vary your choice" instruction; **defer** cross-article rotation (add only if still samey).
+4. **Difficulty contract** — "simpler beats precise" made explicit, subordinate to the facts golden rule.
+5. **Scope** — ship nets + clusters + prompt together, then run the eval harness before done. The RPC change lands as a manual migration file.
+
+## Implementation notes (as built)
+
+- **No SQL migration.** Instead of a new cluster-returning RPC, the pipeline calls the *existing* `jmdict_vocab_candidates` once per concept (parallel `Promise.all`), which keeps each synonym cluster grouped. Zero DB changes to apply by hand; the whole-word-match tweak is deferred (mitigation #2, not core).
+- **Additive prompt.** `RewriteInput.clusters?` is optional. Present → new DIFFICULTY CEILING + concept-cluster block; absent → the legacy flat palette renders byte-for-byte, so the eval harness's frozen fixtures stay a valid baseline (verified via `--print-prompt`).
+- **Cluster contents.** Per concept: keep only `known` (backbone) + `new` (at/below-level) words, easiest-first (`compareKnown` then `compareByProximity`), cap 4, deduped across clusters. `review` (hard/medium) words are excluded from clusters — the topic-independent SRS floor still surfaces them for reinforcement.
+- **Files:** `_shared/rewritePrompt.ts` (clusters field + block), `process-article/index.ts` (two-net `extractConceptsWithGroq` + cluster builder), `scripts/eval-article-rewrite.mjs` (clusters passthrough).
+- **Not yet run:** the paid eval harness (real Gemini calls) and a live regenerate for this user — both need a deploy + API budget; awaiting the go-ahead.
+
+* * *
+## The problem
+Generated articles use vocabulary well above the reader's level (e.g. 導入する, 監視, 罰金, 特定する, 取り締まる in an N3 article), forcing constant lookups. That defeats the app's core promise.
+
+The cause is **input-side**, not the model being disobedient:
+
+1. **JLPT level is prose, not a lexicon.** The prompt tells Gemini "the reader understands everyday Japanese" (`rewritePrompt.ts:50`). There's no word list to anchor to.
+  
+2. **The vocab palette is topic-noun-shaped and thin.** Groq extracts ~12 _English topic nouns_; those are substring-matched against JMDict English glosses (`database/22_vocab_candidates_stretch.sql:45-48`). A Japanese word only surfaces if its gloss contains the exact keyword string.
+  
+3. **The words that actually make news hard are verbs/abstract nouns** — 導入する, 特定する, 取り締まる, 引き起こす — which Groq is explicitly told _not_ to extract ("concrete nouns and topic terms preferred", `process-article/index.ts:133`). They're never candidates, so the model is never told an easier way to say them.
+  
+4. **The known-word backbone is topic-gated**, so the general connective vocabulary the reader actually knows (使う, 続ける, 場所, 出す) is invisible to the palette. When the backbone comes back thin, the prompt falls back to "(rely on natural N-level vocabulary)" (`rewritePrompt.ts:104`) — pure guessing.
+  
+5. **Zero post-generation validation** (`const processedBlocks = rawBlocks`, `process-article/index.ts:416`) — out of scope here by choice; we're fixing the input.
+  
+## What we are NOT doing
+- No post-generation filtering, tokenizing, or regeneration passes.
+  
+- No new dataset (no WordNet import) in the first cut. English-synonym expansion is done by the LLM in-context.
+  
+- No static global top-N backbone list (rejected — see "Variety" below).
+  
+
+* * *
+## Core insight: two nets, one mechanism
+A readable article needs two kinds of non-topic vocabulary, and both should be **derived from the article itself** and **filtered to words the reader knows**:
+
+| Net | What it captures | Example (fireworks/drone article) |
+| --- | --- | --- |
+| **Topic net** (exists today) | Concrete nouns of the story | ドローン, 花火, 消防局 |
+| **Action/relation net** (new) | Verbs, adjectives, abstract nouns describing what _happens_ | 導入する, 監視する, 撮影する, 特定する, 引き起こす, 警告する, 広がる |
+
+The action/relation net is the missing "filler that fits this particular article." It varies story to story (a flood article yields different verbs), so it never makes articles sound alike.
+
+**One mechanism serves both nets: the concept cluster.**
+
+```
+English keyword/action
+  → in-context English synonyms (LLM)
+  → gloss-match each → Japanese candidates
+  → filter to words the reader knows, rank by ease
+  → labeled cluster handed to the LLM
+```
+
+Example clusters:
+
+```
+«identify / locate»    → 特定する · 見つける · わかる
+«crack down / stop»    → 取り締まる · 止める · 捕まえる
+«surveillance / watch» → 監視 · 見張り
+```
+
+The cluster does **double duty**:
+
+- **Difficulty downgrade** — the model picks the easiest member the reader knows.
+  
+- **Variety** — offering 2–3 known synonyms per concept (and rotating which leads across articles) means recurring news actions ("said," "announced") don't always resolve to the identical Japanese word.
+  
+
+* * *
+## Why English-synonym expansion (not Japanese-side)
+We have **no thesaurus data** — JMDict here stores only `gloss` (English) + POS (`database/06_jmdict_schema.sql:31-39`). Deriving synonyms Japanese-side means noisy gloss-overlap self-joins. Expanding on the **English** side is cleaner:
+
+- English synonym generation is something the LLM is genuinely reliable at (unlike Japanese level judgments).
+  
+- It's a **recall booster on the existing gloss match**: 監視's gloss is "surveillance," but 見張り's is "watch / lookout" — same concept, no string overlap, so 見張り never surfaces today. Expanding "surveillance → {monitoring, watching, oversight}" pulls the whole cluster.
+  
+- **Near drop-in**: `extractKeywordsWithGroq` already runs on the source in-context. We extend that one call; the `jmdict_vocab_candidates` RPC is unchanged.
+  
+### Polysemy mitigation
+English is ambiguous and we're compounding it ("fine" → 罰金 but also 元気/細かい; "watch" → 見張り but also 時計). Three cheap guards:
+
+1. **Expand in context** — Groq already sees the sentence; ask for sense-appropriate synonyms ("fine" as _penalty_). Kills most of it.
+  
+2. **Whole-word gloss match** instead of substring (`%fine%` currently hits "define/confine").
+  
+3. **Labeled clusters + existing freq/JLPT ranking** — a bad synonym only pollutes its own cluster, and frequency ranking sinks the junk.
+  
+### Honest limit
+Sometimes the whole cluster is above level (罰金 · 反則金 · 過料 are all hard). When no easy synonym exists, the concept is just hard — the right answer is an inline gloss (yugen-box), which the prompt already supports. We keep that as the fallback, not a word swap.
+
+* * *
+## Proposed pipeline changes
+### 1. Widen keyword extraction → two nets + synonyms
+Change `extractKeywordsWithGroq` (`process-article/index.ts:132-161`) to return, in one call and in-context:
+
+```jsonc
+{
+  "topics":  [{ "concept": "surveillance", "synonyms": ["monitoring", "watching", "oversight"] }, ...],
+  "actions": [{ "concept": "identify",     "synonyms": ["locate", "pinpoint"] }, ...]
+}
+```
+
+- `topics` = concrete nouns (today's behavior).
+  
+- `actions` = verbs / adjectives / abstract nouns describing the events (new net).
+  
+- Each concept carries 2–3 sense-appropriate English synonyms.
+  
+
+**Open question:** target counts — e.g. ~10 topics + ~10 actions, ~3 synonyms each? (See "Sizing" below.)
+### 2. Candidate query → group by concept
+Flatten `{concept + synonyms}` into gloss patterns, run the existing RPC, but **keep the concept grouping** instead of flattening into one bag (today: `process-article/index.ts:277-300`). Each concept becomes a cluster of Japanese candidates.
+
+Also: switch the RPC's gloss match from substring `ILIKE ANY` to whole-word matching.
+### 3. Bucket + known-filter per cluster
+Reuse `classifyBucket` / `wordPriority.ts` per cluster. Within each cluster, rank by ease-for-this-reader (confirmed-known → below-level → frequency). Drop clusters that end up empty after the known-filter, or mark them "needs gloss."
+### 4. Prompt: hand over labeled clusters + a difficulty contract
+Replace the flat palette block (`rewritePrompt.ts:102-107`) with concept clusters:
+
+```
+VOCABULARY GUIDANCE — prefer the reader's known words for each concept:
+- «identify»:   特定する / 見つける / わかる
+- «crack down»: 取り締まる / 止める / 捕まえる
+- «surveillance»: 監視 / 見張り
+Vary your choice across the article; do not reuse the same synonym every time.
+```
+
+And strengthen the difficulty contract (currently "guide, not quota" + "facts override everything", `rewritePrompt.ts:107,120`):
+
+> Do not use vocabulary above N{level}. When a precise term is above level, use a simpler everyday phrasing from the clusters above, or gloss it once in a yugen-box. **Simpler wording beats precise wording.** (Facts still override style — never distort the story to hit a word.)
+### 5. Variety / rotation
+Across a reader's articles, rotate which cluster member is listed first (or shuffle the 2–3 offered) so recurring concepts don't always resolve identically. Deterministic seed per (article, concept) so it's reproducible.
+
+* * *
+## Sizing (replaces the "15–20 is too small" problem)
+Old palette was thin because it was `{topic-keyword-matched} ∩ {known}`. New sizing:
+
+- **Topics:** ~10 concepts × cluster of up to ~4 known Japanese = richer topic pool.
+  
+- **Actions:** ~10 concepts × cluster of up to ~4 known Japanese = the new per-article filler layer.
+  
+- Function-word glue (する/いる/ある/こと…) is left to the model at-level — it repeats in all real text and needs no palette.
+  
+
+**Open question:** do we still want a small universal "safe verbs/adjectives at N-level" seed for when both nets come back thin, or is the LLM-at-level fallback enough?
+
+* * *
+## What this fixes
+| Root cause | Fix |
+| --- | --- |
+| Thin, topic-noun-only palette | Second (action/relation) net |
+| Hard concepts, no easier alternative offered | English-synonym → Japanese clusters, easiest-known surfaced |
+| Same backbone → articles sound alike | Backbone is article-derived + cluster rotation |
+| Soft "guide not quota" contract | Explicit N-level ceiling + "simpler beats precise" + gloss fallback |
+## Live-check findings (2026-07-13, real Groq + real JMDict, N3)
+
+Eval A/B (same fireworks article, hand-curated clusters vs legacy thin palette):
+**jlptFit 2/5 → 5/5**, fidelity + naturalness stayed 5/5. Judge on legacy: *"advanced Sino-Japanese (事案, 科される, 犠牲者, 継続) → closer to N2."* Judge on clusters: *"perfectly targeted for N3, with helpful glosses."* → the mechanism works.
+
+But running the REAL cluster query (not hand-curated) exposed quality gaps the eval couldn't:
+
+1. **Polysemy leaks through, incl. the concept word itself.** «fine» (penalty) → 大丈夫 / 結構 / 立派 (the "fine = good" sense). We match the concept word AND its synonyms as `%substring%` against glosses, so the wrong sense slips in. Needs whole-word match + POS filter (a monetary fine is a noun; drop verb/adj matches).
+2. **Proper-noun topics are noise.** «California» → 意味 / 1月 / 右; «Sacramento» → 電気 / 石. Entities have no JMDict equivalent — the topic net should skip proper nouns (the ACTION net carried the real value: «warning» → 注意(N4)/警告(N3), «filming» → 記録(N3), «publishing» → 発表(N3)).
+3. **The `jlpt_level IS NOT NULL` gate removes the BEST easy synonyms.** «monitoring» surfaced only 監視(N1)/追跡(N1) — 見張り (the easy downgrade we wanted) is untagged, so the RPC drops it, leaving the cluster with *only hard words*. This deferred item is more load-bearing than expected: without an untagged-word fallback, many concepts can't be downgraded at all.
+4. **Recall gaps.** «pinpointing» → 特定(N2) only; 見つける missed because its gloss is "to find", not "locate/identify".
+
+Net: the difficulty ceiling + good action-net clusters help (matching the eval), but topic-noun noise and the tag gate dilute it. The LLM shrugs off obviously-wrong suggestions (it won't say 大丈夫 for a fine), so the deployed version is not worse — but it's below the eval's ceiling until the noise filters land.
+
+### Recommended follow-up pass (turns the eval's 5/5 into the real-pipeline result)
+- **Whole-word gloss match** + **POS filter** (match action concepts to verb/adj entries, topic to nouns) — kills polysemy junk.
+- **Untagged-word fallback** — when a concept's tagged candidates are all above level, allow common untagged entries (by `freq_rank`/`is_common`) so 見張り-type downgrades survive. (RPC change → manual migration.)
+- **Skip proper-noun topic concepts** — ask Groq to flag entities, or drop concepts whose candidates are all low-frequency noise.
+- **Commonness floor** on cluster members so easy-but-irrelevant junk (何, 意味) can't be promoted by the known-filter.
+
+## Deferred (not in first cut)
+- WordNet / real thesaurus import (upgrade to cluster recall if English-synonym coverage proves thin).
+  
+- Any post-generation validation.
+  
+- Eval-harness updates to measure per-cluster known-coverage.
+  
+
+* * *
+## Questions for review
+1. **Extraction counts** — ~10 topics + ~10 actions, ~3 synonyms each? Too many / too few?
+  
+2. **Universal glue seed** — keep a tiny always-on safe-word set, or trust the model at-level?
+  
+3. **Variety** — is per-article rotation worth the complexity, or is the natural per-story variation of the action net enough on its own?
+  
+4. **Difficulty contract wording** — comfortable making "simpler beats precise" an explicit rule, given the existing "facts override everything" golden rule?
+  
+5. **Scope of first cut** — ship nets + clusters + prompt together, or land the action-net extraction first and measure before the prompt rewrite?
+
+---
+comments:
+  c1:
+    body: use your best judgement on the questions. overall this looks good
+    by: user
+    at: 2026-07-13T00:09:35.321Z
+  c2:
+    body: "Resolved all five in the new Decisions section: 8+8 concepts / ≤3 synonyms, no glue seed, variety via multi-synonym + vary-instruction (rotation deferred), explicit simpler-beats-precise, ship together + eval-harness gate. Implementing now."
+    by: AI
+    at: 2026-07-13T00:12:00.000Z
+    re: c1

--- a/scripts/eval-article-rewrite.mjs
+++ b/scripts/eval-article-rewrite.mjs
@@ -158,6 +158,10 @@ function toRewriteInput(fx) {
     reviewPalette,
     newPalette: fx.palette.new ?? [],
     vocabTargets: reviewPalette.slice(0, 5), // mirrors index.ts: vocabTargets = reviewPalette.slice(0,5)
+    // New cluster path (docs/vocab-palette-redesign.md): undefined for legacy fixtures →
+    // the shared builder renders the old flat palette unchanged. A fixture that ships
+    // `palette.clusters` exercises the concept-cluster prompt production now sends.
+    clusters: fx.palette.clusters,
   };
 }
 

--- a/scripts/eval-fixtures/eval-008-drones-fireworks-n3-clusters.json
+++ b/scripts/eval-fixtures/eval-008-drones-fireworks-n3-clusters.json
@@ -1,0 +1,36 @@
+{
+  "id": "EVAL-008",
+  "note": "N3 cluster path (docs/vocab-palette-redesign.md): the drone/fireworks story that motivated the redesign. Ships concept clusters (easiest-known first) + difficulty ceiling. A/B pair with EVAL-009 (same article, legacy thin palette) — expect higher jlptFit here.",
+  "source": {
+    "title": "Drones help fire department catch illegal fireworks",
+    "text": "The fire department in Sacramento, in northern California, used drones for the first time this year on July 4th. Thanks to the drone monitoring, one case resulted in a $100,000 fine. Firefighter Justin Silvia explained that the drones can film high-quality video and use Google Maps to pinpoint the location of fireworks. Every year, illegal fireworks cause serious fires, injuries, and several deaths. They also pollute the air around residential areas and create loud noise. Police and fire departments warned that they will publish the drone footage on social media and continue monitoring in the future.",
+    "sources": []
+  },
+  "profile": {
+    "jlptLevel": 3,
+    "rtkLevel": 700,
+    "studyMode": "balanced",
+    "vocabMode": "balanced",
+    "readingIntensity": "balanced",
+    "targetParagraphs": 3
+  },
+  "palette": {
+    "known": ["使い始める", "入れる", "導入する", "見張る", "監視する", "見つける", "特定する", "撮る", "撮影する", "止める", "捕まえる", "取り締まる", "禁止", "違法", "けが", "被害"],
+    "review": ["罰金", "騒音"],
+    "new": [],
+    "targetReview": 2,
+    "targetNew": 0,
+    "clusters": [
+      { "concept": "introduce", "words": ["使い始める", "入れる", "導入する"] },
+      { "concept": "monitor", "words": ["見張る", "監視する"] },
+      { "concept": "identify", "words": ["見つける", "特定する"] },
+      { "concept": "film", "words": ["撮る", "撮影する"] },
+      { "concept": "crack down", "words": ["止める", "捕まえる", "取り締まる"] },
+      { "concept": "illegal", "words": ["禁止", "違法"] },
+      { "concept": "damage", "words": ["けが", "被害"] }
+    ]
+  },
+  "assertions": {
+    "mustNotContain": []
+  }
+}

--- a/scripts/eval-fixtures/eval-009-drones-fireworks-n3-legacy.json
+++ b/scripts/eval-fixtures/eval-009-drones-fireworks-n3-legacy.json
@@ -1,0 +1,27 @@
+{
+  "id": "EVAL-009",
+  "note": "N3 legacy path A/B control: SAME drone/fireworks article as EVAL-008, but the thin topic-noun palette the OLD pipeline produced (no clusters, no difficulty ceiling). Baseline to measure the cluster path against.",
+  "source": {
+    "title": "Drones help fire department catch illegal fireworks",
+    "text": "The fire department in Sacramento, in northern California, used drones for the first time this year on July 4th. Thanks to the drone monitoring, one case resulted in a $100,000 fine. Firefighter Justin Silvia explained that the drones can film high-quality video and use Google Maps to pinpoint the location of fireworks. Every year, illegal fireworks cause serious fires, injuries, and several deaths. They also pollute the air around residential areas and create loud noise. Police and fire departments warned that they will publish the drone footage on social media and continue monitoring in the future.",
+    "sources": []
+  },
+  "profile": {
+    "jlptLevel": 3,
+    "rtkLevel": 700,
+    "studyMode": "balanced",
+    "vocabMode": "balanced",
+    "readingIntensity": "balanced",
+    "targetParagraphs": 3
+  },
+  "palette": {
+    "known": ["消防", "花火", "警察", "動画"],
+    "review": ["罰金"],
+    "new": ["騒音"],
+    "targetReview": 1,
+    "targetNew": 1
+  },
+  "assertions": {
+    "mustNotContain": []
+  }
+}

--- a/supabase/functions/_shared/rewritePrompt.ts
+++ b/supabase/functions/_shared/rewritePrompt.ts
@@ -35,6 +35,15 @@ export interface RewriteInput {
   newPalette: string[];
   /** vocab_mode "Study" targets, drawn from the review palette. */
   vocabTargets: string[];
+  /**
+   * Concept clusters for input-side difficulty control (docs/vocab-palette-redesign.md).
+   * Each concept lists reader-appropriate Japanese words, EASIEST-KNOWN FIRST, so the
+   * model can say a hard idea with a word the reader already has. When present this
+   * SUPERSEDES the flat known/new palette block and adds an explicit difficulty ceiling.
+   * Absent (e.g. legacy eval fixtures) → the old flat-palette block renders byte-for-byte
+   * unchanged, so the eval harness baseline is preserved.
+   */
+  clusters?: { concept: string; words: string[] }[];
 }
 
 // JLPT level controls COMPLEXITY only (grammar/vocab difficulty). Article
@@ -68,7 +77,7 @@ export function buildRewritePrompt(input: RewriteInput): string {
   const {
     title, sourceText, targetParagraphs, jlptLevel, rtkLevel,
     studyMode, vocabMode, ratios, targetReview, targetNew,
-    knownPalette, reviewPalette, newPalette, vocabTargets,
+    knownPalette, reviewPalette, newPalette, vocabTargets, clusters,
   } = input;
 
   const jlptStr = `N${jlptLevel}`;
@@ -93,9 +102,28 @@ export function buildRewritePrompt(input: RewriteInput): string {
     }
   }
 
-  // Build targeted vocab palette block (empty string if pipeline produced nothing)
+  // Build targeted vocab palette block (empty string if pipeline produced nothing).
+  // Two shapes: the concept-cluster block (new input-side difficulty control) when the
+  // caller supplies `clusters`, else the legacy flat known/review/new palette. The legacy
+  // branch is kept byte-for-byte so the eval harness's frozen fixtures stay a valid
+  // regression baseline (scripts/eval-article-rewrite.mjs).
   let palettePrompt = '';
-  if (knownPalette.length + reviewPalette.length + newPalette.length > 0) {
+  if (clusters && clusters.length > 0) {
+    const clusterLines = clusters
+      .map((c) => `- «${c.concept}»: ${c.words.join(' / ')}`)
+      .join('\n');
+    // The review floor (topic-independent SRS words the reader is due to reinforce) still
+    // rides along as a flat list — it's a scheduling concern, not a difficulty one.
+    const reviewLine = reviewPalette.length > 0
+      ? `\nREVIEW — the reader is due to practise these; work about ${targetReview} of them in where they fit the facts naturally: ${reviewPalette.join('、')}`
+      : '';
+    palettePrompt = `
+DIFFICULTY CEILING: Write at or below ${jlptStr}. When the precise term for something is above ${jlptStr}, express the idea with the simpler wording listed below, or gloss it once in a yugen-box. SIMPLER WORDING BEATS PRECISE WORDING — a reader who understands every word learns more than one reaching for the dictionary. (This never overrides the GOLDEN RULE: never distort the facts to hit or avoid a word.)
+
+VOCABULARY GUIDANCE — to express each concept, PREFER the reader-appropriate words below (calibrated to this reader's level and known vocabulary, easiest first):
+${clusterLines}
+Vary your choice across the article — do not reuse the same word every time a concept recurs.${reviewLine}`;
+  } else if (knownPalette.length + reviewPalette.length + newPalette.length > 0) {
     const pctKnown = Math.round(ratios.known * 100);
     const pctReview = Math.round(ratios.review * 100);
     const pctNew = Math.round(ratios.new * 100);

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -112,9 +112,6 @@ const DEFAULT_TARGET_PARAGRAPHS: Record<SourceKind, number> = {
 // longer full-text article gets proportionally more review/new words — keeping
 // the known/review/new density constant instead of diluting it across more text.
 const WORDS_PER_PARAGRAPH = 67;
-// Backbone (KNOWN) pool size per paragraph — a draw-from pool, not a quota — so a
-// longer article has a richer known palette to build its spine from.
-const KNOWN_WORDS_PER_PARAGRAPH = 10;
 
 // #51: how many review slots to reserve for a topic-INDEPENDENT floor of the user's
 // most-stuck words, blended in regardless of whether they match the article's topic.
@@ -129,13 +126,61 @@ const INTENSITY_RATIOS: Record<string, { known: number; review: number; new: num
   intensive: { known: 0.900, review: 0.080, new: 0.020 },
 };
 
-async function extractKeywordsWithGroq(title: string, snippet: string, apiKey: string): Promise<string[]> {
-  const prompt = `Extract 10-15 topic keywords from this English news article. Return ONLY a JSON array of lowercase single-word or two-word phrases — concrete nouns and topic terms preferred (skip filler like "the", "said", "people"). No explanation.
+// A story concept plus sense-appropriate English synonyms. Expanding on the English
+// side is a recall booster on the JMDict gloss match: 監視's gloss is "surveillance"
+// but 見張り's is "watch / lookout" — same idea, no string overlap — so pulling
+// {monitoring, watching, oversight} surfaces the whole synonym cluster at varying
+// difficulty, from which we later pick the easiest word the reader knows.
+// See docs/vocab-palette-redesign.md.
+interface Concept { concept: string; synonyms: string[] }
+
+// Max concepts per net and synonyms per concept (docs decision #1). Bounds both the
+// per-concept candidate fan-out and the eventual prompt length.
+const MAX_CONCEPTS_PER_NET = 8;
+const MAX_SYNONYMS_PER_CONCEPT = 3;
+// Words offered per concept cluster — enough to give the model an easiest-first choice
+// (and rotate for variety) without bloating the prompt.
+const CLUSTER_WORDS_MAX = 4;
+
+function normalizeConcepts(raw: unknown): Concept[] {
+  if (!Array.isArray(raw)) return [];
+  const out: Concept[] = [];
+  const seen = new Set<string>();
+  for (const item of raw) {
+    // Tolerate both {concept, synonyms:[...]} and a bare "word" string.
+    const concept = String((item && typeof item === 'object' ? (item as any).concept : item) ?? '')
+      .toLowerCase().trim();
+    if (concept.length < 2 || concept.length > 30 || seen.has(concept)) continue;
+    seen.add(concept);
+    const synRaw = (item && typeof item === 'object' ? (item as any).synonyms : []) ?? [];
+    const synonyms = (Array.isArray(synRaw) ? synRaw : [])
+      .map((s: unknown) => String(s).toLowerCase().trim())
+      .filter((s: string) => s.length >= 2 && s.length <= 30 && s !== concept)
+      .slice(0, MAX_SYNONYMS_PER_CONCEPT);
+    out.push({ concept, synonyms });
+    if (out.length >= MAX_CONCEPTS_PER_NET) break;
+  }
+  return out;
+}
+
+// Extract the article's concepts in two nets (docs/vocab-palette-redesign.md):
+//   topics  — concrete nouns/entities the story is ABOUT
+//   actions — verbs/adjectives/abstract ideas describing what HAPPENS (the news-register
+//             vocabulary that makes articles hard and that the old noun-only extractor
+//             threw away). Each concept carries sense-appropriate English synonyms.
+async function extractConceptsWithGroq(
+  title: string, snippet: string, apiKey: string,
+): Promise<{ topics: Concept[]; actions: Concept[] }> {
+  const prompt = `You are preparing vocabulary for a Japanese news rewrite. From this English news article, extract its key CONCEPTS in two groups. For each concept give up to ${MAX_SYNONYMS_PER_CONCEPT} common English synonyms, chosen for THIS article's sense (e.g. "fine" meaning a monetary penalty → "penalty, forfeit"; NOT "healthy, delicate").
+
+- "topics": concrete nouns / entities the story is about (people, things, places, organizations).
+- "actions": verbs, adjectives, and abstract ideas describing what HAPPENS (e.g. introduce, monitor, identify, warn, spread, illegal, damage). Prefer these over filler like "said" or "people".
+
+Give up to ${MAX_CONCEPTS_PER_NET} concepts per group. Return ONLY JSON of this exact shape:
+{"topics":[{"concept":"surveillance","synonyms":["monitoring","watching","oversight"]}],"actions":[{"concept":"identify","synonyms":["locate","pinpoint"]}]}
 
 Title: ${title}
-Snippet: ${snippet}
-
-Example output: ["economy", "trade", "tariff", "minister", "election"]`;
+Snippet: ${snippet}`;
 
   const response = await fetch(GROQ_API_URL, {
     method: 'POST',
@@ -149,15 +194,14 @@ Example output: ["economy", "trade", "tariff", "minister", "election"]`;
   });
   if (!response.ok) {
     const err = await response.json().catch(() => ({}));
-    throw new Error(`Groq keyword extraction failed: ${err.error?.message || response.statusText}`);
+    throw new Error(`Groq concept extraction failed: ${err.error?.message || response.statusText}`);
   }
   const data = await response.json();
-  const raw = data.choices?.[0]?.message?.content ?? '[]';
-  // gpt-oss-20b in json_object mode may wrap in {"keywords": [...]} or return a bare array
-  const parsed = JSON.parse(raw);
-  const arr: unknown = Array.isArray(parsed) ? parsed : (parsed.keywords ?? parsed.topics ?? parsed.terms ?? []);
-  if (!Array.isArray(arr)) return [];
-  return arr.map(String).map((s) => s.toLowerCase().trim()).filter((s) => s.length >= 2 && s.length <= 30);
+  const parsed = JSON.parse(data.choices?.[0]?.message?.content ?? '{}');
+  return {
+    topics: normalizeConcepts(parsed.topics),
+    actions: normalizeConcepts(parsed.actions),
+  };
 }
 
 Deno.serve(async (req) => {
@@ -230,36 +274,50 @@ Deno.serve(async (req) => {
     const targetNew = Math.max(1, Math.round(ratios.new * wordsBudget));
     console.log(`[process-article] length: ${targetParagraphs} paragraphs (sourceKind=${sourceKind}), vocab budget ${wordsBudget} -> ${targetReview} review / ${targetNew} new`);
 
-    // 2. Vocabulary palette pipeline
-    //    a) Extract topic keywords from the English source (Groq)
-    //    b) Query JMDict for candidate entries whose glosses match
-    //    c) Bucket candidates into known / review / new vs. user_word_progress
-    let knownPalette: string[] = [];
+    // 2. Vocabulary palette pipeline (docs/vocab-palette-redesign.md)
+    //    a) Extract the story's concepts in two nets — topics + actions (Groq)
+    //    b) For each concept, gloss-match its English synonyms in JMDict, ONE RPC per
+    //       concept (parallel) so each synonym cluster stays grouped, not flattened
+    //    c) Within a cluster keep only words the reader can USE (known backbone or
+    //       at/below-level "new"), easiest first — so the model can say a hard idea with
+    //       a word the reader already knows.
+    // knownPalette/newPalette stay empty: the flat palette is superseded by clusters, but
+    // the fields remain for the shared prompt builder's legacy (eval-harness) back-compat.
+    const knownPalette: string[] = [];
     let reviewPalette: string[] = [];
-    let newPalette: string[] = [];
+    const newPalette: string[] = [];
     let vocabTargets: string[] = []; // legacy: kept for vocab_mode prompt back-compat
+    const clusters: { concept: string; words: string[] }[] = [];
     try {
-      const keywords = await extractKeywordsWithGroq(title, sourceText.slice(0, 2000), groqKey);
-      if (keywords.length > 0) {
-        const keywordPatterns = keywords.map((k) => `%${k}%`);
-        const { data: candidates, error: candErr } = await supabase.rpc('jmdict_vocab_candidates', {
-          keywords: keywordPatterns,
-          user_jlpt: jlptLevel,
-          max_results: 200,
-        });
-        if (candErr) throw candErr;
+      const { topics, actions } = await extractConceptsWithGroq(title, sourceText.slice(0, 2000), groqKey);
+      const concepts = [...topics, ...actions];
+      if (concepts.length > 0) {
+        // One RPC per concept (parallel) reusing the existing candidate function unchanged
+        // (no migration). Modest per-concept cap — we only surface a few words per cluster.
+        const perConcept = await Promise.all(concepts.map(async (c) => {
+          const patterns = [c.concept, ...c.synonyms].map((k) => `%${k}%`);
+          const { data, error } = await supabase.rpc('jmdict_vocab_candidates', {
+            keywords: patterns,
+            user_jlpt: jlptLevel,
+            max_results: 40,
+          });
+          if (error) {
+            console.warn(`[process-article] cluster query failed for «${c.concept}»:`, error.message);
+            return { concept: c.concept, candidates: [] as any[] };
+          }
+          return { concept: c.concept, candidates: (data ?? []) as any[] };
+        }));
 
-        const entryIds: string[] = (candidates ?? []).map((c: any) => c.entry_id);
-        // Fetch the richer per-user signals (numeric difficulty + times_seen), not just
-        // the coarse mastery_level bucket, so the metric can rank by real familiarity (#25).
+        // One progress lookup across ALL clusters' candidates (avoids N round-trips).
+        const allEntryIds = Array.from(new Set(perConcept.flatMap((p) => p.candidates.map((c) => c.entry_id))));
         type Progress = { mastery: WordSignal['mastery']; difficulty: number | null; timesSeen: number | null };
         let progressMap = new Map<string, Progress>();
-        if (entryIds.length > 0) {
+        if (allEntryIds.length > 0) {
           const { data: progress } = await supabase
             .from('user_word_progress')
             .select('word_id, mastery_level, difficulty, times_seen')
             .eq('user_id', userId)
-            .in('word_id', entryIds);
+            .in('word_id', allEntryIds);
           progressMap = new Map((progress ?? []).map((p: any) => [p.word_id, {
             mastery: p.mastery_level,
             difficulty: p.difficulty ?? null,
@@ -267,45 +325,50 @@ Deno.serve(async (req) => {
           }]));
         }
 
-        // Map DB rows onto the shared Word Priority Metric (../_shared/wordPriority.ts),
-        // the single source of "which word matters" across the palette, intake (#68),
-        // and the deck (#70). It owns the known/review/new bucketing and the per-bucket
-        // ordering: the KNOWN backbone by confirmed-familiarity then frequency (#25), and
-        // REVIEW/NEW by JLPT proximity to the reader then frequency (#22).
-        const display = new Map<string, string>();
-        const buckets: Record<'known' | 'review' | 'new', WordSignal[]> = { known: [], review: [], new: [] };
-        for (const c of (candidates ?? []) as any[]) {
-          const text = c.kanji || c.kana;
-          if (!text) continue;
-          display.set(c.entry_id, text);
-          const prog = progressMap.get(c.entry_id);
-          const signal: WordSignal = {
-            entryId: c.entry_id,
-            jlptLevel: c.jlpt_level ?? null,
-            freqRank: c.freq_rank ?? null,
-            isCommon: !!c.is_common,
-            mastery: prog?.mastery,
-            difficulty: prog?.difficulty ?? null,
-            timesSeen: prog?.timesSeen ?? null,
-          };
-          const bucket = classifyBucket(signal, jlptLevel);
-          if (bucket) buckets[bucket].push(signal);
-        }
+        // Build one cluster per concept via the shared Word Priority Metric
+        // (../_shared/wordPriority.ts). Keep only USABLE words: known backbone
+        // (compareKnown, confirmed/assumed-known easiest first) then at/below-level "new"
+        // (compareByProximity). Hard/medium (review) words are excluded — struggling words
+        // are reinforced through the SRS floor below, not offered as the "easy way to say it".
         const byProximity = compareByProximity(jlptLevel);
-        buckets.known.sort(compareKnown);
-        buckets.review.sort(byProximity);
-        buckets.new.sort(byProximity);
-        knownPalette = buckets.known.map((s) => display.get(s.entryId)!);
-        reviewPalette = buckets.review.map((s) => display.get(s.entryId)!);
-        newPalette = buckets.new.map((s) => display.get(s.entryId)!);
-        // De-dupe while preserving order
-        knownPalette = Array.from(new Set(knownPalette)).slice(0, KNOWN_WORDS_PER_PARAGRAPH * targetParagraphs);
-        reviewPalette = Array.from(new Set(reviewPalette)).slice(0, Math.max(5, targetReview + 2));
-        newPalette = Array.from(new Set(newPalette)).slice(0, Math.max(3, targetNew + 2));
+        const usedSurfaces = new Set<string>(); // a surface leads at most one cluster
+        for (const { concept, candidates } of perConcept) {
+          const known: { s: WordSignal; text: string }[] = [];
+          const fresh: { s: WordSignal; text: string }[] = [];
+          for (const c of candidates) {
+            const text = c.kanji || c.kana;
+            if (!text) continue;
+            const prog = progressMap.get(c.entry_id);
+            const signal: WordSignal = {
+              entryId: c.entry_id,
+              jlptLevel: c.jlpt_level ?? null,
+              freqRank: c.freq_rank ?? null,
+              isCommon: !!c.is_common,
+              mastery: prog?.mastery,
+              difficulty: prog?.difficulty ?? null,
+              timesSeen: prog?.timesSeen ?? null,
+            };
+            const bucket = classifyBucket(signal, jlptLevel);
+            if (bucket === 'known') known.push({ s: signal, text });
+            else if (bucket === 'new') fresh.push({ s: signal, text });
+          }
+          known.sort((a, b) => compareKnown(a.s, b.s));
+          fresh.sort((a, b) => byProximity(a.s, b.s));
+          const words: string[] = [];
+          for (const { text } of [...known, ...fresh]) {
+            if (usedSurfaces.has(text) || words.includes(text)) continue;
+            words.push(text);
+            if (words.length >= CLUSTER_WORDS_MAX) break;
+          }
+          if (words.length > 0) {
+            words.forEach((w) => usedSurfaces.add(w));
+            clusters.push({ concept, words });
+          }
+        }
       }
-      console.log(`[process-article] Palette: ${knownPalette.length} known, ${reviewPalette.length} review, ${newPalette.length} new (intensity=${readingIntensity})`);
+      console.log(`[process-article] Clusters: ${clusters.length} concept(s) [${clusters.map((c) => c.concept).join(', ')}]`);
     } catch (palErr) {
-      console.error('[process-article] Palette pipeline error (continuing without palette):', palErr);
+      console.error('[process-article] Palette pipeline error (continuing without clusters):', palErr);
     }
 
     // #51: topic-INDEPENDENT review floor. The palette above only re-injects a review
@@ -396,6 +459,7 @@ Deno.serve(async (req) => {
       reviewPalette,
       newPalette,
       vocabTargets,
+      clusters,
     });
 
     console.log(`[process-article] Pass 1 for user ${userId}`);


### PR DESCRIPTION
## Problem

Articles were littered with above-level vocabulary (導入する, 監視, 罰金, 特定する, 取り締まる in an N3 article), forcing constant lookups — the exact thing the app exists to prevent. The cause is **input-side**: nothing enforces the reader's level. The prompt only *asks* the model to stay in-level, then tells it facts override that. The vocab palette meant to help was topic-noun-shaped and thin — Groq extracted ~12 English topic nouns, substring-matched them against JMDict glosses, and the news-register verbs/abstract nouns that actually make articles hard were never candidates, so the model was never handed an easier way to say them.

## Approach (input-side only — no post-generation filtering)

- **Two extraction nets** (`extractConceptsWithGroq`): `topics` + a new `actions` net for the verbs/adjectives/abstract ideas describing what *happens* — the per-article "filler" the old noun-only extractor discarded.
- **English-synonym expansion** per concept — a recall booster on the gloss match (監視="surveillance" vs 見張り="watch/lookout" share no string), reached from the English side because we have no thesaurus data.
- **Concept clusters**: one candidate RPC per concept (parallel, existing RPC reused — **no migration**), grouped, keeping only usable words (known backbone + at/below-level), easiest-first. The model picks the easiest word the reader knows per concept and varies across recurrences.
- **Prompt**: explicit **DIFFICULTY CEILING** ("simpler wording beats precise wording", kept subordinate to the facts golden rule) + labeled cluster guidance. **Additive** — `RewriteInput.clusters` is optional, so the legacy flat-palette path renders byte-for-byte and the eval harness's frozen fixtures remain a valid baseline.

## Validation

**A/B eval** (same fireworks article, clusters vs legacy thin palette, same model/temperature):

| | jlptFit | fidelity | naturalness |
|---|---|---|---|
| Legacy thin palette | **2/5** | 5/5 | 5/5 |
| Cluster path | **5/5** | 5/5 | 5/5 |

Judge on legacy: *"advanced Sino-Japanese (事案, 科される, 犠牲者, 継続) → closer to N2."* Judge on clusters: *"perfectly targeted for N3, with helpful glosses."* Concrete downgrades: 負傷者→けが, 継続→続ける, 用いて→使用.

**Live run** (real Groq + real JMDict) confirmed the action net works («warning»→注意/警告, «filming»→記録, «publishing»→発表) and surfaced follow-up work — polysemy leaks, proper-noun topic noise, and the `jlpt_level IS NOT NULL` gate dropping the best untagged easy synonyms (見張り). All captured in the design doc.

## Files
- `supabase/functions/process-article/index.ts` — two-net extraction + cluster builder
- `supabase/functions/_shared/rewritePrompt.ts` — optional clusters + difficulty ceiling block
- `scripts/eval-article-rewrite.mjs` — clusters passthrough
- `scripts/eval-fixtures/eval-00{8,9}-*.json` — A/B fixtures
- `docs/vocab-palette-redesign.md` — design, decisions, live-check findings, recommended follow-up

## Follow-up (deferred, in doc)
Whole-word + POS gloss match, untagged-word fallback (RPC migration), skip proper-noun topics, commonness floor — turns the eval's 5/5 into the real-pipeline result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWQK1Mn21BhmAdtQHCMWfB