### PR TITLE
fix: Discover pills drop captions; furigana splits like regular flashcards

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -274,3 +274,13 @@
     +40d, med/hard queued no schedule → Progress buckets show them → deck stays
     empty → re-entry excludes graded → batch summary → Done). All 5 test
     runners green (122), tsc + vite build clean, 0 new lint in touched files.
+- [x] Discover polish + furigana repair (#115, Jul 14)
+  - [x] Discover pills label-only (dropped "study soon"/"known" captions).
+  - [x] Discover cards align furigana via alignReading (same as enrichment) and
+        persist the map on the materialised record.
+  - [x] Wired up loadReadingData() at app bootstrap — #36's per-kanji aligner was
+        never loaded at runtime, so alignReading silently degraded to
+        alignOkurigana app-wide (意味/病院 showed one grouped reading).
+  - [x] One-shot "Re-align Furigana" in Settings → Advanced (mirrors Rebalance):
+        recomputes the stored furiganaMap back-catalog locally (furiganaMap never
+        syncs to user_word_progress); self-hides via lastFuriganaRealignTs.

--- a/src/components/Flashcards.tsx
+++ b/src/components/Flashcards.tsx
@@ -5,6 +5,7 @@ import { useAppStore, WordData, MasteryLevel } from '../services/store';
 import { selectDeck, DeckEntry } from '../services/deck';
 import { schedule, seedSrsFromDifficulty, type Rating, type SrsState } from '../services/srs';
 import { fetchIntakeCandidates } from '../services/jmdict';
+import { alignReading } from '../services/furigana';
 import type { IntakeCandidate } from '../services/intake';
 import { seedDemoDeck } from '../services/devSeed';
 
@@ -45,19 +46,22 @@ interface Card {
 // → the intake queue, exactly as if graded from reading.
 const DISCOVER_BATCH = 20;
 
-const DISCOVER_GRADES: { level: Exclude<MasteryLevel, 'unseen'>; label: string; caption: string; shadow: string }[] = [
-  { level: 'hard',   label: 'Hard',   caption: 'study soon', shadow: '0 3px 10px rgba(207, 125, 107, 0.30)' },
-  { level: 'medium', label: 'Medium', caption: 'study soon', shadow: '0 3px 10px rgba(194, 160, 88, 0.30)' },
-  { level: 'easy',   label: 'Easy',   caption: 'known',      shadow: '0 3px 10px rgba(143, 170, 116, 0.32)' },
+const DISCOVER_GRADES: { level: Exclude<MasteryLevel, 'unseen'>; label: string; shadow: string }[] = [
+  { level: 'hard',   label: 'Hard',   shadow: '0 3px 10px rgba(207, 125, 107, 0.30)' },
+  { level: 'medium', label: 'Medium', shadow: '0 3px 10px rgba(194, 160, 88, 0.30)' },
+  { level: 'easy',   label: 'Easy',   shadow: '0 3px 10px rgba(143, 170, 116, 0.32)' },
 ];
 
 // Minimal display record for a Discover card — the word has no store entry yet,
-// so the card renders straight off the candidate row.
+// so the card renders straight off the candidate row. furiganaMap comes from the
+// same aligner the enrichment path uses (jmdictToWordDetails), so the reading
+// splits across kanji/okurigana exactly like a regular flashcard.
 function wordForCandidate(c: IntakeCandidate): WordData {
   return {
     reading: c.reading,
     meaning: c.meaning,
     surface: c.word,
+    furiganaMap: alignReading(c.word, c.reading),
     jlptLevel: c.jlptLevel,
     jmdictEntryId: c.entryId,
     freqRank: c.freqRank,
@@ -322,17 +326,16 @@ export function Flashcards() {
           onReveal={() => setRevealed(true)}
           footer={
             <div style={{ display: 'flex', flexShrink: 0, gap: '9px', padding: '0 1.1rem 1.15rem' }}>
-              {DISCOVER_GRADES.map(({ level, label, caption, shadow }) => (
+              {DISCOVER_GRADES.map(({ level, label, shadow }) => (
                 <button
                   key={level}
                   onClick={() => gradeDiscover(level)}
                   style={{
                     flex: 1,
                     display: 'flex',
-                    flexDirection: 'column',
                     alignItems: 'center',
-                    gap: '2px',
-                    padding: '0.55rem 0 0.6rem',
+                    justifyContent: 'center',
+                    padding: '0.75rem 0',
                     border: '1px solid var(--border-light)',
                     borderRadius: '999px',
                     backgroundColor: 'var(--bg-pure)',
@@ -342,7 +345,6 @@ export function Flashcards() {
                   }}
                 >
                   <span style={{ fontSize: '0.8rem', fontWeight: 600 }}>{label}</span>
-                  <span style={{ fontSize: '0.68rem', color: 'var(--text-muted)' }}>{caption}</span>
                 </button>
               ))}
             </div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -36,7 +36,8 @@ export function Settings() {
     newWordsPerDay, setNewWordsPerDay,
     readerFontSize, setReaderFontSize,
     readerFontWeight, setReaderFontWeight,
-    lastStudyPacingResetTs
+    lastStudyPacingResetTs,
+    lastFuriganaRealignTs
   } = useAppStore();
 
   const intensityOptions = ['leisure', 'balanced', 'intensive'] as const;
@@ -464,6 +465,39 @@ export function Settings() {
                   }}
                 >
                   Rebalance Flashcard Deck
+                </button>
+              </div>
+            </>
+          )}
+
+          {/* Re-align Furigana — one-time cleanup of the stored furiganaMap
+              back-catalog: maps saved before the per-kanji reading tables were
+              wired up (see main.tsx) carry one grouped reading per kanji run
+              (意味 → いみ over the pair) instead of per-kanji splits (い/み).
+              Local-only re-derive, nothing scheduled or deleted. Self-hides. */}
+          {lastFuriganaRealignTs == null && (
+            <>
+              <div style={{ width: '40px', height: '2px', backgroundColor: 'var(--border-light)', margin: '2rem 0' }} />
+              <div style={{ marginBottom: '1.5rem' }}>
+                <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-main)', marginBottom: '0.75rem' }}>
+                  Re-align Furigana
+                </label>
+                <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: '1.2rem' }}>
+                  A one-time cleanup of saved furigana: readings now split per kanji (意味 → い・み), but words saved earlier still show one grouped reading. Recomputes them on this device — nothing else changes. You only need to run this once.
+                </p>
+                <button
+                  onClick={async () => {
+                    const { useAppStore } = await import('../services/store');
+                    const r = await useAppStore.getState().realignFurigana();
+                    window.alert(`Furigana re-aligned.\n\n${r.updated} of ${r.scanned} words updated.`);
+                  }}
+                  style={{
+                    width: '100%', padding: '0.9rem', borderRadius: '12px', backgroundColor: 'transparent',
+                    color: 'var(--text-main)', border: '2px solid var(--border-light)', fontWeight: 700,
+                    fontSize: '0.9rem', cursor: 'pointer', letterSpacing: '0.03em',
+                  }}
+                >
+                  Re-align Furigana
                 </button>
               </div>
             </>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,14 @@
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { loadReadingData } from './services/furigana'
+
+// Prime the per-kanji reading tables (#36) as early as possible — alignReading
+// degrades to the coarser okurigana aligner until they land, and enrichment
+// STORES its furiganaMap, so a pre-load alignment would persist. Fire-and-forget:
+// the chunk is code-split and loads well before the first lookup's network
+// round-trip completes.
+loadReadingData()
 
 createRoot(document.getElementById('root')!).render(
   <App />

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -5,6 +5,7 @@ import { NewsArticle } from './api';
 import { supabase } from './supabase';
 import { schedule, ratingForReaderEvent, readerEventMayAdvance, seedSrsFromDifficulty, type SrsState, type SrsStatus, type Rating, type AdjustReason } from './srs';
 import { decidePacing, isActiveForPacing } from './pacing';
+import { alignReading } from './furigana';
 import { selectPromotions, type IntakeItem, type IntakeCandidate } from './intake';
 
 export type MasteryLevel = 'unseen' | 'hard' | 'medium' | 'easy';
@@ -740,12 +741,16 @@ export const useAppStore = create<AppState>()(
           if (existing && (existing.intakeStatus === 'active' || existing.stability != null)) return {};
 
           const difficulty = difficultyForBucket(level);
+          // Same aligner as enrichment (jmdictToWordDetails), so if this word is
+          // later promoted its flashcard shows furigana split like any other.
+          const furiganaMap = alignReading(candidate.word, candidate.reading);
           const base: WordData = existing
             ? {
                 ...existing,
                 reading: existing.reading || candidate.reading,
                 meaning: existing.meaning || candidate.meaning,
                 surface: existing.surface ?? candidate.word,
+                furiganaMap: existing.furiganaMap?.length ? existing.furiganaMap : furiganaMap,
                 jmdictEntryId: existing.jmdictEntryId ?? candidate.entryId,
                 jlptLevel: existing.jlptLevel ?? candidate.jlptLevel,
                 freqRank: existing.freqRank ?? candidate.freqRank,
@@ -755,6 +760,7 @@ export const useAppStore = create<AppState>()(
                 reading: candidate.reading,
                 meaning: candidate.meaning,
                 surface: candidate.word,
+                furiganaMap,
                 jmdictEntryId: candidate.entryId,
                 jlptLevel: candidate.jlptLevel,
                 freqRank: candidate.freqRank,

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -5,7 +5,7 @@ import { NewsArticle } from './api';
 import { supabase } from './supabase';
 import { schedule, ratingForReaderEvent, readerEventMayAdvance, seedSrsFromDifficulty, type SrsState, type SrsStatus, type Rating, type AdjustReason } from './srs';
 import { decidePacing, isActiveForPacing } from './pacing';
-import { alignReading } from './furigana';
+import { alignReading, hasKanji, loadReadingData } from './furigana';
 import { selectPromotions, type IntakeItem, type IntakeCandidate } from './intake';
 
 export type MasteryLevel = 'unseen' | 'hard' | 'medium' | 'easy';
@@ -219,6 +219,9 @@ interface AppState {
   lastResetTs: number | null;
   // Study-pacing flood fix: when the one-time forward-reseed / re-queue last ran.
   lastStudyPacingResetTs: number | null;
+  // One-shot furigana re-align: when the stored furiganaMap back-catalog was last
+  // recomputed with the per-kanji reading tables (see realignFurigana).
+  lastFuriganaRealignTs: number | null;
   currentArticle: NewsArticle | null;
   articlesCache: Record<string, NewsArticle>;
   processingArticles: string[];
@@ -252,6 +255,7 @@ interface AppState {
   applyDifficultyEvent: (word: string, event: 'skip' | 'click', jlptLevel?: number | null) => void;
   reviewWord: (word: string, rating: Rating, now: number) => void;
   resetStudyPacing: () => Promise<{ keptActive: number; requeued: number }>;
+  realignFurigana: () => Promise<{ updated: number; scanned: number }>;
   setWordMastery: (word: string, level: MasteryLevel) => void;
   gradeDiscoverWord: (candidate: IntakeCandidate, level: Exclude<MasteryLevel, 'unseen'>) => void;
   mergeWordRecords: (fromKey: string, toKey: string) => void;
@@ -296,6 +300,7 @@ export const useAppStore = create<AppState>()(
       lastRtkUpdateTs: null,
       lastResetTs: null,
       lastStudyPacingResetTs: null,
+      lastFuriganaRealignTs: null,
       currentArticle: null,
       articlesCache: {},
       processingArticles: [],
@@ -1048,6 +1053,39 @@ export const useAppStore = create<AppState>()(
         return { keptActive, requeued: touched.length - keptActive };
       },
 
+      // One-shot furigana re-align (Settings → Advanced), sibling of resetStudyPacing.
+      // The per-kanji reading tables were never loaded at runtime before main.tsx
+      // primed them (#36 was inert), so every STORED furiganaMap was computed by the
+      // coarser okurigana fallback: no-okurigana compounds (意味, 病院) carry one
+      // grouped segment instead of per-kanji readings. furiganaMap is local-only
+      // (never synced to user_word_progress), so this is a pure client re-derive —
+      // no server writes. Self-hiding via lastFuriganaRealignTs.
+      realignFurigana: async () => {
+        await loadReadingData();
+        let updated = 0;
+        let scanned = 0;
+        set((state) => {
+          const db = { ...state.wordDatabase };
+          for (const [key, w] of Object.entries(db)) {
+            // Entry-id keys are numeric (#39); legacy keys ARE the surface form.
+            const surface = w.surface || (/^\d+$/.test(key) ? '' : key);
+            if (!surface || !w.reading || !hasKanji(surface)) continue;
+            scanned++;
+            const fresh = alignReading(surface, w.reading);
+            const prev = w.furiganaMap ?? [];
+            const same = prev.length === fresh.length &&
+              prev.every((s, i) => s.kanji === fresh[i].kanji && s.kana === fresh[i].kana);
+            if (same) continue;
+            db[key] = { ...w, furiganaMap: fresh };
+            updated++;
+          }
+          return updated > 0
+            ? { wordDatabase: db, lastFuriganaRealignTs: Date.now() }
+            : { lastFuriganaRealignTs: Date.now() };
+        });
+        return { updated, scanned };
+      },
+
       syncSrsWithSupabase: async (userId) => {
         const { fetchUserWordProgress, fetchUserPreferences } = await import('./api');
 
@@ -1599,6 +1637,7 @@ export const useAppStore = create<AppState>()(
         lastRtkUpdateTs: state.lastRtkUpdateTs,
         lastResetTs: state.lastResetTs,
         lastStudyPacingResetTs: state.lastStudyPacingResetTs,
+        lastFuriganaRealignTs: state.lastFuriganaRealignTs,
         dismissedArticleIds: state.dismissedArticleIds,
         readArticleIds: state.readArticleIds,
         readerFontSize: state.readerFontSize,


### PR DESCRIPTION
Follow-up to #114 (Discover mode).

## Changes

- **Grade pills**: removed the "study soon" / "known" captions — label-only Hard / Medium / Easy pills.
- **Furigana**: Discover cards rendered the whole reading over the whole word (ひとつ spanning 一つ). Candidates now go through `alignReading` — the same aligner the enrichment path uses (`jmdictToWordDetails`) — so readings split across kanji/okurigana exactly like regular flashcards (ひと over 一, つ bare). The computed map is also persisted on the materialised record, so a Discover word later promoted into the deck renders identically.
- **Wired up `loadReadingData()`** (found while investigating): the loader for #36's dictionary-driven per-kanji aligner (`kanjiReadings`/`jukujikun`) was never called anywhere in the app — only by `scripts/furigana-align-accuracy.mjs` — so `alignReading` silently degraded to `alignOkurigana` at runtime and no-okurigana compounds (意味, 病院) showed one grouped reading instead of the per-kanji split. Now primed at app bootstrap (`main.tsx`); the chunk is code-split and loads before the first lookup's network round-trip completes. This improves furigana app-wide (Discover, flashcards via enrichment, and the reader/tokenizer path).
- **One-shot back-catalog migration** — Settings → Advanced → **"Re-align Furigana"** (mirrors the Rebalance one-shot): recomputes every stored `furiganaMap` with the loaded tables (意味 → 意/い + 味/み). `furiganaMap` is local-only (never synced to `user_word_progress`), so it's a pure client re-derive per device — nothing scheduled, deleted, or written server-side. Self-hides after running (gated on `lastFuriganaRealignTs`, persisted).

## Verified

Playwright walkthroughs in dev mode:
- 意味 shows い over 意, み over 味 (dictionary aligner active); 一つ shows ひと over 一 with つ unannotated (okurigana split); pills label-only; Discover records carry the furiganaMap.
- Migration: seeded stale grouped maps (意味, 病院) + a kana-only word → button visible → run → "2 of 2 words updated", maps now per-kanji, kana-only word untouched → button self-hides and stays hidden after reload; Rebalance gate unaffected.
- Build + lint clean (all lint findings pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186EMhy2FnJ6zWzPTzhaRv6