### PR TITLE
feat: user-selectable feed topics (#10) + source-fullness fix

### DIFF
--- a/database/26_feed_topics.sql
+++ b/database/26_feed_topics.sql
@@ -1,0 +1,20 @@
+-- ============================================================
+-- 26_feed_topics.sql
+-- User-selectable feed topics (#10): which curated topic groups the news
+-- pipeline pulls from for this user.
+-- ============================================================
+-- APPLY MANUALLY in the Supabase SQL editor (migrations in this repo are not
+-- auto-deployed). Safe to run repeatedly — ADD COLUMN IF NOT EXISTS.
+--
+-- Values are topic ids from the curated catalog (kept in sync between
+-- supabase/functions/fetch-raw-news/index.ts FEED_LIST and the client's
+-- src/data/feedTopics.ts): world, technology, science, business, sports,
+-- culture, health, japan, ai, space, gaming, climate, food, travel, politics.
+--
+-- NULL (or an absent row) means "never chosen" — fetch-raw-news falls back to
+-- the pre-#10 default lineup (world, technology, science). Unknown ids are
+-- dropped server-side, and an empty selection also falls back to the defaults,
+-- so a stale client can never zero out a user's feed.
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS feed_topics text[];

--- a/docs/path-forward-2026-07.md
+++ b/docs/path-forward-2026-07.md
@@ -2,11 +2,11 @@
 A prioritized roadmap based on a full review of the 16 open GitHub issues, the codebase, and the shipped state of the app as of 2026-07-13.
 
 > **Status update (2026-07-18): Phases 0–1 shipped.**
-> - 0.1 ✔ — the stray branch turned out to be already merged (#107); #73 closed (#71/#72 still to close as shipped in #97)
+> - 0.1 ✔ — the stray branch turned out to be already merged (#107); #71/#72/#73 all closed as shipped in #97
 > - 0.2 ✔ #118 · 0.3 ✔ #126 (Sentry live in prod, DSN in Vercel env) · 0.4 ✔ #119 (closes #54) · 0.5 ✔ #125 (SW + update banner + offline kuromoji)
-> - 0.6 ◐ — `daily-feed` confirmed still deployed; cron verification + deletion pending (manual)
+> - 0.6 ✔ (2026-07-19) — `jit-overnight-refill` cron verified live (`0 9 * * *`, active); `daily-feed` deleted
 > - 1.1 ✔ #123 (closes #103) · 1.2 ✔ #124 · 1.3 ✔ #127 · 1.4 ✔ #121 (adds `npm run test:furigana`, 46 asserts)
-> - Pending manual steps: `supabase functions deploy process-article` and `deploy dictionary-lookup`; beta users hard-refresh once for the first SW.
+> - Manual steps done 2026-07-19: `process-article` + `dictionary-lookup` deployed; beta users notified to hard-refresh once for the first SW.
 > - **Next: Phase 2** — #38 BYOC, then #10 topics.
 
 ## Where the app stands

--- a/docs/task.md
+++ b/docs/task.md
@@ -136,7 +136,7 @@
         (2) api.markArticleConsumed writes a dismissed/read TOMBSTONE when no live
         buffer row matched, so ensure_buffer_claim's ON CONFLICT never re-produces
         a swiped raw headline. Self-heals existing stuck buffers on next open.
-  - [/] Step 5: overnight cron — pg_cron + pg_net → ensure-buffer for active users
+  - [x] Step 5: overnight cron — pg_cron + pg_net → ensure-buffer for active users
         (study_history in last 14 days), service-role key via Vault. Retire daily-feed.
         Cron adds overnight/daily-fresh seeding + bootstrap for non-opening users
         (event-driven app-open/read/dismiss refill already shipped in Steps 3/4).
@@ -149,9 +149,11 @@
               is just the gateway pass (body userId is authoritative).
         - [x] daily-feed/index.ts marked DEPRECATED (banner); pg_cron schedule removed
               by 19. Dashboard-scheduled daily-feed (if any) must be disabled by hand.
-        - [ ] APPLY (your steps): (1) select vault.create_secret('<ANON_KEY>','jit_anon_key');
+        - [x] APPLY (your steps): (1) select vault.create_secret('<ANON_KEY>','jit_anon_key');
               (2) run database/19 in SQL editor; (3) smoke-test select jit_refill_active_users().
-        - [ ] After cron verified live: delete the daily-feed Edge Function deployment.
+        - [x] After cron verified live: delete the daily-feed Edge Function deployment.
+              (2026-07-19: cron.job shows jit-overnight-refill @ 0 9 * * * active;
+              daily-feed deleted.)
 - [x] Progress bucketing + sync fixes (2026-06-27): words wrongly in "Other"/Ungraded
       and lost on reinstall. Investigation traced one symptom to four distinct issues:
   - Root symptom: common N5–N4 words sat in Progress "Other" because their cached
@@ -325,7 +327,45 @@
   - [x] 0.5 PWA service worker (#125): vite-plugin-pwa prompt mode, update
         banner (hourly + foreground checks), offline kuromoji via CacheFirst,
         /api/* excluded from SPA fallback. Verified serving at /sw.js in prod.
-  - [ ] Manual follow-ups: supabase functions deploy process-article +
-        dictionary-lookup; verify jit-overnight-refill cron then delete
-        daily-feed; close #71/#72 (shipped in #97); beta users hard-refresh
-        once for the first SW.
+  - [x] Manual follow-ups (done 2026-07-19): deployed process-article +
+        dictionary-lookup; verified jit-overnight-refill cron live and
+        deleted daily-feed; beta users notified to hard-refresh once for
+        the first SW; closed #71/#72 (shipped in #97). Phase 0 fully done.
+- [/] Phase 2.2 Customizable feed topics (#10) + source-fullness audit (Jul 19)
+  - [x] Read-only audit of processed_news source_kind (n=255 tracked rows,
+        2026-W25→W29): snippet tier fully eliminated (0%) since #49/#57, but
+        only ~35-45%/week land `full`; ~55-65% stall at `partial` (median
+        ~870 chars). Root cause identified: EXTRACT_TEASER_THRESHOLD=600 in
+        process-article skips Jina extraction for any teaser ≥600 chars, while
+        fetch-raw-news TEASER_CAP=800 ships description-teasers up to 800 —
+        so the 600-1500-char band (all Guardian-style feeds) never gets
+        upgraded to a full body. Every partial row sits in that skip band.
+        Proposed fix (not yet applied): extract when body < FULL_SOURCE_CHARS
+        (1500) instead of < 600 — would convert most partials to full at the
+        cost of ≤4 Jina calls/article.
+  - [x] Curated topic catalog, 15 topics: world, technology, science,
+        business, sports, culture, health, japan, ai, space, gaming,
+        climate, food, travel, politics. 26 new feeds added across
+        BBC/Guardian/NPR desks + Verge AI, TechCrunch AI, NASA, Polygon,
+        Japan Times. Pool auto-scales per-feed depth (POOL_TARGET=132) so
+        selecting every topic doesn't grow the clustering prompt. All feed
+        URLs verified 200 (redirect targets canonicalized).
+  - [x] fetch-raw-news accepts `topics` (sanitized against catalog; empty/
+        unknown → world+technology+science defaults = pre-#10 behavior).
+  - [x] ensure-buffer reads user_preferences.feed_topics and passes it, so
+        server-produced JIT buffer articles honor the selection (cron too).
+  - [x] Client: feedTopics in store (null = never chosen) synced via
+        upsertUserPreferences + rehydrated in syncSrsWithSupabase; App.tsx
+        passes topics on both fetchNewsFeed paths; Settings "Feed Topics"
+        toggle-chip card (at least one topic enforced). UI chosen over
+        checklist/feed-strip/bilingual variants.
+  - [x] Verified in-browser (Playwright, dev mode): chips render, toggles
+        update + persist across reload, last-topic guard holds. Caught in
+        verification: feedTopics missing from persist partialize (selection
+        silently lost on reload) — fixed. tsc clean.
+  - [ ] APPLY (your steps): (1) run database/26_feed_topics.sql in the SQL
+        editor; (2) supabase functions deploy fetch-raw-news ensure-buffer.
+  - [ ] Note: custom free-text topics deliberately deferred to #11 (RSS
+        management) — Google News RSS query feeds ship headline-only teasers
+        behind redirect URLs that Jina can't extract, which would reintroduce
+        the snippet tier the sourcing work just eliminated.

--- a/docs/task.md
+++ b/docs/task.md
@@ -340,9 +340,15 @@
         fetch-raw-news TEASER_CAP=800 ships description-teasers up to 800 —
         so the 600-1500-char band (all Guardian-style feeds) never gets
         upgraded to a full body. Every partial row sits in that skip band.
-        Proposed fix (not yet applied): extract when body < FULL_SOURCE_CHARS
-        (1500) instead of < 600 — would convert most partials to full at the
-        cost of ≤4 Jina calls/article.
+  - [x] Sourcing fix applied (same session): process-article now extracts
+        whenever a source body < FULL_SOURCE_CHARS (1500), not < 600 —
+        converts the stranded partial band to full at ≤4 Jina calls/article;
+        fullBody now requires a ≥1500-char body (short Jina stubs no longer
+        count). Lead-source cap raised 2500→4500 (LEAD_SOURCE_CHAR_CAP;
+        corroborating sources stay 2500, total stays 7000) since truncating
+        the lead costs real facts; fetch-raw-news FULLTEXT_BODY_CAP matched
+        to 4500. Watch metadata->'usage' token telemetry (1.3) + re-run the
+        database/20 audit query after a week to confirm partial→full shift.
   - [x] Curated topic catalog, 15 topics: world, technology, science,
         business, sports, culture, health, japan, ai, space, gaming,
         climate, food, travel, politics. 26 new feeds added across
@@ -364,7 +370,8 @@
         verification: feedTopics missing from persist partialize (selection
         silently lost on reload) — fixed. tsc clean.
   - [ ] APPLY (your steps): (1) run database/26_feed_topics.sql in the SQL
-        editor; (2) supabase functions deploy fetch-raw-news ensure-buffer.
+        editor; (2) supabase functions deploy fetch-raw-news ensure-buffer
+        process-article (last one carries the sourcing fix + lead cap).
   - [ ] Note: custom free-text topics deliberately deferred to #11 (RSS
         management) — Google News RSS query feeds ship headline-only teasers
         behind redirect URLs that Jina can't extract, which would reintroduce

--- a/docs/task.md
+++ b/docs/task.md
@@ -369,9 +369,13 @@
         update + persist across reload, last-topic guard holds. Caught in
         verification: feedTopics missing from persist partialize (selection
         silently lost on reload) — fixed. tsc clean.
-  - [ ] APPLY (your steps): (1) run database/26_feed_topics.sql in the SQL
-        editor; (2) supabase functions deploy fetch-raw-news ensure-buffer
-        process-article (last one carries the sourcing fix + lead cap).
+  - [x] APPLY (done 2026-07-19): database/26_feed_topics.sql run; fetch-raw-
+        news + ensure-buffer + process-article deployed. Verified live:
+        feed_topics column present (existing row null → defaults),
+        topics=null → World/Technology defaults, topics=[japan,ai] →
+        Japan 15 + AI 25 cards. process-article sourcing fix will show in
+        source_kind of the next JIT-produced articles — re-run the
+        database/20 audit query after ~a week (expect partial ≪ 65%).
   - [ ] Note: custom free-text topics deliberately deferred to #11 (RSS
         management) — Google News RSS query feeds ship headline-only teasers
         behind redirect URLs that Jina can't extract, which would reintroduce

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,7 +101,7 @@ function App() {
       
       // Try current and next page if first is full of dupes
       for (let p = currentPage; p < currentPage + 2; p++) {
-        const moreNews = await fetchNewsFeed(p);
+        const moreNews = await fetchNewsFeed(p, useAppStore.getState().feedTopics);
         if (moreNews.length === 0) {
           setIsEndOfFeed(true);
           break;
@@ -156,7 +156,7 @@ function App() {
       if (userId && !DEV_MODE) ensureBuffer(userId);
 
       const [feed, readyBuffer] = await Promise.all([
-        fetchNewsFeed(1),
+        fetchNewsFeed(1, useAppStore.getState().feedTopics),
         userId && !DEV_MODE ? fetchReadyBufferArticles(userId) : Promise.resolve([] as NewsArticle[]),
       ]);
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ChevronDown } from 'lucide-react';
 import { useAppStore } from '../services/store';
 import { rtkKanjiList } from '../data/rtkKanji';
+import { FEED_TOPICS, DEFAULT_FEED_TOPICS } from '../data/feedTopics';
 
 const stepperBtnStyle = (disabled: boolean): React.CSSProperties => ({
   width: '34px',
@@ -33,6 +34,7 @@ export function Settings() {
     studyMode, setStudyMode,
     readingIntensity, setReadingIntensity,
     targetParagraphs, setTargetParagraphs,
+    feedTopics, setFeedTopics,
     newWordsPerDay, setNewWordsPerDay,
     readerFontSize, setReaderFontSize,
     readerFontWeight, setReaderFontWeight,
@@ -49,6 +51,16 @@ export function Settings() {
     if (!isNaN(val)) {
       setRtkLevel(Math.min(Math.max(1, val), rtkKanjiList.length));
     }
+  };
+
+  // null = never chosen → the server-default lineup is what's effectively active.
+  const selectedTopics = feedTopics ?? DEFAULT_FEED_TOPICS;
+  const toggleTopic = (id: string) => {
+    const next = selectedTopics.includes(id)
+      ? selectedTopics.filter(t => t !== id)
+      : [...selectedTopics, id];
+    if (next.length === 0) return; // keep at least one topic on
+    setFeedTopics(next);
   };
 
   const modes = ['Natural', 'Balanced', 'Study'] as const;
@@ -166,6 +178,43 @@ export function Settings() {
           {readingIntensity === 'leisure' && 'Light reading — ~98% known vocabulary. Flow through articles with minimal dictionary lookups.'}
           {readingIntensity === 'balanced' && 'Comfortable learning — ~95% known, with a handful of review words and 1–2 new words per article.'}
           {readingIntensity === 'intensive' && 'Study-heavy — ~90% known, with more review and new vocabulary packed in. Slower but faster growth.'}
+        </p>
+      </div>
+
+      {/* 2.5 Feed Topics (#10) */}
+      <div style={{ backgroundColor: 'var(--bg-card)', padding: '1.5rem', borderRadius: '16px', marginBottom: '1.5rem' }}>
+        <label style={{ display: 'block', fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-muted)', letterSpacing: '0.1em', marginBottom: '1.5rem', textTransform: 'uppercase' }}>
+          Feed Topics
+        </label>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.6rem', marginBottom: '1.2rem' }}>
+          {FEED_TOPICS.map(topic => {
+            const isOn = selectedTopics.includes(topic.id);
+            return (
+              <button
+                key={topic.id}
+                onClick={() => toggleTopic(topic.id)}
+                title={topic.hint}
+                style={{
+                  padding: '0.5rem 1.1rem',
+                  borderRadius: '100px',
+                  border: 'none',
+                  outline: 'none',
+                  cursor: 'pointer',
+                  backgroundColor: isOn ? 'var(--bg-pure)' : 'var(--border-light)',
+                  color: isOn ? 'var(--text-main)' : 'var(--text-muted)',
+                  fontWeight: isOn ? 700 : 600,
+                  fontSize: '0.85rem',
+                  boxShadow: isOn ? '0 2px 8px rgba(0,0,0,0.1)' : 'none',
+                  transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+                }}
+              >
+                {topic.label}
+              </button>
+            );
+          })}
+        </div>
+        <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', lineHeight: 1.5 }}>
+          Choose what your reading feed draws from. Changes apply to newly fetched articles — stories already prepared for you will still appear first.
         </p>
       </div>
 

--- a/src/data/feedTopics.ts
+++ b/src/data/feedTopics.ts
@@ -1,0 +1,29 @@
+// Curated feed-topic catalog (#10). Mirrors the topic ids tagged onto FEED_LIST
+// in supabase/functions/fetch-raw-news/index.ts — keep the two in sync when
+// adding a topic there. Selection is stored in user_preferences.feed_topics;
+// null means "never chosen" and the server falls back to DEFAULT_FEED_TOPICS.
+export interface FeedTopic {
+  id: string;
+  label: string;
+  hint: string;
+}
+
+export const FEED_TOPICS: FeedTopic[] = [
+  { id: 'world',      label: 'World',      hint: 'BBC, NPR, Guardian world desks' },
+  { id: 'technology', label: 'Technology', hint: 'The Verge, Ars Technica, Wired, TechCrunch' },
+  { id: 'science',    label: 'Science',    hint: 'Guardian and BBC science & environment' },
+  { id: 'business',   label: 'Business',   hint: 'BBC and Guardian business desks' },
+  { id: 'sports',     label: 'Sports',     hint: 'BBC Sport, Guardian Sport' },
+  { id: 'culture',    label: 'Culture',    hint: 'Arts, film, music, entertainment' },
+  { id: 'health',     label: 'Health',     hint: 'BBC Health, NPR Health' },
+  { id: 'japan',      label: 'Japan',      hint: 'Japan Times, Guardian Japan coverage' },
+  { id: 'ai',         label: 'AI',         hint: 'The Verge, TechCrunch, Guardian AI desks' },
+  { id: 'space',      label: 'Space',      hint: 'Guardian Space, NASA news' },
+  { id: 'gaming',     label: 'Gaming',     hint: 'Polygon, Guardian Games' },
+  { id: 'climate',    label: 'Climate',    hint: 'Guardian Environment, NPR Climate' },
+  { id: 'food',       label: 'Food',       hint: 'Guardian Food, NPR Food' },
+  { id: 'travel',     label: 'Travel',     hint: 'Guardian Travel' },
+  { id: 'politics',   label: 'Politics',   hint: 'NPR Politics, Guardian US Politics' },
+];
+
+export const DEFAULT_FEED_TOPICS = ['world', 'technology', 'science'];

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -260,7 +260,7 @@ export async function fetchReadyBufferArticles(userId: string, limit = 10): Prom
   return (data ?? []).map((r) => r.content as NewsArticle).filter(Boolean);
 }
 
-export async function fetchNewsFeed(page: number = 1): Promise<NewsArticle[]> {
+export async function fetchNewsFeed(page: number = 1, topics: string[] | null = null): Promise<NewsArticle[]> {
   const devMode = import.meta.env.VITE_DEV_MODE === 'true';
   if (!devMode) {
     // getSession reads the cached session (no /auth/v1/user round-trip), so a
@@ -270,7 +270,7 @@ export async function fetchNewsFeed(page: number = 1): Promise<NewsArticle[]> {
   }
 
   try {
-    const { articles } = await invokeEdgeFn<{ articles: NewsArticle[] }>('fetch-raw-news', { page });
+    const { articles } = await invokeEdgeFn<{ articles: NewsArticle[] }>('fetch-raw-news', { page, topics });
     if (!articles || articles.length === 0) {
       console.warn(`[api] News API returned zero results for page ${page}. Check Edge Function logs.`);
       return [];
@@ -751,6 +751,7 @@ export async function upsertUserPreferences(
     target_paragraphs_partial?: number;
     target_paragraphs_snippet?: number;
     new_words_per_day?: number;
+    feed_topics?: string[];
   }
 ) {
   const { error } = await supabase

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -205,6 +205,9 @@ interface AppState {
   // Target article length (paragraphs) by source fullness. Length follows how
   // much real source material the article was built from; JLPT drives complexity.
   targetParagraphs: { full: number; partial: number; snippet: number };
+  // Feed topics (#10): curated topic ids the news pipeline pulls from. null =
+  // never chosen → server defaults (world/technology/science). See src/data/feedTopics.ts.
+  feedTopics: string[] | null;
   // Intake queue (#68): the Anki-style daily cap on how many new words graduate from
   // the queue into active study, and when the last promotion pass ran (daily gate).
   newWordsPerDay: number;
@@ -239,6 +242,7 @@ interface AppState {
   setFuriganaMode: (mode: 'always' | 'never' | 'dynamic') => void;
   setReadingIntensity: (intensity: 'leisure' | 'balanced' | 'intensive') => void;
   setTargetParagraphs: (kind: 'full' | 'partial' | 'snippet', value: number) => void;
+  setFeedTopics: (topics: string[]) => void;
   setNewWordsPerDay: (n: number) => void;
   setCurrentArticle: (article: NewsArticle | null) => void;
   saveProcessedArticle: (id: string, article: NewsArticle) => void;
@@ -308,6 +312,7 @@ export const useAppStore = create<AppState>()(
       furiganaMode: 'dynamic',
       readingIntensity: 'balanced',
       targetParagraphs: { full: 5, partial: 4, snippet: 3 },
+      feedTopics: null,
       newWordsPerDay: 3,
       lastIntakePromotionTs: null,
       reviewsByDay: {},
@@ -367,6 +372,16 @@ export const useAppStore = create<AppState>()(
         } as const)[kind];
         currentUserId().then((uid) => {
           if (uid) import('./api').then(m => m.upsertUserPreferences(uid, { [column]: v }));
+        });
+      },
+      setFeedTopics: (topics) => {
+        // Never persist an empty selection — the server would fall back to
+        // defaults anyway, which would silently contradict the UI.
+        if (!Array.isArray(topics) || topics.length === 0) return;
+        const clean = [...new Set(topics)];
+        set({ feedTopics: clean });
+        currentUserId().then((uid) => {
+          if (uid) import('./api').then(m => m.upsertUserPreferences(uid, { feed_topics: clean }));
         });
       },
       setNewWordsPerDay: (n) => {
@@ -1121,6 +1136,7 @@ export const useAppStore = create<AppState>()(
               snippet: remotePrefs.target_paragraphs_snippet ?? state.targetParagraphs.snippet,
             },
             newWordsPerDay: remotePrefs.new_words_per_day ?? state.newWordsPerDay,
+            feedTopics: remotePrefs.feed_topics ?? state.feedTopics,
           }));
         }
 
@@ -1725,6 +1741,7 @@ export const useAppStore = create<AppState>()(
         furiganaMode: state.furiganaMode,
         readingIntensity: state.readingIntensity,
         targetParagraphs: state.targetParagraphs,
+        feedTopics: state.feedTopics,
         newWordsPerDay: state.newWordsPerDay,
         lastIntakePromotionTs: state.lastIntakePromotionTs,
         reviewsByDay: state.reviewsByDay,

--- a/supabase/functions/ensure-buffer/index.ts
+++ b/supabase/functions/ensure-buffer/index.ts
@@ -89,12 +89,16 @@ Deno.serve(async (req) => {
     }
 
     // ── Guardrail #5: fetch fresh candidates. No source ⇒ stop. ───────────────
+    // The user's topic selection (#10) rides along so server-produced buffer
+    // articles match their interests. NULL/absent → fetch-raw-news defaults.
+    const { data: prefs } = await admin.from('user_preferences')
+      .select('feed_topics').eq('user_id', userId).maybeSingle();
     let candidates: RawCard[] = [];
     try {
       const resp = await fetch(`${supabaseUrl}/functions/v1/fetch-raw-news`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${serviceKey}` },
-        body: JSON.stringify({ page: 1 }),
+        body: JSON.stringify({ page: 1, topics: prefs?.feed_topics ?? null }),
       });
       if (resp.ok) {
         const data = await resp.json();

--- a/supabase/functions/fetch-raw-news/index.ts
+++ b/supabase/functions/fetch-raw-news/index.ts
@@ -10,20 +10,58 @@ const corsHeaders = {
 // the same story shows up across several feeds and clusters into much richer
 // source material than a single NewsAPI query can (see #18 follow-up). NewsAPI
 // remains a fallback for the rare case where every feed fails.
-const FEED_LIST: { name: string; url: string; category: string }[] = [
-  { name: 'BBC',        url: 'https://feeds.bbci.co.uk/news/rss.xml',            category: 'World' },
-  { name: 'BBC Tech',   url: 'https://feeds.bbci.co.uk/news/technology/rss.xml', category: 'Technology' },
-  { name: 'The Verge',  url: 'https://www.theverge.com/rss/index.xml',           category: 'Technology' },
-  { name: 'Ars Technica', url: 'https://feeds.arstechnica.com/arstechnica/index', category: 'Technology' },
-  { name: 'TechCrunch', url: 'https://techcrunch.com/feed/',                     category: 'Technology' },
-  { name: 'NPR',        url: 'https://feeds.npr.org/1001/rss.xml',               category: 'World' },
-  { name: 'Engadget',   url: 'https://www.engadget.com/rss.xml',                 category: 'Technology' },
-  { name: 'Wired',      url: 'https://www.wired.com/feed/rss',                   category: 'Technology' },
-  { name: 'Guardian',   url: 'https://www.theguardian.com/world/rss',            category: 'World' },
-  { name: 'Guardian Tech', url: 'https://www.theguardian.com/technology/rss',    category: 'Technology' },
-  { name: 'Guardian Sci',  url: 'https://www.theguardian.com/science/rss',       category: 'Science' },
+//
+// Every feed is tagged with a topic id from the curated catalog (#10). The
+// client mirrors the id/label catalog in src/data/feedTopics.ts — keep the two
+// in sync when adding a topic. `category` stays the human label shown on cards.
+const FEED_LIST: { name: string; url: string; category: string; topic: string }[] = [
+  { name: 'BBC',        url: 'https://feeds.bbci.co.uk/news/rss.xml',            category: 'World',      topic: 'world' },
+  { name: 'NPR',        url: 'https://feeds.npr.org/1001/rss.xml',               category: 'World',      topic: 'world' },
+  { name: 'Guardian',   url: 'https://www.theguardian.com/world/rss',            category: 'World',      topic: 'world' },
+  { name: 'BBC Tech',   url: 'https://feeds.bbci.co.uk/news/technology/rss.xml', category: 'Technology', topic: 'technology' },
+  { name: 'The Verge',  url: 'https://www.theverge.com/rss/index.xml',           category: 'Technology', topic: 'technology' },
+  { name: 'Ars Technica', url: 'https://feeds.arstechnica.com/arstechnica/index', category: 'Technology', topic: 'technology' },
+  { name: 'TechCrunch', url: 'https://techcrunch.com/feed/',                     category: 'Technology', topic: 'technology' },
+  { name: 'Engadget',   url: 'https://www.engadget.com/rss.xml',                 category: 'Technology', topic: 'technology' },
+  { name: 'Wired',      url: 'https://www.wired.com/feed/rss',                   category: 'Technology', topic: 'technology' },
+  { name: 'Guardian Tech', url: 'https://www.theguardian.com/technology/rss',    category: 'Technology', topic: 'technology' },
+  { name: 'Guardian Sci',  url: 'https://www.theguardian.com/science/rss',       category: 'Science',    topic: 'science' },
+  { name: 'BBC Science',   url: 'https://feeds.bbci.co.uk/news/science_and_environment/rss.xml', category: 'Science', topic: 'science' },
+  { name: 'BBC Business',  url: 'https://feeds.bbci.co.uk/news/business/rss.xml', category: 'Business',  topic: 'business' },
+  { name: 'Guardian Business', url: 'https://www.theguardian.com/uk/business/rss', category: 'Business', topic: 'business' },
+  { name: 'BBC Sport',     url: 'https://feeds.bbci.co.uk/sport/rss.xml',         category: 'Sports',    topic: 'sports' },
+  { name: 'Guardian Sport', url: 'https://www.theguardian.com/us/sport/rss',      category: 'Sports',    topic: 'sports' },
+  { name: 'Guardian Culture', url: 'https://www.theguardian.com/us/culture/rss',  category: 'Culture',   topic: 'culture' },
+  { name: 'BBC Arts',      url: 'https://feeds.bbci.co.uk/news/entertainment_and_arts/rss.xml', category: 'Culture', topic: 'culture' },
+  { name: 'BBC Health',    url: 'https://feeds.bbci.co.uk/news/health/rss.xml',   category: 'Health',    topic: 'health' },
+  { name: 'NPR Health',    url: 'https://feeds.npr.org/1128/rss.xml',             category: 'Health',    topic: 'health' },
+  { name: 'Japan Times',   url: 'https://www.japantimes.co.jp/feed/',             category: 'Japan',     topic: 'japan' },
+  { name: 'Guardian Japan', url: 'https://www.theguardian.com/world/japan/rss',   category: 'Japan',     topic: 'japan' },
+  { name: 'The Verge AI',  url: 'https://www.theverge.com/rss/ai-artificial-intelligence/index.xml', category: 'AI', topic: 'ai' },
+  { name: 'TechCrunch AI', url: 'https://techcrunch.com/category/artificial-intelligence/feed/', category: 'AI', topic: 'ai' },
+  { name: 'Guardian AI',   url: 'https://www.theguardian.com/technology/artificialintelligenceai/rss', category: 'AI', topic: 'ai' },
+  { name: 'Guardian Space', url: 'https://www.theguardian.com/science/space/rss', category: 'Space',     topic: 'space' },
+  { name: 'NASA',          url: 'https://www.nasa.gov/news-release/feed/',        category: 'Space',     topic: 'space' },
+  { name: 'Polygon',       url: 'https://www.polygon.com/rss/index.xml/',         category: 'Gaming',    topic: 'gaming' },
+  { name: 'Guardian Games', url: 'https://www.theguardian.com/games/rss',         category: 'Gaming',    topic: 'gaming' },
+  { name: 'Guardian Environment', url: 'https://www.theguardian.com/us/environment/rss', category: 'Climate', topic: 'climate' },
+  { name: 'NPR Climate',   url: 'https://feeds.npr.org/1167/rss.xml',             category: 'Climate',   topic: 'climate' },
+  { name: 'Guardian Food', url: 'https://www.theguardian.com/food/rss',           category: 'Food',      topic: 'food' },
+  { name: 'NPR Food',      url: 'https://feeds.npr.org/1053/rss.xml',             category: 'Food',      topic: 'food' },
+  { name: 'Guardian Travel', url: 'https://www.theguardian.com/us/travel/rss',    category: 'Travel',    topic: 'travel' },
+  { name: 'NPR Politics',  url: 'https://feeds.npr.org/1014/rss.xml',             category: 'Politics',  topic: 'politics' },
+  { name: 'Guardian US Politics', url: 'https://www.theguardian.com/us-news/us-politics/rss', category: 'Politics', topic: 'politics' },
 ];
-const ITEMS_PER_FEED = 12;
+// The catalog's valid topic ids, and the set used when a user has never chosen
+// (feed_topics NULL / absent) — exactly the pre-#10 hardcoded lineup.
+const ALL_TOPICS = [...new Set(FEED_LIST.map((f) => f.topic))];
+const DEFAULT_TOPICS = ['world', 'technology', 'science'];
+// Pool sizing: ~132 items (the historical 11 feeds × 12) regardless of how many
+// feeds the topic selection activates, so the clustering prompt and Groq cost
+// stay flat when a user turns on every topic.
+const POOL_TARGET = 132;
+const MIN_ITEMS_PER_FEED = 6;
+const MAX_ITEMS_PER_FEED = 12;
 const FEED_TIMEOUT_MS = 8000;
 const MAX_CARDS = 40;
 
@@ -169,8 +207,23 @@ function domainOf(url: string): string {
   try { return new URL(url).host.replace(/^www\./, ''); } catch { return url; }
 }
 
-async function fetchFeeds(): Promise<PoolItem[]> {
-  const results = await Promise.allSettled(FEED_LIST.map(async (f) => {
+// Sanitize a client/DB-supplied topic selection down to known catalog ids.
+// Anything unrecognized is dropped; an empty/absent result falls back to the
+// defaults so a stale or corrupt preference can never zero out the feed.
+function resolveTopics(raw: unknown): string[] {
+  const picked = Array.isArray(raw)
+    ? raw.filter((t): t is string => typeof t === 'string' && ALL_TOPICS.includes(t))
+    : [];
+  return picked.length > 0 ? [...new Set(picked)] : DEFAULT_TOPICS;
+}
+
+async function fetchFeeds(topics: string[]): Promise<PoolItem[]> {
+  const feeds = FEED_LIST.filter((f) => topics.includes(f.topic));
+  // Fewer active feeds → deeper per-feed reads; more feeds → shallower, so the
+  // pool (and the clustering prompt built from it) stays near POOL_TARGET.
+  const itemsPerFeed = Math.max(MIN_ITEMS_PER_FEED,
+    Math.min(MAX_ITEMS_PER_FEED, Math.round(POOL_TARGET / Math.max(1, feeds.length))));
+  const results = await Promise.allSettled(feeds.map(async (f) => {
     const ctrl = new AbortController();
     const to = setTimeout(() => ctrl.abort(), FEED_TIMEOUT_MS);
     try {
@@ -180,7 +233,7 @@ async function fetchFeeds(): Promise<PoolItem[]> {
         return [] as PoolItem[];
       }
       const xml = await res.text();
-      return parseFeed(xml, f.name, f.category).filter(isValidItem).slice(0, ITEMS_PER_FEED);
+      return parseFeed(xml, f.name, f.category).filter(isValidItem).slice(0, itemsPerFeed);
     } catch (e) {
       console.warn(`[fetch-raw-news] feed ${f.name} failed:`, e instanceof Error ? e.message : e);
       return [] as PoolItem[];
@@ -200,7 +253,7 @@ async function fetchFeeds(): Promise<PoolItem[]> {
       pool.push(it);
     }
   }
-  console.log(`[fetch-raw-news] RSS pool: ${pool.length} items from ${FEED_LIST.length} feeds`);
+  console.log(`[fetch-raw-news] RSS pool: ${pool.length} items from ${feeds.length}/${FEED_LIST.length} feeds (topics: ${topics.join(',')})`);
   return pool;
 }
 
@@ -372,7 +425,8 @@ Deno.serve(async (req) => {
   }
 
   try {
-    const { page = 1 } = await req.json().catch(() => ({ page: 1 }));
+    const { page = 1, topics: rawTopics } = await req.json().catch(() => ({ page: 1 }));
+    const topics = resolveTopics(rawTopics);
 
     // RSS is multi-outlet and fetched fresh each session; it doesn't paginate
     // like NewsAPI. Serve the full clustered batch on page 1 and signal
@@ -386,7 +440,7 @@ Deno.serve(async (req) => {
 
     const groqKey = Deno.env.get('GROQ_API_KEY');
 
-    let pool = await fetchFeeds();
+    let pool = await fetchFeeds(topics);
     if (pool.length === 0) {
       const newsApiKey = Deno.env.get('NEWS_API_KEY');
       if (newsApiKey) {

--- a/supabase/functions/fetch-raw-news/index.ts
+++ b/supabase/functions/fetch-raw-news/index.ts
@@ -71,8 +71,9 @@ const MAX_CARDS = 40;
 // teaser — the old flat 800-char cap landed full-text feeds as `partial` and also
 // tripped process-article's Jina skip. A bare `description` is just a teaser, so
 // keep it short (Jina backfills the body from the URL). process-article re-caps
-// each source at PER_SOURCE_CHAR_CAP = 2500, so matching that here is the ceiling.
-const FULLTEXT_BODY_CAP = 2500;  // content:encoded / Atom content — a real body
+// the lead source at LEAD_SOURCE_CHAR_CAP = 4500 (extras at 2500), so matching
+// the lead cap here is the ceiling.
+const FULLTEXT_BODY_CAP = 4500;  // content:encoded / Atom content — a real body
 const TEASER_CAP = 800;          // description-only — Jina fills the rest
 // The card preview (shown in the Feed and used only as a fallback snippet) never
 // needs the whole body; the full text rides in each card's `sources[].teaser`.

--- a/supabase/functions/process-article/index.ts
+++ b/supabase/functions/process-article/index.ts
@@ -124,13 +124,22 @@ async function runRewriteWithRetry(
 
 // ── Opportunistic full-text extraction ──────────────────────────────────────
 // A NewsAPI/RSS teaser is ~150-200 chars; the real article body is 10-100x
-// richer. We pull it from the source URL via Jina Reader, but only for sources
-// whose teaser is thin (full-text feeds like Ars already ship the body) and
-// only for articles the user actually opens. Always falls back to the teaser.
+// richer. We pull it from the source URL via Jina Reader for any source that
+// didn't already ship a real body (full-text feeds like Ars do), and always
+// fall back to the teaser when extraction fails. The extraction bar is
+// FULL_SOURCE_CHARS: the old 600-char threshold skipped extraction for
+// description-style teasers in the 600–1500 band (Guardian et al., capped at
+// 800 by fetch-raw-news), which stranded ~65% of production articles at
+// `partial` — the audit showed every partial row sat in exactly that band.
 const JINA_READER_URL = 'https://r.jina.ai/';
-const EXTRACT_TEASER_THRESHOLD = 600; // skip extraction when teaser already this long
 const EXTRACT_TIMEOUT_MS = 8000;
 const MAX_EXTRACT_SOURCES = 4;
+// The LEAD source (index 0 — the story the article is actually about) keeps
+// more of its body than corroborating sources: truncating the lead genuinely
+// costs facts, while extras past ~2500 chars are mostly redundant color. The
+// 7000 total ceiling is unchanged; chunking beyond it is the Magazines (#58)
+// design question, not this path's.
+const LEAD_SOURCE_CHAR_CAP = 4500;
 const PER_SOURCE_CHAR_CAP = 2500;
 const TOTAL_SOURCE_CHAR_CAP = 7000;
 
@@ -189,16 +198,18 @@ async function buildSourceBlock(sources: SourceRef[], jinaKey: string | undefine
   let fullBody = false;
   const parts = await Promise.all(picked.map(async (s, n) => {
     let body = (s.teaser || '').trim();
-    if (s.url && body.length < EXTRACT_TEASER_THRESHOLD) {
+    if (body.length >= FULL_SOURCE_CHARS) {
+      fullBody = true;                 // full-text feed shipped a real body — no Jina needed
+    } else if (s.url) {
       const full = await extractFullText(s.url, jinaKey);
       if (full && full.length > body.length) {
         body = full;
-        fullBody = true;               // Jina supplied the body
+        // Only a substantial extraction counts as a real body; a short Jina
+        // result (error page, stub) just improves the teaser a little.
+        if (full.length >= FULL_SOURCE_CHARS) fullBody = true;
       }
-    } else if (body.length >= FULL_SOURCE_CHARS) {
-      fullBody = true;                 // full-text feed shipped a real body — no Jina needed
     }
-    body = body.slice(0, PER_SOURCE_CHAR_CAP);
+    body = body.slice(0, n === 0 ? LEAD_SOURCE_CHAR_CAP : PER_SOURCE_CHAR_CAP);
     return `${n + 1}. ${s.title || ''} — ${body}`.trim();
   }));
 


### PR DESCRIPTION
Closes #10.

## Feed topics (Phase 2.2)
- **15-topic curated catalog**: the existing world/technology/science lineup plus business, sports, culture, health, japan, ai, space, gaming, climate, food, travel, politics — 37 RSS feeds total (all URLs verified live). Topic ids are mirrored between `fetch-raw-news` `FEED_LIST` and `src/data/feedTopics.ts`.
- `fetch-raw-news` accepts a sanitized `topics` param; empty/unknown falls back to the pre-#10 defaults, so users who never touch the setting see no change. Per-feed depth auto-scales (`POOL_TARGET=132`) so selecting every topic doesn't grow the Groq clustering prompt.
- `ensure-buffer` reads `user_preferences.feed_topics` and forwards it — JIT and overnight-cron articles honor the selection.
- Client: `feedTopics` in the store (null = never chosen), synced + rehydrated via `user_preferences`, included in persist partialize; Settings "Feed Topics" toggle-chip card with an at-least-one guard; both `fetchNewsFeed` paths pass topics.
- Migration: `database/26_feed_topics.sql` (**already applied**).

## Source-fullness fix
Production audit (n=255 tracked rows, W25–W29): snippets 0%, but ~65% of articles stalled at `partial` — all inside the 600–1500-char band where `EXTRACT_TEASER_THRESHOLD=600` skipped Jina extraction while `fetch-raw-news` ships description teasers capped at 800.

- `process-article` now extracts whenever a source body < `FULL_SOURCE_CHARS` (1500); `fullBody` requires a ≥1500-char body so short Jina stubs don't inflate classification.
- Lead-source cap raised 2500→4500 (`LEAD_SOURCE_CHAR_CAP`; corroborating sources stay 2500, 7000 total unchanged); `FULLTEXT_BODY_CAP` matched upstream.

## Verification
- Playwright (dev mode): chips render/toggle/persist across reload; last-topic guard holds. Caught + fixed `feedTopics` missing from persist partialize.
- Deployed functions verified live: `topics=null` → default categories; `topics=[japan,ai]` → Japan 15 + AI 25 cards. `tsc` clean.
- Follow-up: re-run the `database/20_source_fullness.sql` audit query after ~a week (expect partial ≪ 65%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AC7gEfymjKgvaLML3PxRo6