### PR TITLE
feat: DSN-gated Sentry error monitoring + root error boundary (§0.3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ VITE_GEMINI_API_KEY=your_gemini_api_key_here
 VITE_SUPABASE_URL=your_supabase_project_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 VITE_GROQ_API_KEY=
+
+# Optional: Sentry error monitoring (path-forward §0.3). Leave unset to disable.
+VITE_SENTRY_DSN=

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
+        "@sentry/react": "^10.66.0",
         "@sglkc/kuromoji": "^1.1.0",
         "@supabase/supabase-js": "^2.100.1",
         "framer-motion": "^12.38.0",
@@ -1240,6 +1241,112 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.66.0.tgz",
+      "integrity": "sha512-MaPoBqKvI7O3UhexSJ/KO/o6T4Tr3A+vQWLZYTos0mxd59jVKMKbbJ6LxM/0uWQ5JAO2XYC/kCMRvk6VqQ5QZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.66.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0",
+        "@sentry/feedback": "10.66.0",
+        "@sentry/replay": "10.66.0",
+        "@sentry/replay-canvas": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.66.0.tgz",
+      "integrity": "sha512-sHuALvJMMEilUz84F1ZOQuDoZ3MhjwUHWHkXcElcVMrDIlnTO7Ra0E6Kh0e8JyJaLBMk4Sy9srKSqH9zimQVTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.66.0.tgz",
+      "integrity": "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.66.0.tgz",
+      "integrity": "sha512-fr69K76Gz7RRyfMerChdNjWIeQdFh+k21GJcmPCqk43dscUChOsLc3cYLS5cK7iZ/XiUmH9lVzf7EYL2kf2qsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.66.0.tgz",
+      "integrity": "sha512-aodV9C2NnaZBqJvaBceIIaVyMVEisO38EWtH5xL7IMbD6QSmBYsuNU7yYzRcdOj/+99FxJYRPaqwzGnIWnNTHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.66.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.66.0.tgz",
+      "integrity": "sha512-Djb4FxQa9bF8z3PoCO00Nw1u+6hma2YuI8JkMoE+F14KWRfCZKQ28sScsvk+OokbXgjtuIsxDEZj/qFGY0w01w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.66.0",
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.66.0.tgz",
+      "integrity": "sha512-z7fPWEIfAJMJySKXFIqXAzFpkHjp13WGMAmB9+hlHhi9+gjAO8owD9R4XTd86lBswveGwMHKvIx5lFKNVqDcow==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.66.0",
+        "@sentry/replay": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@sglkc/kuromoji": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
+    "@sentry/react": "^10.66.0",
     "@sglkc/kuromoji": "^1.1.0",
     "@supabase/supabase-js": "^2.100.1",
     "framer-motion": "^12.38.0",

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,58 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { captureError } from '../services/monitoring';
+
+// Top-level React error boundary (path-forward §0.3). A render/lifecycle throw
+// used to unmount the whole tree — an installed-PWA user just saw a white
+// screen with no reload button and no report. Now the error is captured
+// (Sentry when configured) and the user gets a minimal zen-styled recovery
+// screen. State/localStorage are untouched: reload resumes where they were.
+export class ErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo) {
+    captureError(error, { componentStack: info.componentStack, boundary: 'root' });
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+    return (
+      <div
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '1.25rem',
+          padding: '2rem',
+          backgroundColor: 'var(--bg-color)',
+          color: 'var(--text-main)',
+          textAlign: 'center',
+        }}
+      >
+        <div style={{ fontFamily: "'Shippori Mincho', serif", fontSize: '1.6rem' }}>侘寂</div>
+        <div style={{ fontSize: '0.9rem', color: 'var(--text-muted)', maxWidth: '26rem', lineHeight: 1.6 }}>
+          Something broke. Your reading progress is safe.
+        </div>
+        <button
+          onClick={() => window.location.reload()}
+          style={{
+            padding: '0.7rem 1.6rem',
+            borderRadius: '14px',
+            border: '1px solid var(--border-light)',
+            backgroundColor: 'var(--bg-card)',
+            color: 'var(--text-main)',
+            fontSize: '0.9rem',
+            cursor: 'pointer',
+          }}
+        >
+          再読み込み — Reload
+        </button>
+      </div>
+    );
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,8 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { loadReadingData } from './services/furigana'
+import { initMonitoring } from './services/monitoring'
+import { ErrorBoundary } from './components/ErrorBoundary'
 
 // Prime the per-kanji reading tables (#36) as early as possible — alignReading
 // degrades to the coarser okurigana aligner until they land, and enrichment
@@ -10,6 +12,11 @@ import { loadReadingData } from './services/furigana'
 // round-trip completes.
 loadReadingData()
 
+// Error monitoring (path-forward §0.3) — no-op unless VITE_SENTRY_DSN is set.
+initMonitoring()
+
 createRoot(document.getElementById('root')!).render(
-  <App />
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
 )

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -46,6 +46,7 @@ export interface NewsArticle {
 }
 
 import { supabase } from './supabase'
+import { captureError } from './monitoring'
 
 // ── Edge Function helper ──────────────────────────────────────────────────────
 /** True when the error looks like an expired/invalid auth token (HTTP 401 / JWT). */
@@ -90,7 +91,15 @@ async function invokeEdgeFn<T = any>(name: string, body: object, timeoutMs?: num
     ({ data, error } = (await run()) as { data: any; error: any });
   }
 
-  if (error) throw error;
+  if (error) {
+    // §0.3: surface real edge-function failures to monitoring. Transient
+    // busy-upstream errors (LLM overload → 503/429) are expected and retried
+    // by callers — reporting them would just be noise.
+    if (!isServerBusyError(error)) {
+      captureError(error, { edgeFn: name, status: (error as { status?: number })?.status ?? null });
+    }
+    throw error;
+  }
   return data as T;
 }
 

--- a/src/services/monitoring.ts
+++ b/src/services/monitoring.ts
@@ -1,0 +1,38 @@
+/**
+ * Error monitoring (path-forward §0.3). Every past PWA incident — dead taps
+ * from a full localStorage quota, stale-cache breakage — required getting a
+ * device console from a user; with beta users on installed PWAs this surfaces
+ * those failures in hours instead of days.
+ *
+ * Gated on VITE_SENTRY_DSN and lazy-loaded: without a DSN nothing initializes
+ * and the Sentry SDK never enters the bundle's critical path, so local dev and
+ * DSN-less deploys behave exactly as before. Callers use captureError()
+ * unconditionally — it no-ops until init completes.
+ */
+
+const DSN = import.meta.env.VITE_SENTRY_DSN as string | undefined;
+
+let sentry: typeof import('@sentry/react') | null = null;
+
+export function initMonitoring(): void {
+  if (!DSN) return;
+  import('@sentry/react')
+    .then((mod) => {
+      mod.init({
+        dsn: DSN,
+        // Errors only — no session replay, no tracing. Keeps the free tier
+        // roomy and avoids shipping user reading content anywhere.
+        sendDefaultPii: false,
+        tracesSampleRate: 0,
+      });
+      sentry = mod;
+    })
+    .catch((e) => console.warn('[monitoring] Sentry init failed:', e));
+}
+
+/** Report an error with optional context. Safe to call always: logs to the
+ *  console in every environment, forwards to Sentry only when configured. */
+export function captureError(error: unknown, context?: Record<string, unknown>): void {
+  console.error('[monitoring]', error, context ?? '');
+  sentry?.captureException(error, context ? { extra: context } : undefined);
+}

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { rtkKanjiList } from '../data/rtkKanji';
+import { captureError } from './monitoring';
 import { NewsArticle } from './api';
 import { supabase } from './supabase';
 import { schedule, ratingForReaderEvent, readerEventMayAdvance, seedSrsFromDifficulty, type SrsState, type SrsStatus, type Rating, type AdjustReason } from './srs';
@@ -1639,7 +1640,7 @@ export const useAppStore = create<AppState>()(
                 return;
               }
             } catch { /* fall through to the log below */ }
-            console.error('[store] localStorage persist failed (quota?) — continuing without persisting:', e);
+            captureError(e, { where: 'localStorage-persist', evicted: true });
           }
         },
         removeItem: (name) => localStorage.removeItem(name),


### PR DESCRIPTION
## Summary
Path-forward plan §0.3: there was zero telemetry — every past PWA incident required getting a device console from a user.

- **`services/monitoring.ts`** — init gated on `VITE_SENTRY_DSN` and **lazy-loaded**: without a DSN nothing initializes, the Sentry SDK stays out of the bundle's critical path, and dev/DSN-less deploys behave exactly as before. `captureError()` is safe to call unconditionally. Errors only (no session replay, no tracing, `sendDefaultPii: false`) — keeps the free tier roomy and reading content private.
- **Root `ErrorBoundary`** — a render/lifecycle throw used to unmount the tree into a white screen with no reload button and no report. Now: captured + minimal zen-styled recovery screen with a reload button (state/localStorage untouched).
- **`invokeEdgeFn`** — real failures (after the auth-refresh retry) report with the edge-function name and status; transient busy-upstream 503/429s are excluded as noise.
- **Quota catch** — the evict-and-retry's *final* failure (from #119) reports instead of only logging.

**Stacked on #119** (`fix/bound-localstorage-54`) — it instruments that PR's quota path. Merge #119 first.

## To activate (optional, works fine without)
1. Create a Sentry project (React), free tier.
2. Add `VITE_SENTRY_DSN` to `.env` and the Vercel project env.

## Verification
- `npm run build` clean; 122 tests green across 5 runners; lint on all touched files identical to main baseline; new files lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWQK1Mn21BhmAdtQHCMWfB