### PR TITLE
fix: morning-empty flashcard deck (calendar-day gate + cross-device sync) + in-card grade pills

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -220,3 +220,26 @@
         test-intake 14 — all green; tsc clean; 0 new lint.
   - [ ] ACTIVATE (your step): deploy process-article, then Settings → Rebalance Flashcard
         Deck. No new DB column (reuses user_word_progress scheduling columns).
+- [x] Morning-empty-deck fix + in-card grade strip (Jul 13)
+  - Symptom: 0 cards at 9:36am, then a single NEW card (出口) that was just read.
+    Verified against prod data: 出口 was a WordModal mastery-tap promotion (by
+    design); the daily batch never ran (rolling 24h gate — phone last promoted
+    12:17pm Jul 12); and Jul 11's 3 promoted words (reps 0 server-side) were
+    invisible because rehydrate dropped promotedTs/intakeStatus/schedule fields.
+  - [x] store.promoteIntakeQueue — gate by LOCAL CALENDAR DAY (sameLocalDay), not
+        rolling 24h; count words already promoted today (promotedTs, rides the
+        sync — cross-device + manual modal promotions) against newWordsPerDay;
+        only deck-eligible (JLPT-leveled) queued words may win slots.
+  - [x] store.checkDailyKanji — same calendar-day gate (same drift bug).
+  - [x] syncSrsWithSupabase rehydrate — carry stability/dueAt/reps/lapses/
+        srsStatus/intervalDays/fsrsDifficulty/lastReviewedTs/intakeStatus/promotedTs
+        so cross-device promotions surface in the deck.
+  - [x] Flashcards.tsx — constant card height (min(540px,62vh) both faces); the 4
+        grade buttons now live INSIDE the back face as a hairline-divided bottom
+        strip (no height change on flip); empty-deck snapshot rebuilds when the
+        async app-open promotion lands.
+  - Verified: all 5 test runners green (122 total), tsc -b + vite build clean,
+    0 new lint; Playwright walkthrough (front → flip → grade → next card).
+  - [x] Grade-strip restyle (variant A): floating white capsule pills, grade color
+        carried ONLY by a soft tinted shadow (no dots, no divider grid); JLPT tag
+        de-pilled to plain text so it doesn't read as a fifth button.

--- a/src/components/Flashcards.tsx
+++ b/src/components/Flashcards.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronDown } from 'lucide-react';
 import { useAppStore, WordData } from '../services/store';
@@ -14,14 +14,15 @@ const DEV_MODE = import.meta.env.VITE_DEV_MODE === 'true';
 // (#67) and writes a `flashcard` review-log row. The deck is SNAPSHOTTED at mount
 // (tab open) so grading a card doesn't reshuffle the pile underfoot.
 
-// Grade color is carried by a small dot (not a full fill) so the buttons read as
-// part of the card's white/hairline aesthetic while keeping the red→green
-// traffic-light cue. Dots are muted tones from the same palette family.
-const RATINGS: { rating: Rating; label: string; dot: string }[] = [
-  { rating: 1, label: 'Again', dot: '#cf7d6b' },
-  { rating: 2, label: 'Hard', dot: '#c2a058' },
-  { rating: 3, label: 'Good', dot: '#8fb0c4' },
-  { rating: 4, label: 'Easy', dot: '#8faa74' },
+// Grade color is carried entirely by a soft tinted shadow under each white pill —
+// no dot, no fill, no colored border — so the buttons keep the card's hairline
+// aesthetic while the red→green traffic-light cue glows quietly beneath them.
+// Tones are the same muted palette family the dots used.
+const RATINGS: { rating: Rating; label: string; shadow: string }[] = [
+  { rating: 1, label: 'Again', shadow: '0 3px 10px rgba(207, 125, 107, 0.30)' },
+  { rating: 2, label: 'Hard', shadow: '0 3px 10px rgba(194, 160, 88, 0.30)' },
+  { rating: 3, label: 'Good', shadow: '0 3px 10px rgba(143, 176, 196, 0.35)' },
+  { rating: 4, label: 'Easy', shadow: '0 3px 10px rgba(143, 170, 116, 0.32)' },
 ];
 
 // A card carries the full word plus which source (due review / new) put it here.
@@ -87,6 +88,21 @@ export function Flashcards() {
 
   const [index, setIndex] = useState(0);
   const [revealed, setRevealed] = useState(false);
+
+  // The app-open promotion pass (sync → promoteIntakeQueue) is async and can land
+  // AFTER this tab mounted with an empty deck. While the deck is empty, rebuild the
+  // snapshot whenever words change so freshly promoted cards surface without a
+  // tab-away round trip. Once a deck exists it stays snapshotted (no reshuffling).
+  const wordDatabase = useAppStore((s) => s.wordDatabase);
+  useEffect(() => {
+    if (cards.length > 0) return;
+    const fresh = buildDeck();
+    if (fresh.length > 0) {
+      setCards(fresh);
+      setIndex(0);
+      setRevealed(false);
+    }
+  }, [cards.length, wordDatabase]);
 
   // Dev-only: seed a demo deck, then rebuild the snapshot in place (no reload).
   function seedAndReload() {
@@ -185,10 +201,10 @@ export function Flashcards() {
         </div>
       </div>
 
-      {/* Card + grade group — the FRONT card grows down into the button zone so the
-          flip target sits where the thumb already rests. On flip the card shrinks
-          up and the grade buttons slide into the space it vacated. Both live in one
-          centered column so the whole unit stays put. */}
+      {/* The card is a single FIXED-HEIGHT flip surface. The grade buttons live
+          INSIDE the back face, as a hairline-divided strip along its bottom edge —
+          so flipping never changes the card's height or shifts the layout, and the
+          buttons arrive with the flip itself (no second animation). */}
       <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem', perspective: '1600px' }}>
         <AnimatePresence mode="wait">
           {/* Outer wrapper handles the between-cards slide/fade. */}
@@ -197,10 +213,10 @@ export function Flashcards() {
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0, transition: { duration: 0.2, ease: [0.22, 1, 0.36, 1] } }}
             exit={{ opacity: 0, y: -10, transition: { duration: 0.11, ease: 'easeIn' } }}
-            style={{ width: '100%', maxWidth: '340px', display: 'flex', flexDirection: 'column' }}
+            style={{ width: '100%', maxWidth: '340px' }}
           >
-            {/* Inner element rotates in 3D — front and back are its two faces. Its
-                height shrinks on reveal (540→440) to open room for the buttons. */}
+            {/* Inner element rotates in 3D — front and back are its two faces.
+                Capped in px but scaled by vh so it never tucks under the nav. */}
             <motion.div
               onClick={() => !revealed && setRevealed(true)}
               initial={false}
@@ -209,11 +225,7 @@ export function Flashcards() {
               style={{
                 position: 'relative',
                 width: '100%',
-                // Front grows into the button zone; shrinks on reveal. Capped in px but
-                // scaled by vh so it never tucks under the nav on short screens.
-                // (Height rides a CSS transition since framer can't tween a min() calc.)
-                height: revealed ? 'min(440px, 50vh)' : 'min(540px, 62vh)',
-                transition: 'height 0.55s cubic-bezier(0.22, 1, 0.36, 1)',
+                height: 'min(540px, 62vh)',
                 transformStyle: 'preserve-3d',
                 cursor: revealed ? 'default' : 'pointer',
               }}
@@ -226,8 +238,38 @@ export function Flashcards() {
                 </div>
               </CardFace>
 
-              {/* BACK — reading (furigana) + meaning + grammar note + JLPT pill. */}
-              <CardFace back>
+              {/* BACK — reading (furigana) + meaning + grammar note + JLPT level,
+                  with the grade pills floating along the bottom edge. */}
+              <CardFace
+                back
+                footer={
+                  <div style={{ display: 'flex', flexShrink: 0, gap: '9px', padding: '0 1.1rem 1.15rem' }}>
+                    {RATINGS.map(({ rating, label, shadow }) => (
+                      <button
+                        key={rating}
+                        onClick={() => grade(rating)}
+                        style={{
+                          flex: 1,
+                          display: 'flex',
+                          flexDirection: 'column',
+                          alignItems: 'center',
+                          gap: '2px',
+                          padding: '0.55rem 0 0.6rem',
+                          border: '1px solid var(--border-light)',
+                          borderRadius: '999px',
+                          backgroundColor: 'var(--bg-pure)',
+                          boxShadow: shadow,
+                          color: 'var(--text-main)',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        <span style={{ fontSize: '0.8rem', fontWeight: 600 }}>{label}</span>
+                        <span style={{ fontSize: '0.68rem', color: 'var(--text-muted)' }}>{previews[rating]}</span>
+                      </button>
+                    ))}
+                  </div>
+                }
+              >
                 <FuriganaWord word={card.word} reveal={true} />
                 <div style={{ fontSize: '1.1rem', color: 'var(--text-main)', marginTop: '1.5rem', lineHeight: 1.6, maxWidth: '28ch' }}>
                   {card.word.meaning}
@@ -237,16 +279,14 @@ export function Flashcards() {
                     {card.word.grammarNote}
                   </div>
                 )}
+                {/* Plain text (no pill chrome) — a pill here would read as a fifth
+                    button now that the grade pills share the card. */}
                 {card.word.jlptLevel != null && (
                   <span
                     className="sans"
                     title={card.word.jlptDerived ? 'Approximate level (inferred from kanji / frequency)' : undefined}
                     style={{
                       marginTop: '1.5rem',
-                      padding: '0.25rem 0.75rem',
-                      border: '1px solid var(--border-light)',
-                      borderRadius: '999px',
-                      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.05)',
                       fontSize: '0.7rem',
                       fontWeight: 800,
                       letterSpacing: '0.04em',
@@ -259,46 +299,6 @@ export function Flashcards() {
                 )}
               </CardFace>
             </motion.div>
-
-            {/* Grade buttons — slide into the space the shrinking card vacated,
-                so they land right under the thumb that just tapped to flip. */}
-            <AnimatePresence>
-              {revealed && (
-                <motion.div
-                  initial={{ opacity: 0, y: 8 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.3, delay: 0.18, ease: [0.22, 1, 0.36, 1] }}
-                  style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}
-                >
-                  {RATINGS.map(({ rating, label, dot }) => (
-                <button
-                  key={rating}
-                  onClick={() => grade(rating)}
-                  style={{
-                    flex: 1,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    gap: '0.3rem',
-                    padding: '0.7rem 0.25rem',
-                    border: '1px solid var(--border-light)',
-                    borderRadius: '14px',
-                    backgroundColor: 'var(--bg-pure)',
-                    boxShadow: '0 2px 8px rgba(0, 0, 0, 0.05)',
-                    color: 'var(--text-main)',
-                    cursor: 'pointer',
-                  }}
-                >
-                  <span style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', fontSize: '0.85rem', fontWeight: 600 }}>
-                    <span style={{ width: '7px', height: '7px', borderRadius: '50%', backgroundColor: dot }} />
-                    {label}
-                  </span>
-                  <span style={{ fontSize: '0.7rem', color: 'var(--text-muted)' }}>{previews[rating]}</span>
-                </button>
-                  ))}
-                </motion.div>
-              )}
-            </AnimatePresence>
           </motion.div>
         </AnimatePresence>
       </div>
@@ -362,8 +362,9 @@ function FuriganaWord({ word, reveal }: { word: WordData; reveal: boolean }) {
 // One face of the flip card — a minimal white card surface (hairline border, soft
 // shadow). Both faces stack via absolute positioning; the back is pre-rotated 180°
 // so it reads correctly once the card flips. `backface-visibility: hidden` hides
-// whichever face currently points away from the viewer.
-function CardFace({ children, back = false }: { children: React.ReactNode; back?: boolean }) {
+// whichever face currently points away from the viewer. `footer` renders flush
+// against the face's bottom edge, outside the content padding (the grade strip).
+function CardFace({ children, back = false, footer }: { children: React.ReactNode; back?: boolean; footer?: React.ReactNode }) {
   return (
     <div
       style={{
@@ -371,10 +372,6 @@ function CardFace({ children, back = false }: { children: React.ReactNode; back?
         inset: 0,
         display: 'flex',
         flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        textAlign: 'center',
-        padding: '2rem 1.75rem',
         backgroundColor: 'var(--bg-pure)',
         border: '1px solid var(--border-light)',
         borderRadius: '22px',
@@ -385,7 +382,22 @@ function CardFace({ children, back = false }: { children: React.ReactNode; back?
         overflow: 'hidden',
       }}
     >
-      {children}
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          position: 'relative',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          textAlign: 'center',
+          padding: '2rem 1.75rem',
+        }}
+      >
+        {children}
+      </div>
+      {footer}
     </div>
   );
 }

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -142,6 +142,14 @@ export function mergeWordData(into: WordData, from: WordData): WordData {
   };
 }
 
+/** True when two ms-epoch timestamps fall on the same LOCAL calendar day. Daily
+ * gates (intake promotion, RTK bump) compare days rather than elapsed hours: a
+ * rolling `now - last >= 24h` check only fires while the app happens to be open,
+ * so its fire time drifts later every day and mornings come up empty. */
+function sameLocalDay(a: number, b: number): boolean {
+  return new Date(a).toDateString() === new Date(b).toDateString();
+}
+
 export interface WordData {
   reading: string;
   meaning: string;
@@ -970,6 +978,20 @@ export const useAppStore = create<AppState>()(
                     streak: r.streak ?? 0,
                     lastSeenTs: r.lastSeenTs ?? Date.now(),
                     uniqueDaysSeen: [],
+                    // FSRS schedule + intake state (#67/#68). Dropping these here made
+                    // a word promoted on ANOTHER device rehydrate as unscheduled — its
+                    // promotedTs/stability vanished, so it never surfaced in the deck
+                    // and never counted against the daily new-word cap.
+                    stability: r.stability ?? null,
+                    fsrsDifficulty: r.fsrsDifficulty ?? null,
+                    dueAt: r.dueAt ?? null,
+                    lastReviewedTs: r.lastReviewedTs ?? null,
+                    intervalDays: r.intervalDays ?? null,
+                    reps: r.reps ?? 0,
+                    lapses: r.lapses ?? 0,
+                    srsStatus: r.srsStatus ?? null,
+                    intakeStatus: r.intakeStatus ?? undefined,
+                    promotedTs: r.promotedTs ?? null,
                   };
                 });
                 return { wordDatabase: newDatabase };
@@ -1140,8 +1162,9 @@ export const useAppStore = create<AppState>()(
       checkDailyKanji: () => {
         const now = Date.now();
         const state = get();
-        // If it's the first time or 24 hours (86400000 ms) have passed
-        if (!state.lastRtkUpdateTs || now - state.lastRtkUpdateTs > 86400000) {
+        // First time, or a new local calendar day (a rolling 24h gate drifts later
+        // every day — see sameLocalDay).
+        if (!state.lastRtkUpdateTs || !sameLocalDay(state.lastRtkUpdateTs, now)) {
           let currentLevel = state.rtkLevel || 122;
           if (currentLevel < 122) currentLevel = 122; // One-time alignment
           const newLevel = Math.min(currentLevel + 3, rtkKanjiList.length);
@@ -1162,20 +1185,34 @@ export const useAppStore = create<AppState>()(
       // then most common). The queue draws from TWO sources — words the user has met
       // while reading (local 'queued' records) and important common words at/below their
       // level they haven't read yet (the get_intake_candidates RPC) — so the common
-      // backbone gets built even when articles skip it. Gated to once per 24h, mirroring
-      // checkDailyKanji; call it on app open alongside that pass.
+      // backbone gets built even when articles skip it. Gated to once per LOCAL CALENDAR
+      // DAY: a rolling 24h gate ratchets the promotion time later every day (it only
+      // fires while the app is open), so a morning open kept finding yesterday's stamp
+      // too fresh and produced no cards. Call it on app open, AFTER syncSrsWithSupabase.
       promoteIntakeQueue: async (now: number) => {
         const state = get();
-        if (state.lastIntakePromotionTs && now - state.lastIntakePromotionTs < 86400000) return;
+        if (state.lastIntakePromotionTs && sameLocalDay(state.lastIntakePromotionTs, now)) return;
         // Stamp immediately so a re-entrant call (e.g. a double mount) can't double-promote.
         set({ lastIntakePromotionTs: now });
 
-        const cap = state.newWordsPerDay ?? 3;
-        if (cap <= 0) return; // 0 = new words paused
+        const capPref = state.newWordsPerDay ?? 3;
+        if (capPref <= 0) return; // 0 = new words paused
 
-        // Source 1: words already encountered and waiting in the local queue.
+        // Words already promoted TODAY count against the cap. `promotedTs` stamps ride
+        // the sync (this runs after syncSrsWithSupabase), so a batch promoted on another
+        // device — or a manual modal mastery-set — spends today's slots instead of
+        // stacking a second full batch on top.
+        const promotedToday = Object.values(state.wordDatabase)
+          .filter((w) => w.promotedTs != null && sameLocalDay(w.promotedTs, now)).length;
+        const cap = capPref - promotedToday;
+        if (cap <= 0) return;
+
+        // Source 1: words already encountered and waiting in the local queue. Only
+        // deck-eligible words (JLPT level known — mirrors deck.isEligible) may compete:
+        // a level-less fragment that wins a slot becomes an *invisible* active word,
+        // silently burning the day's cap on cards the deck refuses to show.
         const queuedItems: IntakeItem[] = Object.entries(state.wordDatabase)
-          .filter(([, w]) => w.intakeStatus === 'queued')
+          .filter(([, w]) => w.intakeStatus === 'queued' && w.jlptLevel != null)
           .map(([key, w]) => ({
             key,
             entryId: w.jmdictEntryId ?? key,


### PR DESCRIPTION
## Symptom

Study tab was empty this morning; later a single NEW card (出口) appeared — a word just read in an article.

## Diagnosis (verified against production `user_word_progress` / `study_history`)

Three stacked causes:

1. **Rolling 24h promotion gate drifts.** `promoteIntakeQueue` fired only when 24h had elapsed since the last run *while the app was open*, so the daily promotion time ratchets later every day. The phone last promoted 12:17pm Jul 12 → gate still closed at 9:36am Jul 13.
2. **Per-device gate stamps don't dedupe across devices.** `lastIntakePromotionTs` lives in localStorage, so each device ran its own daily batch. Meanwhile the stray 出口 card was a WordModal mastery-tap (seen 9:30:38 → lookup 9:31:07 → "easy" tap 9:31:09), which #68 D3 promoted instantly — it was the *only* card because the daily batch never ran.
3. **Rehydrate dropped schedule fields.** Three words promoted Jul 11 (still `reps: 0` server-side) never surfaced: `syncSrsWithSupabase`'s remote-only-word rehydrate rebuilt WordData without `promotedTs`/`intakeStatus`/FSRS fields, so the deck couldn't see them.

## Fixes (`store.ts`)

- Gate `promoteIntakeQueue` (and `checkDailyKanji` — same drift bug) by **local calendar day** via `sameLocalDay()`.
- Count words with a today-stamped `promotedTs` against `newWordsPerDay` — `promoted_at` rides the sync, so cross-device batches spend slots instead of stacking.
- Carry all FSRS + intake fields (`stability`, `dueAt`, `reps`, `lapses`, `srsStatus`, `intervalDays`, `fsrsDifficulty`, `lastReviewedTs`, `intakeStatus`, `promotedTs`) through the rehydrate path.
- Only deck-eligible (JLPT-leveled) queued words may win promotion slots — level-less winners became invisible actives that silently burned the daily cap.

## D3 revision: mastery-taps no longer fast-track into the deck (2nd commit)

#68 D3 predates Policy F ("flashcards augment reading") — tapping EASY declared the word *known*, and the system answered by drilling it same-session, jumping the foundation-first queue. Revised, using `decidePacing` as the classifier:

- **hard/medium**: record the self-assessment only; the word **stays queued** and exits via the daily foundation-first cap (which seeds its schedule from the recorded grade).
- **easy**: skip drilling — activate into **far-out maintenance** (the same forward reseed the pacing rebalance uses) with `promotedTs` left null, so it never surfaces as a "new" card and never spends a daily slot. Reading pushes it further out.

`activateWord` (promotedTs-stamping) is now used only by the daily promotion pass — the single path that mints new flashcards.

## Flashcard redesign (`Flashcards.tsx`)

- Constant card height (`min(540px, 62vh)`) on both faces — no more height change on flip.
- The four grade buttons live **inside the back face** as floating capsule pills; the grade color is carried only by a soft tinted shadow (no dots, no divider grid).
- JLPT tag de-pilled to plain text so it doesn't read as a fifth button.
- An empty deck snapshot rebuilds when the async app-open promotion lands, so opening STUDY a beat early no longer shows "all caught up" until a tab round-trip.

## Verification

- All 5 standalone test runners green (122 tests): srs, deck, intake, pacing, wordpriority. Deck tests pin that `promotedTs: null` never surfaces as a new card.
- `tsc -b` + vite build clean; no new lint in touched files.
- Playwright walkthrough at iPhone viewport: front → flip → grade → next card, constant height throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWQK1Mn21BhmAdtQHCMWfB