### PR TITLE
feat: JLPT label on the detail card + stronger active-label contrast

### DIFF
--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -319,7 +319,7 @@ export function Progress() {
                     bottom: 'calc(100% + 7px)',
                     left: '50%',
                     transform: 'translateX(-50%)',
-                    fontSize: isActive ? '1.05rem' : '0.95rem',
+                    fontSize: isActive ? '1.1rem' : '0.85rem',
                     fontWeight: isActive ? 700 : 600,
                     letterSpacing: '0.04em',
                     lineHeight: 1,
@@ -357,6 +357,22 @@ export function Progress() {
           marginBottom: '1.5rem',
         }}
       >
+        {/* Mirrors the active mini donut's label styling so the card visibly
+            belongs to the selected level. */}
+        <span
+          className="sans"
+          style={{
+            display: 'block',
+            fontSize: '1.1rem',
+            fontWeight: 700,
+            letterSpacing: '0.04em',
+            color: 'var(--text-main)',
+            lineHeight: 1,
+            marginBottom: '1rem',
+          }}
+        >
+          {LEVELS.find((l) => l.value === activeLevel)?.label}
+        </span>
         {donutTotal === 0 ? (
           <p
             className="sans"


### PR DESCRIPTION
## Summary
- The detail card now opens with the selected level's label ("N4" etc.) top-left, styled identically to the active mini donut label (1.1rem, weight 700, 0.04em tracking, --text-main) so the card visibly belongs to the selected donut.
- Mini donut label contrast widened: inactive 0.95rem → 0.85rem, active 1.05rem → 1.1rem.

## Test plan
- Verified in Playwright 390×844 mobile emulation across level switches; `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186EMhy2FnJ6zWzPTzhaRv6