### PR TITLE
fix: modal mastery-tap no longer fast-tracks words into the flashcard deck

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -243,3 +243,8 @@
   - [x] Grade-strip restyle (variant A): floating white capsule pills, grade color
         carried ONLY by a soft tinted shadow (no dots, no divider grid); JLPT tag
         de-pilled to plain text so it doesn't read as a fifth button.
+  - [x] D3 revision (Policy F): a modal mastery-tap no longer fast-tracks a word
+        into the deck. Hard/medium record the grade and STAY QUEUED (daily
+        foundation-first cap seeds from the grade at promotion); EASY activates
+        into far-out maintenance via decidePacing (promotedTs null → never a
+        "new" card, doesn't spend a daily slot). Was how 出口 jumped the queue.

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -53,8 +53,9 @@ export function seedDifficulty(jlptLevel: number | null | undefined, userLevel: 
 // Promote a word from the intake queue into active FSRS scheduling (#68). Seeds an
 // initial schedule from `difficulty`, anchored at `now` (a freshly promoted word
 // becomes due ~one interval from promotion), and stamps it `active`. Pure: the caller
-// persists + syncs the returned record. Used by the daily promotion pass and by an
-// explicit manual mastery-set (the two paths that graduate a queued word).
+// persists + syncs the returned record. Used ONLY by the daily promotion pass — the
+// one path that mints a "new" flashcard (a manual easy-set activates into far-out
+// maintenance instead, without a promotedTs; see setWordMastery).
 function activateWord(w: WordData, difficulty: number, now: number): WordData {
   const srs = seedSrsFromDifficulty(difficulty, now);
   return {
@@ -182,9 +183,10 @@ export interface WordData {
   lapses?: number | null;
   srsStatus?: SrsStatus | null;
   // Intake queue (#68). `queued` = encountered/candidate, exposure recorded but NOT on
-  // a schedule; `active` = promoted into FSRS scheduling. A word is promoted only by the
-  // daily new-word cap (foundation-first) or an explicit manual mastery-set. Undefined
-  // on legacy records until the v7 migration stamps them.
+  // a schedule; `active` = promoted into FSRS scheduling. Only the daily new-word cap
+  // (foundation-first) mints a NEW card (promotedTs stamped); a manual easy-set
+  // activates into far-out maintenance with promotedTs null (Policy F — known words
+  // aren't drilled). Undefined on legacy records until the v7 migration stamps them.
   freqRank?: number | null;       // JMDict freq_rank (1 = most common); for compareIntake
   intakeStatus?: 'queued' | 'active';
   promotedTs?: number | null;     // ms epoch — when it entered active study
@@ -637,13 +639,46 @@ export const useAppStore = create<AppState>()(
           const now = Date.now();
           const difficulty = level === 'unseen' ? null : difficultyForBucket(level);
 
-          // Explicit manual classification promotes a queued word into active study
-          // (#68, D3): opening the modal and declaring a word's difficulty is a direct
-          // statement of knowledge — unlike a passive read or a lookup, which only
-          // signal "I don't know it" and never fast-track promotion. Setting 'unseen'
-          // is not a promotion. Seeds the schedule from the chosen difficulty.
-          const shouldActivate = difficulty != null && current.intakeStatus !== 'active' && current.stability == null;
-          const base = shouldActivate ? activateWord(current, difficulty, now) : current;
+          // #68 D3, revised under Policy F ("flashcards augment reading"): a manual
+          // grade no longer fast-tracks a word into the flashcard deck. For a word
+          // not yet in active study, decidePacing classifies the declaration:
+          //   • hard/medium ("I'm learning this") — just record the grade; the word
+          //     STAYS QUEUED and exits via the daily foundation-first cap, which
+          //     seeds its schedule from this grade when it wins a slot.
+          //   • easy ("I know this") — drilling a known word wastes a daily slot, so
+          //     it skips the queue INTO FAR-OUT MAINTENANCE: the same forward reseed
+          //     the pacing rebalance uses, with promotedTs left null so it never
+          //     surfaces as a "new" card. Reading pushes it further out from there.
+          // Setting 'unseen' is never a promotion.
+          const notActive = current.intakeStatus !== 'active' && current.stability == null;
+          let base = current;
+          let toMaintenance = false;
+          if (difficulty != null && notActive) {
+            const decision = decidePacing({
+              key: word,
+              difficulty,
+              distinctExposures: current.uniqueDaysSeen?.length ?? 0,
+              intakeStatus: current.intakeStatus,
+              stability: current.stability,
+            }, now);
+            if (decision.action === 'keep-active') {
+              const srs = decision.srs;
+              toMaintenance = true;
+              base = {
+                ...current,
+                intakeStatus: 'active',
+                promotedTs: null,
+                stability: srs.stability,
+                fsrsDifficulty: srs.fsrsDifficulty,
+                dueAt: srs.dueAt,
+                lastReviewedTs: srs.lastReviewedAt,
+                intervalDays: (srs.dueAt - srs.lastReviewedAt) / 86_400_000,
+                reps: srs.reps,
+                lapses: srs.lapses,
+                srsStatus: srs.status,
+              };
+            }
+          }
           const updatedWord: WordData = { ...base, mastery: level, difficulty, lastAdjustedDay: today, lastAdjustReason: 'manual' };
 
           // Sync to Supabase
@@ -656,10 +691,10 @@ export const useAppStore = create<AppState>()(
                   timesSeen: updatedWord.timesSeen,
                   streak: updatedWord.streak,
                   lastSeenTs: updatedWord.lastSeenTs,
-                  // On promotion, persist the freshly-seeded schedule + intake status.
-                  ...(shouldActivate ? {
+                  // On a maintenance activation, persist the far-out schedule +
+                  // intake status (promotedTs stays null — not a "new" card).
+                  ...(toMaintenance ? {
                     intakeStatus: 'active',
-                    promotedTs: updatedWord.promotedTs,
                     stability: updatedWord.stability,
                     fsrsDifficulty: updatedWord.fsrsDifficulty,
                     dueAt: updatedWord.dueAt,


### PR DESCRIPTION
Follow-up to #106 — the second half of the 出口 investigation. (This commit was pushed to the #106 branch moments after it merged, so it's re-landed here.)

## Problem

#68 D3 let an explicit mastery-set in the WordModal promote a queued word straight into active study — that's how 出口 became a same-session "new" card, jumping the foundation-first queue. The intended flow is: every word enters the intake queue, and only the daily cap promotes, ordered by JLPT level / commonness.

D3 also predates Policy F ("flashcards augment reading"): tapping **easy** declares the word *known*, and the system answered by drilling it.

## Change (`store.setWordMastery`)

For a word not yet in active study, `decidePacing` (the Policy F classifier the rebalance already uses) now classifies the manual grade:

- **hard/medium** — record the self-assessment only; the word **stays queued** and exits via the daily foundation-first cap, which seeds its schedule from the recorded grade when it wins a slot.
- **easy** — skip drilling entirely: activate into **far-out maintenance** (same forward reseed as the pacing rebalance) with `promotedTs` left null, so it never surfaces as a "new" card and never spends a daily new-word slot. Reading pushes it further out.

`activateWord` (the promotedTs-stamping path) is now used only by the daily promotion pass — the single path that mints new flashcards.

## Verification

- All 5 test runners green (122 tests); deck tests pin that `promotedTs: null` never surfaces as a new card.
- `tsc -b` + vite build clean; 0 new lint in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWQK1Mn21BhmAdtQHCMWfB