### PR TITLE
docs: mark path-forward Phases 0–1 shipped; log Jul 18 batch in task.md

### DIFF
--- a/docs/path-forward-2026-07.md
+++ b/docs/path-forward-2026-07.md
@@ -1,5 +1,14 @@
 # Path Forward — July 2026
 A prioritized roadmap based on a full review of the 16 open GitHub issues, the codebase, and the shipped state of the app as of 2026-07-13.
+
+> **Status update (2026-07-18): Phases 0–1 shipped.**
+> - 0.1 ✔ — the stray branch turned out to be already merged (#107); #73 closed (#71/#72 still to close as shipped in #97)
+> - 0.2 ✔ #118 · 0.3 ✔ #126 (Sentry live in prod, DSN in Vercel env) · 0.4 ✔ #119 (closes #54) · 0.5 ✔ #125 (SW + update banner + offline kuromoji)
+> - 0.6 ◐ — `daily-feed` confirmed still deployed; cron verification + deletion pending (manual)
+> - 1.1 ✔ #123 (closes #103) · 1.2 ✔ #124 · 1.3 ✔ #127 · 1.4 ✔ #121 (adds `npm run test:furigana`, 46 asserts)
+> - Pending manual steps: `supabase functions deploy process-article` and `deploy dictionary-lookup`; beta users hard-refresh once for the first SW.
+> - **Next: Phase 2** — #38 BYOC, then #10 topics.
+
 ## Where the app stands
 The **Word Mastery Loop is complete**. Phases A–E of `word-mastery-loop-plan.md` all shipped: canonical entry-id keying (#39), FSRS-6 engine (#67), intake queue with calendar-day pacing (#68, #106), flashcard UI (#70), reader⇄flashcard one-schedule convergence (#71 via PR #97), pre-due review floor in articles (#72/#51), and the study dashboard (#73). On the content side, source-fullness ranking (#49/#57), topic clustering (#18), server-side JIT buffer (#31), concept clusters (#101), and the controlled-vocabulary lexicon (#105) are live — a real N4 reader's struggling-word share dropped from 39% to ~10%.
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -299,3 +299,33 @@
   - Verified: Playwright walkthrough (seed deck → focus on tap → outside-tap
     exit → re-focus → grade 8/8 → finish card flip → Discover launch with live
     candidates → focus re-entry). tsc clean.
+- [x] Path-forward Phases 0–1: hardening + learning-loop quality (Jul 18)
+  - [x] 0.2 Gemini output validated before persisting in process-article (#118):
+        parseBlocks-style structural check inside the retry loop; a bad
+        generation regenerates instead of writing a client-crashing article.
+  - [x] 1.3 Real token/cost telemetry (#127): usageMetadata logged per article
+        and persisted to processed_news.metadata->'usage' (SQL-aggregatable).
+  - [x] 1.1 Concept↔SRS strong matching (#123, closes #103): concepts extracted
+        on every article; reverse user_word_progress ⋈ jmdict_senses gloss match
+        (client-side over the pre-due pool, no migration); matched studied words
+        lead clusters past the JLPT-tag gate; review floor concept-aligned.
+  - [x] 0.4 localStorage bounded (#119, closes #54): id lists capped at 1000 +
+        quota evict-and-retry so a full quota can't silently drop grades.
+  - [x] 0.3 Error monitoring (#126): DSN-gated lazy Sentry + root ErrorBoundary
+        (no more white screens); invokeEdgeFn + quota failures report. LIVE in
+        prod — VITE_SENTRY_DSN set in Vercel + .env, verified in the bundle.
+  - [x] 1.4 Correctness batch (#121): buildFuriganaMap extracted to _shared +
+        46-assert fixture runner (test:furigana; round-trip invariant incl.
+        jukujikun); intake candidate fetch retries once; grade pills use
+        reviewWord's exact new-card predicate (due-but-ungraded showed wrong
+        intervals).
+  - [x] 1.2 Local-only word gap (#124): entry-less graded words sync under their
+        surface key and rehydrate after reinstall (word_id has no FK — no
+        migration); healing pass keeps retrying links each session.
+  - [x] 0.5 PWA service worker (#125): vite-plugin-pwa prompt mode, update
+        banner (hourly + foreground checks), offline kuromoji via CacheFirst,
+        /api/* excluded from SPA fallback. Verified serving at /sw.js in prod.
+  - [ ] Manual follow-ups: supabase functions deploy process-article +
+        dictionary-lookup; verify jit-overnight-refill cron then delete
+        daily-feed; close #71/#72 (shipped in #97); beta users hard-refresh
+        once for the first SW.


### PR DESCRIPTION
Doc-only: adds a dated status block to `docs/path-forward-2026-07.md` (per-item PR refs, pending manual steps, Phase 2 next) and the corresponding `docs/task.md` log entry for today's 9-PR batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWQK1Mn21BhmAdtQHCMWfB