### PR TITLE
fix: heal degraded entry-less word records stuck in Progress "Other"

### DIFF
--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -106,12 +106,15 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     if (!token) return;
     const details = token.details;
     const entryId = details?.jmdictEntryId || token.jmdict_entry_id;
-    // Don't grade off a raw, un-enriched token: with no dictionary link the JLPT
-    // is unknown, so seeding difficulty here would assume the word is hard (and it
-    // can't sync without an entry id). If the article hasn't been dictionary-linked
-    // yet, defer — leave the word un-marked so it grades correctly once enrichment
-    // swaps in linked tokens and it scrolls into view again.
-    if (!details && !entryId) {
+    // Only an entry id makes a token dictionary-linked. Fallback details from a
+    // partially-failed enrichment (reading-only, empty meaning, no entry id) must
+    // not be trusted here: grading off them stored degraded records — conjugated
+    // reading, blank meaning, no JLPT (→ stuck in Progress's "Other") — that can
+    // never sync. While the article isn't fully enriched the link may still
+    // arrive, so defer: leave the word un-marked and it grades correctly once
+    // enrichment swaps in linked tokens and it scrolls into view again.
+    const linked = !!entryId;
+    if (!linked) {
       const blocks = useAppStore.getState().currentArticle?.blocks;
       if (blocks && !isEnriched(blocks)) return;
     }
@@ -121,20 +124,20 @@ export function Reader({ initialArticle, onComplete }: ReaderProps) {
     const existing = useAppStore.getState().wordDatabase[key];
     const surface = details?.word ?? token.lemma ?? token.text ?? key;
     if (!existing) {
-      saveWordDefinition(key, details
-        ? { reading: details.reading, meaning: details.meaning, surface, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, freqRank: details.freqRank, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id }
-        : { reading: '...', meaning: 'Implicitly parsed context', surface, jmdictEntryId: token.jmdict_entry_id });
-    } else if (details && existing.jlptLevel == null && details.jlptLevel != null) {
+      saveWordDefinition(key, linked && details
+        ? { reading: details.reading, meaning: details.meaning, surface, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, freqRank: details.freqRank, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: entryId }
+        : { reading: details?.reading || '...', meaning: 'Implicitly parsed context', surface, furiganaMap: details?.furiganaMap, jmdictEntryId: entryId });
+    } else if (linked && details && existing.jlptLevel == null && details.jlptLevel != null) {
       // Self-heal: the word was first stored before enrichment linked it (so it had
       // no JLPT and sat in Progress's "Other"). Now that we have dictionary details,
       // patch in the level and full definition.
-      saveWordDefinition(key, { reading: details.reading, meaning: details.meaning, surface, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, freqRank: details.freqRank, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: details.jmdictEntryId || token.jmdict_entry_id });
+      saveWordDefinition(key, { reading: details.reading, meaning: details.meaning, surface, jlptLevel: details.jlptLevel, jlptDerived: details.jlptDerived, freqRank: details.freqRank, furiganaMap: details.furiganaMap, pos: details.pos, jmdictEntryId: entryId });
     }
     recordWordSeen(key, true);
     // Count the read either way, but only seed a difficulty when the word is
-    // dictionary-linked (official or freq-derived JLPT). A wholly unlinkable word
-    // stays ungraded rather than being guessed as hard.
-    if (details || entryId) applyDifficultyEvent(key, 'skip', jlptLevel);
+    // dictionary-linked (entry id present). A wholly unlinkable word stays
+    // ungraded rather than being guessed as hard.
+    if (linked) applyDifficultyEvent(key, 'skip', jlptLevel);
   };
   gradeRef.current = gradeWordByKey;
 

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -1070,8 +1070,9 @@ export const useAppStore = create<AppState>()(
         }
       },
 
-      // Backfill cached words that have a JMDict entry id but are missing a JLPT
-      // level and/or a difficulty:
+      // Backfill degraded cached words:
+      //   - entry-less records: resolved by surface form and re-keyed onto their
+      //     canonical entry_id (see the first stage below).
       //   - jlptLevel: resolved official → kanji → frequency (matches enrichment).
       //   - difficulty: seeded from the (now-known) JLPT as a read-past 'skip',
       //     exactly like applyDifficultyEvent's first contact, so a word seen before
@@ -1079,6 +1080,85 @@ export const useAppStore = create<AppState>()(
       // Only seeds difficulty for words actually encountered (timesSeen >= 1) and
       // syncs the seeded grades to Supabase in one batched round-trip.
       backfillWordProgress: async () => {
+        // Heal entry-less records by resolving their surface form against JMDict.
+        // A partially-failed enrichment (one lookup leg timing out / truncating)
+        // used to leave tokens link-less, and grading off them stored degraded
+        // records: conjugated reading, blank meaning, no entry id, no JLPT — stuck
+        // permanently in Progress's "Other" and invisible to the entry-id stages
+        // below. The stored surface is the kuromoji lemma, so a JMDict surface
+        // lookup recovers the entry; the record is then re-keyed onto its canonical
+        // entry_id (merging into any healthy duplicate tracked there) and picks up
+        // the dictionary reading/meaning/JLPT. Katakana-only surfaces are skipped
+        // on purpose: article katakana is mostly proper nouns, and linking e.g.
+        // トランプ (the person) to JMDict's "playing cards" would be wrong — those
+        // records legitimately live in "Other".
+        const entrylessTargets = Object.entries(get().wordDatabase)
+          .map(([key, w]) => ({ key, surface: w.surface ?? key, w }))
+          .filter(({ surface, w }) => {
+            if (w.jmdictEntryId) return false;
+            // Resolvable = contains hiragana or kanji (excludes katakana-only,
+            // romaji, digits) and isn't a bare single-kana parse fragment.
+            if (!/[぀-ゟ一-鿿㐀-䶿々]/.test(surface)) return false;
+            if (surface.length === 1 && /[぀-ゟ]/.test(surface)) return false;
+            return true;
+          });
+        if (entrylessTargets.length > 0) {
+          try {
+            const { lookupLemmasBatch, jmdictToWordDetails } = await import('./jmdict');
+            const surfaces = [...new Set(entrylessTargets.map(t => t.surface))];
+            // Chunk the batch: each surface can match several entries, and one huge
+            // .in() risks the silent ~1000-row cap — the very truncation that
+            // created these records during enrichment.
+            const resolved = new Map<string, import('./jmdict').JMDictResult>();
+            const CHUNK = 50;
+            for (let i = 0; i < surfaces.length; i += CHUNK) {
+              const part = await lookupLemmasBatch(surfaces.slice(i, i + CHUNK));
+              part.forEach((v, k) => resolved.set(k, v));
+            }
+            if (resolved.size > 0) {
+              set((state) => {
+                const db = { ...state.wordDatabase };
+                let changed = false;
+                for (const { key, surface } of entrylessTargets) {
+                  // Re-read latest; a concurrent lookup may have linked it already.
+                  const current = db[key];
+                  if (!current || current.jmdictEntryId) continue;
+                  const entry = resolved.get(surface);
+                  if (!entry) continue;
+                  const d = jmdictToWordDetails(surface, entry);
+                  const healed: WordData = {
+                    ...current,
+                    // The stored reading/furigana came from a conjugated token;
+                    // the JMDict lemma reading matches the displayed surface.
+                    reading: d.reading || current.reading,
+                    meaning: current.meaning && current.meaning !== 'Implicitly parsed context'
+                      ? current.meaning
+                      : (d.meaning || current.meaning),
+                    furiganaMap: d.furiganaMap.length > 0 ? d.furiganaMap : current.furiganaMap,
+                    pos: current.pos ?? d.pos,
+                    jlptLevel: current.jlptLevel ?? d.jlptLevel,
+                    jlptDerived: current.jlptLevel != null ? current.jlptDerived : d.jlptDerived,
+                    freqRank: current.freqRank ?? d.freqRank,
+                    surface: current.surface ?? surface,
+                    jmdictEntryId: d.jmdictEntryId,
+                  };
+                  if (d.jmdictEntryId !== key) {
+                    const existing = db[d.jmdictEntryId];
+                    db[d.jmdictEntryId] = existing ? mergeWordData(existing, healed) : healed;
+                    delete db[key];
+                  } else {
+                    db[key] = healed;
+                  }
+                  changed = true;
+                }
+                return changed ? { wordDatabase: db } : {};
+              });
+            }
+          } catch (e) {
+            console.warn('[store] entry-less word resolve failed:', e);
+          }
+        }
+
         // Heal words that entered via read-past (recordWordSeen creates them with an
         // empty `reading`) or were promoted to the deck before ever being looked up:
         // with no reading and no furiganaMap the flashcard front can't show furigana.


### PR DESCRIPTION
## Problem

Common kanji words (政府, 心配, 行う…) were showing up in Progress's **Other** tab — the bucket meant for words JMDict has no JLPT tag for. The tell was in the records themselves: conjugated readings (行う showing おこないました), blank meanings, uniform Medium ~5/10 seeds.

**Root cause:** when the enrichment batch lookup partially fails (a leg errors, times out, or hits the silent ~1000-row cap), unlinked tokens carry fallback details (reading-only, empty meaning, no entry id). The dwell-grader trusted any details, so it stored those degraded records and seeded a difficulty. With no entry id they were invisible to the existing entry-id backfill, could never sync, and duplicated the healthy record the same word later accrued under its entry id.

## Fix

**1. Stop creating them** (`Reader.tsx` — `gradeWordByKey`)
A token counts as dictionary-linked only when it has a JMDict entry id. Link-less fallback details no longer get stored as definitions or seed a difficulty; while the article is un-enriched, unlinked words defer and grade correctly once linked tokens swap in.

**2. Heal the existing ones** (`store.ts` — `backfillWordProgress`, new first stage)
Entry-less records are resolved by surface via `lookupLemmasBatch` (chunked at 50 to dodge the very row-cap truncation that caused this), get their dictionary reading/meaning/JLPT restored, and are re-keyed onto the canonical entry id — merging into any healthy duplicate (exposures add up, the stronger grade wins). Katakana-only surfaces are skipped on purpose: article katakana is mostly proper nouns (トランプ the person must not link to "playing cards"), so those legitimately stay in Other. Runs automatically on the existing sync path; healed words gain entry ids and start syncing for the first time.

## Expected impact (single-user audit)

- The degraded records live only on-device (zero surface-keyed traces among 31k `study_history` rows — they never synced). Everything containing kanji/hiragana that matches a JMDict surface heals to its real level.
- "Other" shrinks to the genuine no-JLPT-signal population: ~396 synced katakana loanwords / kana-only adverbs (アカウント, アニメ, ゆっくり…) plus katakana proper nouns.

## Verification (dev mode, driven in-browser)

- Seeded exact replicas of the degraded records → backfill healed 政府→N3 / 行う→N4 / できる→N5 with definitions restored, grades and ×2 seen-counts intact; トランプ untouched; Progress UI shows them under the right tabs.
- Duplicate merge: zombie 政府 + healthy entry-id record with a manual Easy grade → one record, timesSeen 2+5=7, manual grade preserved. Second load is a no-op.
- Grade guard: mock article with all JMDict requests blocked → dwelling over every word stores **zero** records (old code wrote degraded ones); with JMDict live, all words store linked with entry ids + JLPT, proper nouns stay ungraded placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015crQj1cntjSyLwhckHEzXp