### PR TITLE
Fix excessive/unnatural kanji in articles and Discover cards

### DIFF
--- a/database/25_natural_surface_forms.sql
+++ b/database/25_natural_surface_forms.sql
@@ -1,0 +1,150 @@
+-- ============================================================
+-- 25. Natural surface forms for discover / intake candidates
+-- ============================================================
+-- Fixes "excessive kanji" on Discover cards and the unseen-words list. Both
+-- get_intake_candidates (database/24) and get_unseen_common_words (database/13)
+-- chose the display surface with:
+--
+--   coalesce( (first kanji form by id), (first kana form by id) )
+--
+-- i.e. the FIRST kanji form in JMDict document order, with NO regard for whether
+-- that form is rare. その (entry 1006830) has a kanji form 其の tagged `rK`
+-- (rare kanji), so the card showed 其の instead of その — a form no modern text
+-- uses. Same for 迚も (とても), 何時も (いつも), 其れ (それ), etc.
+--
+-- The data to avoid this is already imported (scripts/import_jmdict.cjs stores
+-- each kanji form's `common` flag and its `info` tags — rK/oK/iK/ateji…). This
+-- migration adds a shared surface picker that USES them, and points both RPCs
+-- at it. The rule mirrors process-article's pickSurface intent, but correctly
+-- falls back to kana when the only kanji forms are rare/non-common:
+--
+--   1. a COMMON kanji form that is not rare/outdated/irregular (rK/oK/iK)
+--   2. else any kanji form that is not rare/outdated/irregular
+--   3. else the COMMON kana reading
+--   4. else any kana reading
+--
+-- So a word whose only kanji spelling is rare (その, とても, いつも) now displays
+-- in kana, while ordinary kanji words (食べる, 会社) are unaffected.
+--
+-- APPLY MANUALLY in the Supabase SQL editor (migrations here are not
+-- auto-deployed). Safe to run repeatedly — CREATE OR REPLACE throughout.
+
+-- ── Shared display-surface picker ───────────────────────────────────────────
+-- The natural everyday spelling for a JMDict entry: common non-rare kanji first,
+-- otherwise any non-rare kanji, otherwise the kana reading. `info && array[...]`
+-- is array overlap: true when the form carries any rare/outdated/irregular tag.
+create or replace function public.jmdict_display_surface(p_entry_id text)
+returns text
+language sql
+stable
+as $$
+  select coalesce(
+    -- 1. common, non-rare kanji form
+    (select k.text from public.jmdict_kanji k
+       where k.entry_id = p_entry_id
+         and k.common = true
+         and not (k.info && array['rK','oK','iK']::text[])
+       order by k.id limit 1),
+    -- 2. any non-rare kanji form
+    (select k.text from public.jmdict_kanji k
+       where k.entry_id = p_entry_id
+         and not (k.info && array['rK','oK','iK']::text[])
+       order by k.id limit 1),
+    -- 3. common kana reading
+    (select a.text from public.jmdict_kana a
+       where a.entry_id = p_entry_id and a.common = true
+       order by a.id limit 1),
+    -- 4. any kana reading
+    (select a.text from public.jmdict_kana a
+       where a.entry_id = p_entry_id
+       order by a.id limit 1)
+  );
+$$;
+
+grant execute on function public.jmdict_display_surface(text) to anon, authenticated;
+
+-- ── get_intake_candidates (supersedes database/24) ──────────────────────────
+-- Identical to database/24 except `word` now comes from jmdict_display_surface.
+create or replace function public.get_intake_candidates(
+  p_user_jlpt smallint,
+  p_seen_ids  text[] default '{}',
+  p_limit     integer default 50
+)
+returns table (
+  entry_id   text,
+  jlpt_level smallint,
+  freq_rank  integer,
+  word       text,
+  reading    text,
+  meaning    text
+)
+language sql
+stable
+as $$
+  with ranked as (
+    select e.id, e.jlpt_level, e.freq_rank, e.common
+    from public.jmdict_entries e
+    where e.jlpt_level is not null
+      and e.jlpt_level >= p_user_jlpt        -- user's level and EASIER (higher number)
+      and not (e.id = any(p_seen_ids))       -- exclude already-tracked, by entry_id (#39)
+    order by e.jlpt_level desc, e.freq_rank asc nulls last, e.common desc, e.id asc
+    limit p_limit
+  )
+  select
+    r.id,
+    r.jlpt_level,
+    r.freq_rank::integer,
+    public.jmdict_display_surface(r.id) as word,
+    (select a.text from public.jmdict_kana a where a.entry_id = r.id order by a.id limit 1) as reading,
+    (select array_to_string(s.gloss, '; ') from public.jmdict_senses s
+       where s.entry_id = r.id order by s.id limit 1) as meaning
+  from ranked r
+  order by r.jlpt_level desc, r.freq_rank asc nulls last, r.common desc, r.id asc;
+$$;
+
+grant execute on function public.get_intake_candidates(smallint, text[], integer)
+  to anon, authenticated;
+
+-- ── get_unseen_common_words (supersedes database/13) ────────────────────────
+-- Identical to database/13 except `word` now comes from jmdict_display_surface.
+create or replace function public.get_unseen_common_words(
+  p_level      smallint,
+  p_seen_words text[] default '{}',
+  p_limit      integer default 40
+)
+returns table (
+  word    text,
+  reading text,
+  rank    integer,
+  meaning text
+)
+language sql
+stable
+as $$
+  with candidates as (
+    select e.id, e.freq_rank, e.common
+    from public.jmdict_entries e
+    where e.jlpt_level = p_level
+      and not exists (
+        select 1 from public.jmdict_kanji k
+        where k.entry_id = e.id and k.text = any(p_seen_words)
+      )
+      and not exists (
+        select 1 from public.jmdict_kana a
+        where a.entry_id = e.id and a.text = any(p_seen_words)
+      )
+  )
+  select
+    public.jmdict_display_surface(c.id) as word,
+    (select a.text from public.jmdict_kana a
+       where a.entry_id = c.id order by a.id limit 1) as reading,
+    c.freq_rank::integer as rank,
+    (select array_to_string(s.gloss, '; ') from public.jmdict_senses s
+       where s.entry_id = c.id order by s.id limit 1) as meaning
+  from candidates c
+  order by c.freq_rank asc nulls last, c.common desc, c.id asc
+  limit p_limit;
+$$;
+
+grant execute on function public.get_unseen_common_words(smallint, text[], integer)
+  to anon, authenticated;

--- a/supabase/functions/_shared/rewritePrompt.ts
+++ b/supabase/functions/_shared/rewritePrompt.ts
@@ -186,8 +186,9 @@ Rules:
 2. Pick 1 or 2 important vocabulary words and explain them in English as a "yugen-box".
 3. Provide the full Japanese text strings. DO NOT tokenize the text yet.
 4. KANJI PREFERENCE: ${biasInstruction}
-5. VOCABULARY PREFERENCE: ${vocabInstruction}
-6. NO MARKUP: DO NOT use brackets [], parentheses (), or special formatting around Japanese words.
+5. NATURAL ORTHOGRAPHY — OVERRIDES ALL KANJI PREFERENCE ABOVE: Spell every word the way a modern Japanese newspaper spells it. Words normally written in kana MUST stay in kana: その (never 其の), それ／それから (never 其れ／其れから), とても (never 迚も), いつも (never 何時も), また (never 亦／又), もの・こと・ため・とき when grammatical, できる, ある, いる, など, ください, よう. NEVER use rare, archaic, literary, or irregular kanji forms (the forms JMDict tags rK/oK/iK). NEVER use ateji for foreign words: write country names and loanwords in KATAKANA — カナダ (never 加奈陀), アメリカ (never 亜米利加), イギリス (never 英吉利). When unsure whether a kanji form is in common everyday use, choose kana. This rule is absolute even in study/balanced kanji-bias mode.
+6. VOCABULARY PREFERENCE: ${vocabInstruction}
+7. NO MARKUP: DO NOT use brackets [], parentheses (), or special formatting around Japanese words.
 
 Output EXACTLY a JSON array:
 [{"type":"paragraph"|"yugen-box","text":"...","keyword":"...","reading":"...","description":"..."}]

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -219,11 +219,20 @@ async function fetchAllRows<T>(page: (from: number, to: number) => PromiseLike<{
 
 type EmbeddedEntry = { id: string; jmdict_kanji: { text: string; common: boolean }[]; jmdict_kana: { text: string; common: boolean }[] };
 
-// Preferred display surface for an entry: common kanji > common kana > any kanji > any kana.
+// Preferred display surface for an entry: common kanji > common kana > any kanji
+// > any kana. Preferring a common KANA reading over a non-common kanji form keeps
+// words whose only kanji spelling is rare (その's 其の, とても's 迚も) in kana,
+// instead of feeding an unnatural surface into the vocab palette.
 function pickSurface(e: EmbeddedEntry): string | null {
-  const first = (rows: { text: string; common: boolean }[]) =>
-    rows.find((r) => r.common)?.text ?? rows[0]?.text ?? null;
-  return first(e.jmdict_kanji ?? []) ?? first(e.jmdict_kana ?? []);
+  const commonOf = (rows: { text: string; common: boolean }[]) =>
+    rows.find((r) => r.common)?.text ?? null;
+  const anyOf = (rows: { text: string; common: boolean }[]) => rows[0]?.text ?? null;
+  return (
+    commonOf(e.jmdict_kanji ?? []) ??
+    commonOf(e.jmdict_kana ?? []) ??
+    anyOf(e.jmdict_kanji ?? []) ??
+    anyOf(e.jmdict_kana ?? [])
+  );
 }
 
 function normalizeConcepts(raw: unknown): Concept[] {


### PR DESCRIPTION
## Problem

Words were rendering with dictionary-valid but essentially-unused kanji forms — 其の for その, 迚も for とても, 何時も for いつも, 其れから for それから, and ateji like 加奈陀 / 亜米利加 for カナダ / アメリカ. This showed up in two unrelated places (article reader and Discover flashcards), which pointed to two independent root causes.

## Root causes & fixes

**1. Article body (Gemini) — `supabase/functions/_shared/rewritePrompt.ts`**
The rewrite prompt asked for "authentic" text and, in study/balanced mode, "prefer kanji", but never forbade rare/archaic/ateji forms — so the model reached for them. Added a **NATURAL ORTHOGRAPHY** rule that overrides all kanji preference: normally-kana words stay in kana, no `rK`/`oK`/`iK` forms, foreign words and country names in katakana.

**2. Discover / unseen-words RPCs — `database/25_natural_surface_forms.sql` (new)**
`get_intake_candidates` (database/24) and `get_unseen_common_words` (database/13) picked the display surface as the **first kanji form by id**, ignoring the per-form `common` flag and rare tags (`rK`/`oK`/`iK`) that `import_jmdict.cjs` already stores. Added a shared `jmdict_display_surface()` picker — **common non-rare kanji → any non-rare kanji → common kana → any kana** — and repointed both RPCs at it. Signature and return shape are unchanged, so it's a drop-in replacement.

**3. Bonus — `supabase/functions/process-article/index.ts`**
Aligned `pickSurface()` with its own documented precedence (it took *any* kanji over *common* kana, leaking rare forms into the vocab palette fed to Gemini).

## Deployment notes

- **`database/25` must be applied manually** in the Supabase SQL editor — migrations in this repo are not auto-deployed (same convention as database/24). It is backward-compatible, so applying it before or after deploying the code is equally safe.
- The prompt change takes effect on the next `process-article` edge-function deploy.

## Testing

- `npm run build` passes (tsc + vite).
- Verified `buildRewritePrompt` renders the new rule with correct rule numbering.
- The article eval harness (`scripts/eval-article-rewrite.mjs`) was **not** run — it makes real Gemini calls and needs `GEMINI_API_KEY`. Worth a run before/after deploy to confirm article quality holds; the change is additive (one new constraint), so regression risk is low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017a6ERq81YMxzJxJumoYRCd

---
_Generated by [Claude Code](https://claude.ai/code/session_017a6ERq81YMxzJxJumoYRCd)_