### PR TITLE
fix: retry transient Gemini failures in process-article

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { LandingPage } from './components/LandingPage'
 import { useAppStore } from './services/store'
 import { supabase } from './services/supabase'
 import { useEffect, useState, useCallback, useRef } from 'react'
-import { fetchNewsFeed, NewsArticle, requestArticleProcessing, fetchReadyBufferArticles, ensureBuffer } from './services/api'
+import { fetchNewsFeed, NewsArticle, requestArticleProcessing, fetchReadyBufferArticles, ensureBuffer, isServerBusyError } from './services/api'
 import { MoreVertical, ChevronLeft } from 'lucide-react'
 
 const DEV_MODE = import.meta.env.VITE_DEV_MODE === 'true';
@@ -39,7 +39,6 @@ function App() {
   const dismissedArticleIds = useAppStore(state => state.dismissedArticleIds || []);
   const dismissArticle = useAppStore(state => state.dismissArticle);
   const markArticleRead = useAppStore(state => state.markArticleRead);
-  const [failedArticleIds, setFailedArticleIds] = useState<Set<string>>(new Set());
   // Transient, user-visible message for failures that would otherwise be silent
   // (e.g. an article that does nothing when tapped because processing failed).
   const [actionError, setActionError] = useState<string | null>(null);
@@ -50,7 +49,13 @@ function App() {
   }, [actionError]);
 
   const handleProcessArticle = useCallback(async (article: NewsArticle): Promise<NewsArticle | null> => {
-    if (!article.id || articlesCache[article.id] || (processingArticles || []).includes(article.id) || failedArticleIds.has(article.id)) return null;
+    // null return = a no-op guard (already cached or a tap while a prior run for
+    // this same article is still in flight), NOT a failure. Real failures throw,
+    // so the caller can classify them and show accurate copy. We deliberately do
+    // NOT remember failures: the only caller is an explicit user tap (the client
+    // JIT pre-processor is retired), so a re-tap should always retry — a single
+    // transient blip must never permanently brick a card for the session.
+    if (!article.id || articlesCache[article.id] || (processingArticles || []).includes(article.id)) return null;
 
     setProcessing(article.id, true);
     try {
@@ -73,15 +78,14 @@ function App() {
       );
       const processed = { ...article, blocks: processedBlocks };
       saveProcessedArticle(article.id, processed);
-      setProcessing(article.id, false);
       return processed;
     } catch (e) {
       console.error('[process] Failed for article:', article.id, article.title, e);
-      setFailedArticleIds(prev => new Set(prev).add(article.id));
+      throw e;
+    } finally {
+      setProcessing(article.id, false);
     }
-    setProcessing(article.id, false);
-    return null;
-  }, [articlesCache, processingArticles, setProcessing, saveProcessedArticle, failedArticleIds]);
+  }, [articlesCache, processingArticles, setProcessing, saveProcessedArticle]);
 
   const replenishFeedAtBottom = useCallback(async () => {
     if (isReplenishing || isLoadingFeed || isEndOfFeed) return;
@@ -454,17 +458,18 @@ function App() {
 
       // Genuinely not processed yet — process on demand, then open the Reader.
       const processed = await handleProcessArticle(article);
-      if (processed) {
-        // Don't yank the user in if they moved on during the long processing wait.
-        if (pendingOpenIdRef.current === article.id) openReader(processed);
-      } else {
-        // handleProcessArticle swallows its error into failedArticleIds; surface
-        // it here so the tap doesn't just silently do nothing.
-        setActionError("Couldn't load this article — the server may be busy. Please try another.");
-      }
+      // A null (non-throwing) result means a no-op guard fired — most likely a
+      // tap while a prior run for this same article is still in flight. Don't
+      // show an error; the in-flight run will open it.
+      if (processed && pendingOpenIdRef.current === article.id) openReader(processed);
     } catch (e) {
       console.error('[select] Failed to open article:', article.id, e);
-      setActionError("Couldn't load this article — the server may be busy. Please try another.");
+      const busy = isServerBusyError(e);
+      setActionError(
+        busy
+          ? "The server's busy right now — give it a moment and tap again."
+          : "Couldn't load this article. Please try again, or pick another."
+      );
     }
   };
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -56,6 +56,18 @@ function isAuthError(error: any): boolean {
   return msg.includes('jwt') || msg.includes('token') || msg.includes('unauthorized');
 }
 
+/** True when a failed edge-function call reflects a transiently-busy upstream
+ *  (LLM overloaded/rate-limited) rather than a real bug — process-article maps
+ *  these to HTTP 503, and a platform 429/503 counts too. Lets the UI show
+ *  "try again in a moment" instead of a generic failure. */
+export function isServerBusyError(error: unknown): boolean {
+  const e = error as { status?: number; context?: { status?: number }; message?: string } | null;
+  const status = e?.status ?? e?.context?.status;
+  if (status === 503 || status === 429) return true;
+  const msg = String(e?.message || '').toLowerCase();
+  return msg.includes('overload') || msg.includes('rate limit') || msg.includes('busy');
+}
+
 async function invokeEdgeFn<T = any>(name: string, body: object, timeoutMs?: number): Promise<T> {
   const run = () => {
     const invocation = supabase.functions.invoke(name, { body });

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -11,6 +11,56 @@ const corsHeaders = {
 
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
 
+// ── Transient LLM failure retry ──────────────────────────────────────────────
+// Gemini flash intermittently returns 429 (rate limit) / 503 (model overloaded)
+// and, less often, a truncated/empty body that fails JSON.parse. A single blip
+// used to brick the whole article — the user just saw "the server may be busy."
+// Retry the rewrite (generate + parse together, since a bad parse means we need
+// a fresh generation) with exponential backoff before giving up.
+const REWRITE_MAX_ATTEMPTS = 3;
+const REWRITE_BACKOFF_MS = [500, 1000, 2000];
+
+/** True for the transient upstream failures worth retrying: LLM rate-limit /
+ *  overload / 5xx, and malformed-JSON (empty or truncated) generations. */
+function isTransientLlmError(err: unknown): boolean {
+  if (err instanceof SyntaxError) return true; // truncated/empty JSON → regenerate
+  const status = (err as { status?: number; code?: number })?.status
+    ?? (err as { code?: number })?.code;
+  if (status === 429 || status === 500 || status === 503) return true;
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return /\b(429|500|503)\b|overload|unavailable|rate.?limit|resource.?exhausted|deadline|timeout/.test(msg);
+}
+
+/** Run the Pass-1 rewrite (Gemini generate + JSON.parse) with backoff on
+ *  transient failures. Non-transient errors throw immediately. */
+async function runRewriteWithRetry(ai: GoogleGenAI, prompt: string): Promise<any> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < REWRITE_MAX_ATTEMPTS; attempt++) {
+    try {
+      const result = await ai.models.generateContent({
+        model: GEMINI_FLASH,
+        contents: prompt,
+        config: { responseMimeType: 'application/json' },
+      });
+      const rawText = (result.text ?? '')
+        .replace(/^```(json)?[\s\n]*/i, '')
+        .replace(/[\s\n]*```$/i, '')
+        .trim();
+      return JSON.parse(rawText);
+    } catch (err) {
+      lastErr = err;
+      const transient = isTransientLlmError(err);
+      console.warn(
+        `[process-article] rewrite attempt ${attempt + 1}/${REWRITE_MAX_ATTEMPTS} failed (transient=${transient}):`,
+        err instanceof Error ? err.message : err,
+      );
+      if (!transient || attempt === REWRITE_MAX_ATTEMPTS - 1) throw err;
+      await new Promise((r) => setTimeout(r, REWRITE_BACKOFF_MS[attempt]));
+    }
+  }
+  throw lastErr;
+}
+
 // ── Opportunistic full-text extraction ──────────────────────────────────────
 // A NewsAPI/RSS teaser is ~150-200 chars; the real article body is 10-100x
 // richer. We pull it from the source URL via Jina Reader, but only for sources
@@ -463,13 +513,10 @@ Deno.serve(async (req) => {
     });
 
     console.log(`[process-article] Pass 1 for user ${userId}`);
-    const result1 = await ai.models.generateContent({
-      model: GEMINI_FLASH,
-      contents: prompt1,
-      config: { responseMimeType: 'application/json' },
-    });
-    const rawText1 = (result1.text ?? '').replace(/^```(json)?[\s\n]*/i, '').replace(/[\s\n]*```$/i, '').trim();
-    const rawBlocks = JSON.parse(rawText1);
+    // Retries transient Gemini overload/rate-limit and malformed-JSON blips with
+    // backoff (see runRewriteWithRetry) so one upstream hiccup no longer surfaces
+    // as "the server may be busy."
+    const rawBlocks = await runRewriteWithRetry(ai, prompt1);
 
     // Store paragraphs as raw text ({type, text}); the client tokenizes, adds
     // furigana, and links JMDict entries with a real morphological analyzer
@@ -525,9 +572,21 @@ Deno.serve(async (req) => {
     });
 
   } catch (err) {
-    console.error('[process-article] Error:', err);
-    return new Response(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }), {
-      status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    // Distinguish a genuinely-busy upstream (LLM overloaded/rate-limited even
+    // after retries) from a real server bug, so the client can show accurate
+    // copy instead of always blaming a busy server. `errorKind: 'llm_busy'` +
+    // HTTP 503 → "try again in a moment"; anything else → generic failure.
+    const busy = isTransientLlmError(err);
+    console.error(`[process-article] Error (busy=${busy}):`, err);
+    return new Response(
+      JSON.stringify({
+        error: err instanceof Error ? err.message : String(err),
+        errorKind: busy ? 'llm_busy' : 'server_error',
+      }),
+      {
+        status: busy ? 503 : 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      },
+    );
   }
 });


### PR DESCRIPTION
## Problem

Intermittent **"Couldn't load this article — the server may be busy. Please try another."** errors when opening articles (reported ~every other day, a few articles at a time).

Root cause: the `process-article` edge function made a **single** Gemini call with **no retry**. Gemini flash intermittently returns transient **429 (rate limit) / 503 (model overloaded)**, and occasionally a truncated/empty body that fails `JSON.parse`. Any of these flattened to a 500 and failed the whole request. Worse, the client then added the article to a permanent in-session `failedArticleIds` blacklist, so re-tapping the same card **never retried** until reload.

## Changes

**`process-article/index.ts`** — retry + accurate status
- New `runRewriteWithRetry()` wraps the Pass-1 rewrite (Gemini `generateContent` **and** `JSON.parse` together, since a bad parse needs a fresh generation): **3 attempts, 0.5→1→2s backoff**.
- `isTransientLlmError()` gates retries — fires on 429/500/503 (`.status`/`.code` + message) and on `SyntaxError`. Non-transient errors throw immediately.
- Catch block now returns **HTTP 503 + `errorKind: 'llm_busy'`** for transient upstream failures, **500** for genuine bugs.

**`App.tsx`** — no more sticky failures
- Removed `failedArticleIds` entirely. Its only caller is an explicit user tap (the client JIT pre-processor is retired), so a re-tap now always retries — one transient blip no longer bricks a card for the session.
- `handleProcessArticle` now **throws** real failures (via `finally` for the processing flag) instead of swallowing them; a `null` return strictly means a no-op guard (already cached / in-flight) and shows no error.

**`api.ts`** — accurate copy
- New exported `isServerBusyError()` reads the 503/429 signal. UI shows *"The server's busy right now — give it a moment and tap again."* only for real busy signals, and a generic retry message otherwise.

## Verification
- ✅ `tsc --noEmit` clean
- ✅ No new lint errors (pre-existing `no-explicit-any` only)
- ⚠️ Deno not installed locally — edge-fn untyped-checked but follows the file's conventions

## Deploy note
The edge-function half needs `supabase functions deploy process-article` to take effect (retry + status codes are server-side). Frontend ships on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)