### PR TITLE
Study focus mode, 完了 finish card, Progress donut polish

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -284,3 +284,18 @@
   - [x] One-shot "Re-align Furigana" in Settings → Advanced (mirrors Rebalance):
         recomputes the stored furiganaMap back-catalog locally (furiganaMap never
         syncs to user_word_progress); self-hides via lastFuriganaRealignTs.
+- [x] Study focus mode + 完了 finish card + Progress donut polish (Jul 14)
+  - [x] Progress: JLPT labels inside the mini donuts (count removed), 'Other'
+        level dropped from the selector, level row space-evenly (edge gap ==
+        inter-donut gap), detail donut shows total word count (percent-seen
+        removed), thicker ring, larger legend text.
+  - [x] Flashcards focus mode: first tap into a card hides the bottom nav and
+        the card grows into the space (min(660px, 74vh)); tap outside the card
+        exits; in-card taps stopPropagation so grading never exits; focus
+        releases on session end / unmount.
+  - [x] 完了 finish card replaces the plain deck-complete text: same flip
+        surface, front 完了 / COMPLETE, back お疲れさま + session cards /
+        reviews today / day streak + compact "Discover new words" pill.
+  - Verified: Playwright walkthrough (seed deck → focus on tap → outside-tap
+    exit → re-focus → grade 8/8 → finish card flip → Discover launch with live
+    candidates → focus re-entry). tsc clean.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,9 @@ function App() {
   const checkDailyKanji = useAppStore(state => state.checkDailyKanji);
   const [activeTab, setActiveTab] = useState<'news' | 'flashcards' | 'progress' | 'settings'>('news');
   const [showNav, setShowNav] = useState(true);
+  // Flashcard focus mode: tapping into a card hides the bottom nav so the card
+  // can use that space; Flashcards reports the state up from its card flow.
+  const [studyFocus, setStudyFocus] = useState(false);
   const [session, setSession] = useState<any>(null);
   const [isInitializing, setIsInitializing] = useState(true);
   const [approvalStatus, setApprovalStatus] = useState<'approved' | 'waitlisted' | 'not_joined' | null>(null);
@@ -659,11 +662,15 @@ function App() {
             <Reader key={activeArticle?.id} initialArticle={activeArticle} onComplete={handleFinishArticle} />
           )
         )}
-        {activeTab === 'flashcards' && <Flashcards />}
+        {activeTab === 'flashcards' && <Flashcards onFocusChange={setStudyFocus} />}
         {activeTab === 'progress' && <Progress />}
         {activeTab === 'settings' && <Settings />}
       </main>
-      <BottomNav activeTab={activeTab} onChange={setActiveTab} isVisible={showNav && newsView !== 'reading'} />
+      <BottomNav
+        activeTab={activeTab}
+        onChange={setActiveTab}
+        isVisible={showNav && newsView !== 'reading' && !(activeTab === 'flashcards' && studyFocus)}
+      />
     </div>
   )
 }

--- a/src/components/Flashcards.tsx
+++ b/src/components/Flashcards.tsx
@@ -120,7 +120,7 @@ function formatInterval(days: number): string {
   return `${(days / 365).toFixed(1)}y`;
 }
 
-export function Flashcards() {
+export function Flashcards({ onFocusChange }: { onFocusChange?: (focused: boolean) => void }) {
   const reviewWord = useAppStore((s) => s.reviewWord);
   const gradeDiscoverWord = useAppStore((s) => s.gradeDiscoverWord);
   const jlptLevel = useAppStore((s) => s.jlptLevel);
@@ -131,6 +131,12 @@ export function Flashcards() {
 
   const [index, setIndex] = useState(0);
   const [revealed, setRevealed] = useState(false);
+
+  // Focus mode: the first tap into a card hides the bottom nav (reported up via
+  // onFocusChange) and the card grows into the reclaimed space. Sticky across
+  // cards for the rest of the run; it releases when the run ends (finish card,
+  // Discover summary, empty deck) so the nav is back for onward navigation.
+  const [focused, setFocused] = useState(false);
 
   // Discover mode (#113). Non-null = in Discover; [] while loading or exhausted.
   const [discoverCards, setDiscoverCards] = useState<IntakeCandidate[] | null>(null);
@@ -144,6 +150,7 @@ export function Flashcards() {
     setDiscoverCards([]);
     setDiscoverIndex(0);
     setRevealed(false);
+    setFocused(false); // each run re-enters focus on its first card tap
     const s = useAppStore.getState();
     const seenIds = Object.values(s.wordDatabase)
       .map((w) => w.jmdictEntryId)
@@ -193,6 +200,33 @@ export function Flashcards() {
   }
   const total = cards.length;
   const card = cards[index];
+
+  // Focus is only real while a card is actually on screen — the summary/empty
+  // states always get the nav back, whatever `focused` says.
+  const inCardFlow =
+    discoverCards != null
+      ? !discoverLoading && discoverIndex < discoverCards.length && discoverCards.length > 0
+      : total > 0 && index < total;
+  const focusActive = focused && inCardFlow;
+  useEffect(() => {
+    onFocusChange?.(focusActive);
+  }, [focusActive, onFocusChange]);
+  // Leaving the tab unmounts this component — always hand the nav back.
+  useEffect(() => () => onFocusChange?.(false), [onFocusChange]);
+
+  // Card-flow wrapper: in focus mode the nav-reserving bottom padding collapses
+  // and the card (FlipSurface `tall`) grows into the space.
+  const flowStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 'calc(100dvh - 5rem)',
+    paddingTop: '0.5rem',
+    paddingBottom: focusActive
+      ? 'calc(1.25rem + env(safe-area-inset-bottom))'
+      : 'calc(4.75rem + env(safe-area-inset-bottom))',
+    boxSizing: 'border-box',
+    transition: 'padding-bottom 0.4s cubic-bezier(0.22, 1, 0.36, 1)',
+  };
 
   // Interval each rating would assign, previewed against the current card's schedule.
   const previews = useMemo(() => {
@@ -300,7 +334,7 @@ export function Flashcards() {
 
     const cand = discoverCards[discoverIndex];
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', minHeight: 'calc(100dvh - 5rem)', paddingTop: '0.5rem', paddingBottom: 'calc(4.75rem + env(safe-area-inset-bottom))', boxSizing: 'border-box' }}>
+      <div style={flowStyle} onClick={() => setFocused(false)}>
         {/* Progress */}
         <div style={{ marginBottom: '1.5rem' }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '0.4rem' }}>
@@ -323,6 +357,8 @@ export function Flashcards() {
           cardKey={cand.entryId}
           word={wordForCandidate(cand)}
           revealed={revealed}
+          tall={focusActive}
+          onTap={() => setFocused(true)}
           onReveal={() => setRevealed(true)}
           footer={
             <div style={{ display: 'flex', flexShrink: 0, gap: '9px', padding: '0 1.1rem 1.15rem' }}>
@@ -387,23 +423,30 @@ export function Flashcards() {
     );
   }
 
-  // ── Deck complete ───────────────────────────────────────────────────────
+  // ── Deck complete — the 完了 finish card ─────────────────────────────────
+  // Sits in the same card flow as the deck (full progress bar above it); flips
+  // to the day's stats with Discover as the only onward action.
   if (index >= total) {
     return (
-      <Centered>
-        <p className="serif" style={{ fontSize: '1.5rem', color: 'var(--text-main)', marginBottom: '0.5rem' }}>
-          お疲れさま
-        </p>
-        <p style={{ color: 'var(--text-muted)', fontSize: '0.9rem' }}>
-          Deck complete — {total} {total === 1 ? 'card' : 'cards'} reviewed.
-        </p>
-        {discoverEntry}
-      </Centered>
+      <div style={flowStyle} onClick={() => setFocused(false)}>
+        <div style={{ marginBottom: '1.5rem' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '0.4rem' }}>
+            <span style={{ fontSize: '0.7rem', letterSpacing: '0.08em', color: 'var(--text-muted)', textTransform: 'uppercase' }}>
+              Review
+            </span>
+            <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>{total} / {total}</span>
+          </div>
+          <div style={{ height: '3px', backgroundColor: 'var(--border-light)', borderRadius: '2px', overflow: 'hidden' }}>
+            <div style={{ height: '100%', width: '100%', backgroundColor: 'var(--accent-progress)' }} />
+          </div>
+        </div>
+        <FinishCard sessionCount={total} onDiscover={jlptLevel != null ? startDiscover : undefined} />
+      </div>
     );
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', minHeight: 'calc(100dvh - 5rem)', paddingTop: '0.5rem', paddingBottom: 'calc(4.75rem + env(safe-area-inset-bottom))', boxSizing: 'border-box' }}>
+    <div style={flowStyle} onClick={() => setFocused(false)}>
       {/* Progress */}
       <div style={{ marginBottom: '1.5rem' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '0.4rem' }}>
@@ -426,6 +469,8 @@ export function Flashcards() {
         cardKey={card.key}
         word={card.word}
         revealed={revealed}
+        tall={focusActive}
+        onTap={() => setFocused(true)}
         onReveal={() => setRevealed(true)}
         footer={
           <div style={{ display: 'flex', flexShrink: 0, gap: '9px', padding: '0 1.1rem 1.15rem' }}>
@@ -484,12 +529,14 @@ function ExitDiscoverButton({ onClick }: { onClick: () => void }) {
 // The grade buttons live INSIDE the back face (passed as `footer`), as a strip
 // along its bottom edge — so flipping never changes the card's height or shifts
 // the layout, and the buttons arrive with the flip itself (no second animation).
-function FlipSurface({ cardKey, word, revealed, onReveal, footer }: {
+function FlipSurface({ cardKey, word, revealed, onReveal, onTap, footer, tall = false }: {
   cardKey: string;
   word: WordData;
   revealed: boolean;
   onReveal: () => void;
+  onTap?: () => void; // fires on ANY in-card tap (even revealed) — re-enters focus
   footer: React.ReactNode;
+  tall?: boolean; // focus mode: grow into the space the hidden nav frees up
 }) {
   return (
     <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem', perspective: '1600px' }}>
@@ -503,16 +550,25 @@ function FlipSurface({ cardKey, word, revealed, onReveal, footer }: {
           style={{ width: '100%', maxWidth: '340px' }}
         >
           {/* Inner element rotates in 3D — front and back are its two faces.
-              Capped in px but scaled by vh so it never tucks under the nav. */}
+              Capped in px but scaled by vh so it never tucks under the nav.
+              Clicks stop here: anything outside the card (the flow wrapper)
+              exits focus mode, so in-card taps must not bubble that far. */}
           <motion.div
-            onClick={() => !revealed && onReveal()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onTap?.();
+              if (!revealed) onReveal();
+            }}
             initial={false}
             animate={{ rotateY: revealed ? 180 : 0 }}
             transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
             style={{
               position: 'relative',
               width: '100%',
-              height: 'min(540px, 62vh)',
+              // Framer only drives `transform` here, so a plain CSS transition
+              // can own the focus-mode height change without any conflict.
+              height: tall ? 'min(660px, 74vh)' : 'min(540px, 62vh)',
+              transition: 'height 0.4s cubic-bezier(0.22, 1, 0.36, 1)',
               transformStyle: 'preserve-3d',
               cursor: revealed ? 'default' : 'pointer',
             }}
@@ -559,6 +615,126 @@ function FlipSurface({ cardKey, word, revealed, onReveal, footer }: {
           </motion.div>
         </motion.div>
       </AnimatePresence>
+    </div>
+  );
+}
+
+// ── Finish card ──────────────────────────────────────────────────────────────
+// Shown when the day's deck is done: the same quiet card surface as the
+// flashcards, with 完了 on the front. Tapping flips it to a small stats panel
+// for the day, with Discover as the only onward action.
+function FinishCard({ sessionCount, onDiscover }: { sessionCount: number; onDiscover?: () => void }) {
+  const [revealed, setRevealed] = useState(false);
+  const reviewsByDay = useAppStore((s) => s.reviewsByDay);
+
+  // Same UTC day key the store stamps reviewsByDay with.
+  const dayKey = (ms: number) => new Date(ms).toISOString().split('T')[0];
+  const todayReviews = reviewsByDay[dayKey(Date.now())] ?? 0;
+  // Consecutive review days ending today.
+  let streak = 0;
+  for (let ms = Date.now(); (reviewsByDay[dayKey(ms)] ?? 0) > 0; ms -= 86_400_000) streak += 1;
+
+  const stats = [
+    { value: sessionCount, label: sessionCount === 1 ? 'card' : 'cards' },
+    { value: todayReviews, label: 'today' },
+    { value: streak, label: streak === 1 ? 'day' : 'days' },
+  ];
+
+  return (
+    <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '1rem', perspective: '1600px' }}>
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0, transition: { duration: 0.2, ease: [0.22, 1, 0.36, 1] } }}
+        style={{ width: '100%', maxWidth: '340px' }}
+      >
+        <motion.div
+          onClick={() => !revealed && setRevealed(true)}
+          initial={false}
+          animate={{ rotateY: revealed ? 180 : 0 }}
+          transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
+          style={{
+            position: 'relative',
+            width: '100%',
+            height: 'min(540px, 62vh)',
+            transformStyle: 'preserve-3d',
+            cursor: revealed ? 'default' : 'pointer',
+          }}
+        >
+          {/* FRONT — 完了, nothing else. */}
+          <CardFace>
+            <span
+              className="serif"
+              translate="no"
+              style={{ fontSize: '3.4rem', lineHeight: 1.15, color: 'var(--text-main)', letterSpacing: '0.08em' }}
+            >
+              完了
+            </span>
+            <span
+              className="sans"
+              style={{
+                marginTop: '1.2rem',
+                fontSize: '0.7rem',
+                fontWeight: 600,
+                letterSpacing: '0.28em',
+                textTransform: 'uppercase',
+                color: 'var(--text-muted)',
+              }}
+            >
+              Complete
+            </span>
+            <div style={{ position: 'absolute', bottom: '1.5rem', left: 0, right: 0, display: 'flex', justifyContent: 'center', color: 'var(--text-muted)', opacity: 0.35 }}>
+              <ChevronDown size={20} strokeWidth={1.5} />
+            </div>
+          </CardFace>
+
+          {/* BACK — today's numbers, then Discover. */}
+          <CardFace
+            back
+            footer={
+              onDiscover && (
+                <div style={{ flexShrink: 0, display: 'flex', justifyContent: 'center', padding: '0 1.1rem 1.35rem' }}>
+                  <button
+                    onClick={onDiscover}
+                    style={{
+                      padding: '0.7rem 1.6rem',
+                      border: '1px solid var(--border-light)',
+                      borderRadius: '999px',
+                      backgroundColor: 'var(--bg-pure)',
+                      boxShadow: '0 3px 10px rgba(143, 170, 116, 0.32)',
+                      color: 'var(--text-main)',
+                      fontSize: '0.8rem',
+                      fontWeight: 600,
+                      letterSpacing: '0.02em',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    Discover new words
+                  </button>
+                </div>
+              )
+            }
+          >
+            <span className="serif" translate="no" style={{ fontSize: '1.4rem', color: 'var(--text-main)' }}>
+              お疲れさま
+            </span>
+            <div style={{ display: 'flex', gap: '2.4rem', marginTop: '2.25rem' }}>
+              {stats.map((s) => (
+                <div key={s.label} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.45rem' }}>
+                  <span className="serif" style={{ fontSize: '1.8rem', lineHeight: 1, color: 'var(--text-main)' }}>
+                    {s.value}
+                  </span>
+                  <span className="sans" style={{ fontSize: '0.65rem', letterSpacing: '0.06em', color: 'var(--text-muted)' }}>
+                    {s.label}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <span className="sans" style={{ marginTop: '1.4rem', fontSize: '0.72rem', color: 'var(--text-muted)', letterSpacing: '0.02em' }}>
+              {streak > 1 ? `${streak} days in a row — keep it going.` : 'Every review counts.'}
+            </span>
+          </CardFace>
+        </motion.div>
+      </motion.div>
     </div>
   );
 }

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -43,7 +43,8 @@ const emptyBuckets = (): Record<BucketKey, number> => ({
 });
 
 // JLPT numbering: 5 = N5 (easiest) ... 1 = N1 (hardest). `'other'` collects
-// words JMDict has no JLPT tag for.
+// words JMDict has no JLPT tag for — grouped internally but not shown as a
+// selectable level (no corpus to measure against).
 type LevelKey = number | 'other';
 const LEVELS: { value: LevelKey; label: string; note?: string }[] = [
   { value: 5, label: 'N5', note: 'easiest' },
@@ -51,7 +52,6 @@ const LEVELS: { value: LevelKey; label: string; note?: string }[] = [
   { value: 3, label: 'N3' },
   { value: 2, label: 'N2' },
   { value: 1, label: 'N1', note: 'hardest' },
-  { value: 'other', label: 'Other' },
 ];
 
 const levelKeyFor = (w: WordData): LevelKey =>
@@ -228,17 +228,16 @@ export function Progress() {
           display: 'flex',
           alignItems: 'center',
           // Fluid row: on narrow screens the donuts SHRINK proportionally (via
-          // flex-grow ratios on the buttons) so all six always fit with at least
-          // the fixed gap between them; on wide screens they cap at full size
-          // and space-between spreads the leftover as extra spacing. When the
-          // active donut grows, flexbox re-spreads every frame — neighbors
-          // slide smoothly.
-          justifyContent: 'space-between',
-          gap: '8px',
+          // flex-grow ratios on the buttons) so all five always fit with at
+          // least the fixed gap between them; on wide screens they cap at full
+          // size and space-evenly spreads the leftover. With side padding equal
+          // to `gap`, edge gap (padding + evenly share) always matches inner
+          // gap (gap + evenly share). When the active donut grows, flexbox
+          // re-spreads every frame — neighbors slide smoothly.
+          justifyContent: 'space-evenly',
+          gap: '10px',
           overflowX: 'auto',
-          // Generous padding so the active donut's shadow (14px blur) never
-          // clips against the overflow scroller on any edge.
-          padding: '0.5rem 0.9rem 1.25rem',
+          padding: '0.5rem 10px 1.25rem',
           // Bleed through main's 1.25rem side padding: the row isn't a card, so
           // it may run wider than the cards — on phones that slack goes straight
           // into bigger donuts (the fluid sizing absorbs it).
@@ -251,9 +250,6 @@ export function Progress() {
           const isActive = l.value === activeLevel;
           const bucketCounts = levelBucketCounts.get(l.value) ?? emptyBuckets();
           const tracked = byLevel.get(l.value)?.length ?? 0;
-          // Full corpus size for JLPT levels; 'Other' has no corpus, so tracked.
-          const total =
-            typeof l.value === 'number' ? levelTotals[l.value] ?? tracked : tracked;
           return (
             <button
               key={String(l.value)}
@@ -266,17 +262,15 @@ export function Progress() {
                 // at full size on wide screens. min-width floors legibility —
                 // below it the row overflows into a scroll with gaps intact.
                 // Height is fixed so nothing below the row moves vertically.
-                flex: `${isActive ? 80 : 64} 1 0px`,
-                maxWidth: isActive ? '80px' : '64px',
-                minWidth: isActive ? '54px' : '43px',
-                height: '108px',
+                flex: `${isActive ? 92 : 70} 1 0px`,
+                maxWidth: isActive ? '92px' : '70px',
+                minWidth: isActive ? '58px' : '45px',
+                height: '92px',
                 display: 'flex',
                 flexDirection: 'column',
                 alignItems: 'center',
-                // A fixed-height slot at the bottom centers the donut vertically,
-                // so every donut's CENTER sits on the same line regardless of
-                // size; the label is anchored to the donut's top edge, so it
-                // rides up as the active donut grows into the headroom above.
+                // A fixed-height slot centers the donut vertically, so every
+                // donut's CENTER sits on the same line regardless of size.
                 justifyContent: 'flex-end',
                 padding: 0,
                 border: 'none',
@@ -289,7 +283,7 @@ export function Progress() {
               {/* Fixed-height slot = max donut size; smaller donuts center in it. */}
               <span
                 style={{
-                  height: '80px',
+                  height: '92px',
                   width: '100%',
                   display: 'flex',
                   alignItems: 'center',
@@ -312,23 +306,6 @@ export function Progress() {
                   transition: 'box-shadow 0.25s ease',
                 }}
               >
-                <span
-                  className="sans"
-                  style={{
-                    position: 'absolute',
-                    bottom: 'calc(100% + 7px)',
-                    left: '50%',
-                    transform: 'translateX(-50%)',
-                    fontSize: isActive ? '1.1rem' : '0.85rem',
-                    fontWeight: isActive ? 700 : 600,
-                    letterSpacing: '0.04em',
-                    lineHeight: 1,
-                    whiteSpace: 'nowrap',
-                    transition: 'font-size 0.25s ease',
-                  }}
-                >
-                  {l.label}
-                </span>
                 <Donut
                   counts={bucketCounts}
                   total={tracked + bucketCounts.notSeen}
@@ -337,7 +314,8 @@ export function Progress() {
                   strokeWidth={8}
                   fluid
                   showText={false}
-                  centerText={total.toLocaleString()}
+                  centerText={l.label}
+                  centerFontSize={13}
                   holeFill={isActive ? 'var(--bg-card)' : undefined}
                 />
               </span>
@@ -389,10 +367,10 @@ export function Progress() {
               // keeps its natural (content) width and hugs the right edge, so
               // the leftover always lands as whitespace between the two.
               justifyContent: 'space-between',
-              gap: '1.25rem',
+              gap: '1rem',
             }}
           >
-            <div style={{ flex: '1 1 0', minWidth: 0, maxWidth: '210px' }}>
+            <div style={{ flex: '0 1 42%', minWidth: 0, maxWidth: '230px' }}>
               {/* Same lifted look as the active mini donut: round box-shadow
                   wrapper + card-colored hole so the shadow can't bleed through. */}
               <span
@@ -406,10 +384,11 @@ export function Progress() {
                   counts={counts}
                   total={donutTotal}
                   activeBucket={activeBucket}
+                  strokeWidth={26}
                   fluid
                   holeFill="var(--bg-card)"
-                  headline={`${donutTotal > 0 ? Math.round((levelTotal / donutTotal) * 100) : 0}%`}
-                  subline="seen"
+                  headline={donutTotal.toLocaleString()}
+                  subline="words"
                 />
               </span>
             </div>
@@ -427,9 +406,9 @@ export function Progress() {
                     style={{
                       display: 'flex',
                       alignItems: 'center',
-                      gap: '0.45rem',
+                      gap: '0.4rem',
                       width: '100%',
-                      padding: '0.45rem 0.4rem',
+                      padding: '0.45rem 0.3rem',
                       background: isActive ? 'var(--bg-pure)' : 'none',
                       border: 'none',
                       borderRadius: '10px',
@@ -448,19 +427,19 @@ export function Progress() {
                         flex: '0 0 auto',
                       }}
                     />
-                    <span style={{ fontSize: '0.85rem', color: 'var(--text-main)', flex: 1, whiteSpace: 'nowrap' }}>
+                    <span style={{ fontSize: '0.88rem', color: 'var(--text-main)', flex: 1, whiteSpace: 'nowrap' }}>
                       {m.label}
                     </span>
                     {/* Fixed-width number columns: the legend keeps the same width
                         no matter the digit counts, so the donut never resizes when
                         switching levels or buckets. */}
                     <span
-                      style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--text-main)', width: '2.5rem', textAlign: 'right', flex: '0 0 auto' }}
+                      style={{ fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-main)', width: '2.3rem', textAlign: 'right', flex: '0 0 auto' }}
                     >
                       {pct}%
                     </span>
                     <span
-                      style={{ fontSize: '0.75rem', color: 'var(--text-muted)', width: '2.7rem', textAlign: 'right', flex: '0 0 auto' }}
+                      style={{ fontSize: '0.78rem', color: 'var(--text-muted)', width: '2.6rem', textAlign: 'right', flex: '0 0 auto' }}
                     >
                       {value.toLocaleString()}
                     </span>
@@ -693,6 +672,7 @@ function Donut({
   strokeWidth = 20,
   showText = true,
   centerText,
+  centerFontSize = 11,
   headline,
   subline,
   displaySize,
@@ -705,7 +685,8 @@ function Donut({
   size?: number;
   strokeWidth?: number;
   showText?: boolean;
-  centerText?: string;  // compact center count (mini donuts)
+  centerText?: string;  // compact center label (mini donuts)
+  centerFontSize?: number; // viewBox-unit cap for the centerText size
   headline?: string;    // big center line (detail donut), e.g. "42%"
   subline?: string;     // small line under the headline, e.g. "seen"
   displaySize?: number; // rendered size; defaults to `size` (the viewBox scale)
@@ -776,9 +757,10 @@ function Donut({
           textAnchor="middle"
           className="sans"
           style={{
-            // Shrink to fit the hole: ~0.62em average glyph width for digits.
-            fontSize: `${Math.min(11, (size - strokeWidth * 2 - 4) / (Math.max(centerText.length, 1) * 0.62))}px`,
-            fontWeight: 600,
+            // Shrink to fit the hole: ~0.62em average glyph width.
+            fontSize: `${Math.min(centerFontSize, (size - strokeWidth * 2 - 4) / (Math.max(centerText.length, 1) * 0.62))}px`,
+            fontWeight: 700,
+            letterSpacing: '0.03em',
             fill: 'currentColor',
           }}
         >
@@ -794,7 +776,7 @@ function Donut({
             textAnchor="middle"
             className="serif"
             style={{
-              fontSize: headline.length > 4 ? '1rem' : '1.2rem',
+              fontSize: headline.length > 5 ? '1rem' : '1.15rem',
               fontWeight: 700,
               fill: 'var(--text-main)',
             }}
@@ -804,10 +786,10 @@ function Donut({
           {subline != null && (
             <text
               x={center}
-              y={center + 14}
+              y={center + 13}
               textAnchor="middle"
               className="sans"
-              style={{ fontSize: '0.65rem', fill: 'var(--text-muted)', letterSpacing: '0.04em' }}
+              style={{ fontSize: '0.62rem', fill: 'var(--text-muted)', letterSpacing: '0.04em' }}
             >
               {subline}
             </text>


### PR DESCRIPTION
## What

Two pieces of Study/Progress UI polish, verified end-to-end with Playwright in mobile view.

### Progress donut polish
- JLPT labels move inside the mini donut centers (corpus count removed); the 'Other' level drops out of the selector row
- Level row uses `space-evenly` with edge padding equal to the gap, so edge spacing always matches inter-donut spacing at any width
- Detail donut center shows the level's total word count instead of "% seen"; ring thickened (stroke 20 → 26), sized to ~42% of the card, legend text enlarged

### Flashcard focus mode + finish card
- First tap into a card enters focus mode: bottom nav slides away and the card grows into the reclaimed space (`min(660px, 74vh)`)
- Tapping outside the card exits focus; in-card taps stop propagation so grading never exits; focus releases on session end or unmount
- Deck completion lands on a 完了 finish card in the same flip surface: front 完了 / COMPLETE, back お疲れさま with session cards / reviews today / day streak and a compact "Discover new words" pill

## Verification
- Playwright walkthrough: seed deck → focus on tap → outside-tap exit → re-focus → grade 8/8 → finish card flip → Discover launch with live candidates → focus re-entry
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186EMhy2FnJ6zWzPTzhaRv6