### PR TITLE
fix: Phase 1.4 correctness batch — furigana tests, intake retry, honest grade pills

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:srs": "node scripts/test-srs.mjs",
     "test:intake": "node scripts/test-intake.mjs",
     "test:deck": "node scripts/test-deck.mjs",
+    "test:furigana": "node scripts/test-furigana-map.mjs",
     "test:wordpriority": "node scripts/test-wordpriority.mjs"
   },
   "dependencies": {

--- a/scripts/test-furigana-map.mjs
+++ b/scripts/test-furigana-map.mjs
@@ -1,0 +1,109 @@
+/**
+ * Standalone test runner for the server-side furigana aligner
+ * (supabase/functions/_shared/furiganaMap.ts).
+ *
+ *   node scripts/test-furigana-map.mjs
+ *
+ * No test framework (matches test-srs.mjs / test-deck.mjs): the module is pure,
+ * so we bundle it with esbuild and assert on a fixture table. Exits non-zero on
+ * any failure.
+ *
+ * What it locks in:
+ *   • the RECONSTRUCTION INVARIANT for every fixture: concatenating the
+ *     segments reproduces the word and its full reading. Wrong furigana
+ *     corrupts both display and SRS keying, and a dropped/duplicated kana is
+ *     the corrupting failure mode — a merely-coarse per-kanji split is not.
+ *   • exact per-character splits for the shapes the kana-anchor algorithm
+ *     handles deterministically: all-kana words, okurigana, kana anchors
+ *     between kanji runs, leading kana.
+ *   • documented-heuristic shapes (unanchored multi-kanji runs: jukujikun,
+ *     compounds) keep the invariant even though the per-kanji split is
+ *     proportional guesswork (今日 has no true per-kanji reading).
+ */
+import esbuild from 'esbuild';
+import { pathToFileURL } from 'node:url';
+import { rmSync } from 'node:fs';
+import path from 'node:path';
+
+const TMP = path.join('scripts', '.tmp-furigana-bundle.mjs');
+
+await esbuild.build({
+  entryPoints: ['supabase/functions/_shared/furiganaMap.ts'],
+  outfile: TMP,
+  bundle: true,
+  format: 'esm',
+  platform: 'neutral',
+});
+const { buildFuriganaMap } = await import(pathToFileURL(path.resolve(TMP)).href);
+rmSync(TMP);
+
+let passed = 0;
+let failed = 0;
+function check(name, cond, detail = '') {
+  if (cond) {
+    passed++;
+    console.log(`  \x1b[32m✓\x1b[0m ${name}`);
+  } else {
+    failed++;
+    console.log(`  \x1b[31m✗\x1b[0m ${name}${detail ? `  — ${detail}` : ''}`);
+  }
+}
+
+const seg = (kanji, kana) => ({ kanji, kana });
+const show = (segs) => segs.map((s) => `${s.kanji}:${s.kana}`).join(' ');
+
+// ── Fixture table ────────────────────────────────────────────────────────────
+// exact: the algorithm's kana anchors make the split deterministic — pin it.
+// invariant-only: unanchored multi-kanji runs split proportionally; the split is
+// a display heuristic but the reading must still round-trip in full.
+const FIXTURES = [
+  // all-kana: identity mapping
+  { word: 'さくら', reading: 'さくら', exact: [seg('さ', 'さ'), seg('く', 'く'), seg('ら', 'ら')] },
+  // okurigana: kana anchor bounds the kanji reading
+  { word: '食べる', reading: 'たべる', exact: [seg('食', 'た'), seg('べ', 'べ'), seg('る', 'る')] },
+  { word: '聞く', reading: 'きく', exact: [seg('聞', 'き'), seg('く', 'く')] },
+  // adjective with the anchor kana appearing only at its true position
+  { word: '冷たい', reading: 'つめたい', exact: [seg('冷', 'つめ'), seg('た', 'た'), seg('い', 'い')] },
+  // kana anchors BETWEEN two kanji runs
+  { word: '引き出し', reading: 'ひきだし', exact: [seg('引', 'ひ'), seg('き', 'き'), seg('出', 'だ'), seg('し', 'し')] },
+  { word: '焼き肉', reading: 'やきにく', exact: [seg('焼', 'や'), seg('き', 'き'), seg('肉', 'にく')] },
+  // leading kana (honorific o-)
+  { word: 'お金', reading: 'おかね', exact: [seg('お', 'お'), seg('金', 'かね')] },
+  // interior 2-kanji run bounded by a trailing kana anchor: even split
+  { word: '気持ち', reading: 'きもち', exact: [seg('気', 'き'), seg('持', 'も'), seg('ち', 'ち')] },
+  // kana anchor inside a longer word
+  { word: '生け花', reading: 'いけばな', exact: [seg('生', 'い'), seg('け', 'け'), seg('花', 'ばな')] },
+  // sokuon anchor
+  { word: '引っ越し', reading: 'ひっこし', exact: [seg('引', 'ひ'), seg('っ', 'っ'), seg('越', 'こ'), seg('し', 'し')] },
+  // ── unanchored multi-kanji runs: proportional heuristic, invariant only ──
+  { word: '勉強', reading: 'べんきょう' },   // true split べん/きょう; heuristic gives べんき/ょう
+  { word: '図書館', reading: 'としょかん' }, // true と/しょ/かん
+  { word: '今日', reading: 'きょう' },       // jukujikun — no per-kanji reading exists
+  { word: '大人', reading: 'おとな' },       // jukujikun
+  { word: '昨日', reading: 'きのう' },       // jukujikun
+  { word: '一人', reading: 'ひとり' },       // jukujikun
+  { word: '日々', reading: 'ひび' },         // iteration mark 々 treated as kanji
+  { word: '飛行機', reading: 'ひこうき' },   // heteronym-prone compound
+];
+
+console.log('reconstruction invariant (word + full reading round-trip):');
+for (const { word, reading } of FIXTURES) {
+  const segs = buildFuriganaMap(word, reading);
+  const wordBack = segs.map((s) => s.kanji).join('');
+  const kanaBack = segs.map((s) => s.kana).join('');
+  check(`${word} → word round-trips`, wordBack === word, `got «${wordBack}»`);
+  check(`${word}/${reading} → reading round-trips`, kanaBack === reading, `got «${kanaBack}» (${show(segs)})`);
+}
+
+console.log('exact splits (kana-anchored shapes):');
+for (const { word, reading, exact } of FIXTURES) {
+  if (!exact) continue;
+  const segs = buildFuriganaMap(word, reading);
+  const ok = segs.length === exact.length && segs.every((s, i) => s.kanji === exact[i].kanji && s.kana === exact[i].kana);
+  check(`${word}/${reading}`, ok, `expected «${show(exact)}», got «${show(segs)}»`);
+}
+
+console.log(failed === 0
+  ? `\x1b[1m${passed} passed, 0 failed\x1b[0m`
+  : `\x1b[1m\x1b[31m${passed} passed, ${failed} failed\x1b[0m`);
+process.exit(failed === 0 ? 0 : 1);

--- a/src/components/Flashcards.tsx
+++ b/src/components/Flashcards.tsx
@@ -232,11 +232,15 @@ export function Flashcards({ onFocusChange }: { onFocusChange?: (focused: boolea
   const previews = useMemo(() => {
     if (!card) return {} as Record<Rating, string>;
     const now = Date.now();
-    // A never-studied "new" card previews from a fresh FSRS card (State.New) so the
+    // A never-studied card previews from a fresh FSRS card (State.New) so the
     // grades ladder (Again→Easy) instead of bunching around the synthetic
-    // difficulty-seed stability that promotion writes as status 'review'. Review
-    // cards preview from their real prior schedule. Mirrors store.reviewWord.
-    const prior = card.kind === 'new' ? null : priorSrsFor(card.word, now);
+    // difficulty-seed stability that promotion writes as status 'review'.
+    // Never-studied = the SAME predicate store.reviewWord uses (promoted, reps
+    // still 0) — NOT the deck's card.kind: a promoted-never-graded word that is
+    // already due gets kind 'review', and keying off kind made the pills show
+    // seed-bunched intervals while grading actually applied the fresh ladder.
+    const neverStudied = card.word.promotedTs != null && (card.word.reps ?? 0) === 0;
+    const prior = neverStudied ? null : priorSrsFor(card.word, now);
     const out = {} as Record<Rating, string>;
     for (const { rating } of RATINGS) out[rating] = formatInterval(schedule(prior, rating, now).intervalDays);
     return out;

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -1524,22 +1524,34 @@ export const useAppStore = create<AppState>()(
         const uid = await currentUserId();
         const userJlpt = state.jlptLevel;
         if (uid && userJlpt != null) {
-          try {
-            const seenIds = Object.values(get().wordDatabase)
-              .map((w) => w.jmdictEntryId)
-              .filter((id): id is string => !!id);
-            const { fetchIntakeCandidates } = await import('./jmdict');
-            const cands = await fetchIntakeCandidates(userJlpt, seenIds, cap + 20);
-            candidateItems = cands.map((c) => ({
-              key: null,
-              entryId: c.entryId,
-              jlptLevel: c.jlptLevel,
-              freqRank: c.freqRank,
-              timesSeen: 0,
-              candidate: c,
-            }));
-          } catch (e) {
-            console.warn('[store] intake candidate fetch failed:', e);
+          // A failed fetch silently erases the day's unseen-foundation slots (this
+          // pass runs once per calendar day — there is no later attempt). Retry once
+          // after a short pause before giving up, and log the give-up as an error so
+          // it surfaces once error monitoring lands (path-forward §0.3).
+          for (let attempt = 0; attempt < 2; attempt++) {
+            try {
+              const seenIds = Object.values(get().wordDatabase)
+                .map((w) => w.jmdictEntryId)
+                .filter((id): id is string => !!id);
+              const { fetchIntakeCandidates } = await import('./jmdict');
+              const cands = await fetchIntakeCandidates(userJlpt, seenIds, cap + 20);
+              candidateItems = cands.map((c) => ({
+                key: null,
+                entryId: c.entryId,
+                jlptLevel: c.jlptLevel,
+                freqRank: c.freqRank,
+                timesSeen: 0,
+                candidate: c,
+              }));
+              break;
+            } catch (e) {
+              if (attempt === 0) {
+                console.warn('[store] intake candidate fetch failed, retrying once:', e);
+                await new Promise((r) => setTimeout(r, 1500));
+              } else {
+                console.error('[store] intake candidate fetch failed after retry — no unseen-foundation words today:', e);
+              }
+            }
           }
         }
 

--- a/supabase/functions/_shared/furiganaMap.ts
+++ b/supabase/functions/_shared/furiganaMap.ts
@@ -1,0 +1,70 @@
+// Server-side furigana alignment: split a word's reading across its characters
+// so the client can render per-character <ruby> text. Kana characters anchor the
+// split (they must appear in the reading); a run of kanji between anchors gets
+// the enclosed reading slice, divided proportionally when the run is longer than
+// one kanji. Extracted from dictionary-lookup/index.ts so the alignment — which
+// feeds both displayed furigana and SRS keying — is unit-testable offline
+// (scripts/test-furigana-map.mjs). Mirrors the client aligner's contract
+// (src/services/furigana.ts): concatenating the segments always reproduces the
+// word and its full reading, even when a per-kanji split is heuristic (jukujikun
+// like 今日 have no true per-kanji reading).
+export const isKana = (c: string) => /[\u3040-\u309f\u30a0-\u30ff]/.test(c);
+
+export function buildFuriganaMap(word: string, reading: string): { kanji: string; kana: string }[] {
+  const chars = Array.from(word);
+
+  if (chars.every(isKana)) {
+    return chars.map(c => ({ kanji: c, kana: c }));
+  }
+
+  const segments: { kanji: string; kana: string }[] = [];
+  let readingIdx = 0;
+
+  for (let i = 0; i < chars.length; i++) {
+    const char = chars[i];
+    if (isKana(char)) {
+      segments.push({ kanji: char, kana: char });
+      const kanaPos = reading.indexOf(char, readingIdx);
+      if (kanaPos !== -1) {
+        readingIdx = kanaPos + 1;
+      } else {
+        readingIdx++;
+      }
+    } else {
+      let kanjiEnd = i + 1;
+      while (kanjiEnd < chars.length && !isKana(chars[kanjiEnd])) {
+        kanjiEnd++;
+      }
+
+      let readingEnd = readingIdx;
+      if (kanjiEnd < chars.length) {
+        const nextKana = chars[kanjiEnd];
+        const nextAnchorPos = reading.indexOf(nextKana, readingIdx);
+        readingEnd = nextAnchorPos !== -1 ? nextAnchorPos : readingIdx + (kanjiEnd - i);
+      } else {
+        readingEnd = reading.length;
+      }
+
+      const kanjiBlock = chars.slice(i, kanjiEnd);
+      const blockReading = reading.slice(readingIdx, readingEnd);
+
+      if (kanjiBlock.length === 1) {
+        segments.push({ kanji: kanjiBlock[0], kana: blockReading });
+      } else {
+        const readingPerKanji = Math.floor(blockReading.length / kanjiBlock.length);
+        const remainder = blockReading.length % kanjiBlock.length;
+        let rIdx = 0;
+        for (let k = 0; k < kanjiBlock.length; k++) {
+          const count = readingPerKanji + (k < remainder ? 1 : 0);
+          segments.push({ kanji: kanjiBlock[k], kana: blockReading.slice(rIdx, rIdx + count) });
+          rIdx += count;
+        }
+      }
+
+      readingIdx = readingEnd;
+      i = kanjiEnd - 1;
+    }
+  }
+
+  return segments.length > 0 ? segments : [{ kanji: word, kana: reading }];
+}

--- a/supabase/functions/dictionary-lookup/index.ts
+++ b/supabase/functions/dictionary-lookup/index.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI } from 'https://esm.sh/@google/genai';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { GEMINI_FLASH, GROQ_GENERAL as GROQ_MODEL } from '../_shared/models.ts';
+import { buildFuriganaMap } from '../_shared/furiganaMap.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -11,66 +12,8 @@ const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
 
 // --- JMDict lookup helpers (server-side, mirrors client jmdict.ts) ---
 
-const isKana = (c: string) => /[\u3040-\u309f\u30a0-\u30ff]/.test(c);
-
-function buildFuriganaMap(word: string, reading: string): { kanji: string; kana: string }[] {
-  const chars = Array.from(word);
-
-  if (chars.every(isKana)) {
-    return chars.map(c => ({ kanji: c, kana: c }));
-  }
-
-  const segments: { kanji: string; kana: string }[] = [];
-  let readingIdx = 0;
-
-  for (let i = 0; i < chars.length; i++) {
-    const char = chars[i];
-    if (isKana(char)) {
-      segments.push({ kanji: char, kana: char });
-      const kanaPos = reading.indexOf(char, readingIdx);
-      if (kanaPos !== -1) {
-        readingIdx = kanaPos + 1;
-      } else {
-        readingIdx++;
-      }
-    } else {
-      let kanjiEnd = i + 1;
-      while (kanjiEnd < chars.length && !isKana(chars[kanjiEnd])) {
-        kanjiEnd++;
-      }
-
-      let readingEnd = readingIdx;
-      if (kanjiEnd < chars.length) {
-        const nextKana = chars[kanjiEnd];
-        const nextAnchorPos = reading.indexOf(nextKana, readingIdx);
-        readingEnd = nextAnchorPos !== -1 ? nextAnchorPos : readingIdx + (kanjiEnd - i);
-      } else {
-        readingEnd = reading.length;
-      }
-
-      const kanjiBlock = chars.slice(i, kanjiEnd);
-      const blockReading = reading.slice(readingIdx, readingEnd);
-
-      if (kanjiBlock.length === 1) {
-        segments.push({ kanji: kanjiBlock[0], kana: blockReading });
-      } else {
-        const readingPerKanji = Math.floor(blockReading.length / kanjiBlock.length);
-        const remainder = blockReading.length % kanjiBlock.length;
-        let rIdx = 0;
-        for (let k = 0; k < kanjiBlock.length; k++) {
-          const count = readingPerKanji + (k < remainder ? 1 : 0);
-          segments.push({ kanji: kanjiBlock[k], kana: blockReading.slice(rIdx, rIdx + count) });
-          rIdx += count;
-        }
-      }
-
-      readingIdx = readingEnd;
-      i = kanjiEnd - 1;
-    }
-  }
-
-  return segments.length > 0 ? segments : [{ kanji: word, kana: reading }];
-}
+// isKana / buildFuriganaMap moved to ../_shared/furiganaMap.ts so the alignment
+// is unit-testable offline (scripts/test-furigana-map.mjs).
 
 interface JMDictDefinition {
   word: string;


### PR DESCRIPTION
## Summary
Path-forward plan §1.4, batched as prescribed:

**1. Furigana-map unit tests** — `buildFuriganaMap` did proportional multi-kanji splitting with zero tests; wrong furigana corrupts both reading display and SRS keying.
- Extracted **verbatim** (diff-verified identical) from `dictionary-lookup/index.ts` into `supabase/functions/_shared/furiganaMap.ts` so it's pure and offline-testable.
- New `scripts/test-furigana-map.mjs` (esbuild-bundle pattern, matches the other 5 runners): a fixture table pinning the **reconstruction invariant** (concatenated segments always reproduce the word and its full reading — the property SRS keying depends on) for every fixture including jukujikun (今日, 大人, 昨日, 一人) and heteronym-prone compounds, plus **exact splits** for kana-anchored shapes (okurigana, sokuon, interior anchors, leading kana). 46 assertions, wired as `npm run test:furigana`.

**2. Intake RPC failure visibility** — `fetchIntakeCandidates` failures were a silent `console.warn`, and the once-per-calendar-day promotion pass has no later attempt, so the day's unseen-foundation slots just vanished. Now retries once after 1.5s; final failure logs as `console.error` so it surfaces once §0.3 monitoring lands.

**3. New-card interval preview** — the grade pills keyed off the deck's `card.kind`, but a promoted-never-graded word that is already **due** gets `kind: 'review'` (`deck.ts:126` checks due first) — so the pills showed seed-bunched intervals while `reviewWord` actually applied the fresh new-card ladder. The preview now uses the exact predicate `reviewWord` uses (`promotedTs != null && reps === 0`).

## Verification
- `npm run build` clean
- 168 tests green across all 6 runners (srs 36, intake 14, deck 32, **furigana 46 new**, wordpriority 25, pacing 15)
- Lint on changed files identical to main baseline

## Deploy note
`supabase functions deploy dictionary-lookup` after merge (imports the new `_shared/furiganaMap.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWQK1Mn21BhmAdtQHCMWfB