### PR TITLE
Kana-homophone attribution fix + stale JLPT label refresh

### DIFF
--- a/docs/task.md
+++ b/docs/task.md
@@ -397,3 +397,10 @@
   - [ ] Manual follow-ups: re-run database/15_backfill_unseen_difficulty.sql
         (re-seed unseen difficulty from corrected tags); hard-refresh PWA after
         deploy; re-run fix_progress_rows.cjs if any tombstoned rows resurrect.
+  - [x] Homophone attribution fix (follow-up, same day): pickBestEntry now
+        prefers kana-primary (uk/no-kanji) entries for kana lemmas — freq-rank
+        tiebreak had credited する to 擦る (×155), いる to 射る (×43), なる to
+        生る (×108); rows remapped server-side, persist v9 drops local copies
+        once (RECOVERABLE_WORD_IDS, not tombstoned — real words). Sync now
+        refreshes JLPT labels daily from the server (stale 来る/先 showed as
+        N1). なる pinned to 成る in the enricher (生る keeps its legit N3 tag).

--- a/scripts/jlpt_overrides.json
+++ b/scripts/jlpt_overrides.json
@@ -3,11 +3,13 @@
   "deny": {},
   "pin": {
     "5|ラジオカセ": "1138960",
+    "5|なる": "1375610",
     "2|行っていらっしゃい": "2088750",
     "2|お世話になりました": "1002260"
   },
   "_pin_notes": {
     "5|ラジオカセ": "deck truncation of ラジオカセット; pinned to the common ラジカセ entry",
+    "5|なる": "成る (to become) — 生る (to bear fruit) is also uk+common and carries the better freq band, so scoring picks it without the pin",
     "2|行っていらっしゃい": "JMDict headword is 行ってらっしゃい",
     "2|お世話になりました": "JMDict headword is お世話になる"
   },

--- a/scripts/jlpt_progress_fix.json
+++ b/scripts/jlpt_progress_fix.json
@@ -26,9 +26,15 @@
     "1428285": "1428280",
     "1447430": "1447440",
     "1165980": "1165970",
-    "2246880": "1203100"
+    "2246880": "1203100",
+    "1595910": "1157170",
+    "1322180": "1577980",
+    "1611000": "1375610"
   },
   "_remap_notes": {
+    "1595910": "擦る(する to rub) -> 為る(to do): reader lookup freq-rank tiebreak credited 155 する sightings to the rub entry",
+    "1322180": "射る(いる to shoot) -> 居る(to be): same tiebreak bug, 43 sightings",
+    "1611000": "生る(なる to bear fruit) -> 成る(to become): same, 108 sightings; these three are in RECOVERABLE_WORD_IDS (v9 local migration), NOT the permanent tombstone set — they are real words the user may study later",
     "1643470": "大切り(おおぎり) -> 大切(たいせつ): 18 sightings were almost certainly たいせつ",
     "1525750": "万(ばん) -> 万(まん): 33 sightings",
     "1465580": "入る(いる) -> 入る(はいる)",

--- a/src/services/jmdict.ts
+++ b/src/services/jmdict.ts
@@ -50,8 +50,17 @@ export async function lookupWord(text: string): Promise<JMDictResult[]> {
   const kanjiResults = await lookupByKanji(text);
   if (kanjiResults.length > 0) return kanjiResults;
 
-  // 2. Fall back to kana
-  return lookupByKana(text);
+  // 2. Fall back to kana. Order kana-primary entries first so downstream
+  // "first candidate" fallbacks (e.g. failed LLM disambiguation) land on the
+  // word actually written in kana, not a kanji-primary homophone.
+  const kanaResults = await lookupByKana(text);
+  return [...kanaResults].sort((a, b) => {
+    const ka = isKanaPrimary(a) ? 0 : 1;
+    const kb = isKanaPrimary(b) ? 0 : 1;
+    if (ka !== kb) return ka - kb;
+    if (a.isCommon !== b.isCommon) return a.isCommon ? -1 : 1;
+    return (a.freqRank ?? Infinity) - (b.freqRank ?? Infinity);
+  });
 }
 
 async function lookupByKanji(text: string): Promise<JMDictResult[]> {
@@ -128,15 +137,29 @@ function posMatches(result: JMDictResult, pos: CoarsePos | undefined): boolean {
   return false;
 }
 
+/** Entry is written in kana in practice: no kanji forms, or usually-kana senses. */
+function isKanaPrimary(e: JMDictResult): boolean {
+  return e.kanji.length === 0 || e.senses.some(s => s.misc.includes('uk'));
+}
+
 /**
- * Pick the best entry for a lemma: prefer a POS match, then common words, then
- * the most frequent (lowest freq_rank). Replaces the old "first entry wins".
+ * Pick the best entry for a lemma: prefer a POS match, then — for kana lemmas —
+ * kana-primary entries, then common words, then the most frequent (lowest
+ * freq_rank). The kana-primary step matters because homophone verbs are all
+ * common and freq_rank alone routes する to 擦る "to rub" (為る has no rank) and
+ * いる to 射る "to shoot" — a word WRITTEN in kana is almost never the
+ * kanji-primary homophone. Replaces the old "first entry wins".
  */
-export function pickBestEntry(candidates: JMDictResult[], pos?: CoarsePos): JMDictResult {
+export function pickBestEntry(candidates: JMDictResult[], pos?: CoarsePos, kanaLemma = false): JMDictResult {
   return [...candidates].sort((a, b) => {
     const pa = posMatches(a, pos) ? 0 : 1;
     const pb = posMatches(b, pos) ? 0 : 1;
     if (pa !== pb) return pa - pb;
+    if (kanaLemma) {
+      const ka = isKanaPrimary(a) ? 0 : 1;
+      const kb = isKanaPrimary(b) ? 0 : 1;
+      if (ka !== kb) return ka - kb;
+    }
     if (a.isCommon !== b.isCommon) return a.isCommon ? -1 : 1;
     return (a.freqRank ?? Infinity) - (b.freqRank ?? Infinity);
   })[0];
@@ -180,9 +203,10 @@ export async function lookupLemmasBatch(
 
   const result = new Map<string, JMDictResult>();
   for (const lemma of unique) {
-    const ids = (kanjiIds.get(lemma)?.size ? kanjiIds.get(lemma) : kanaIds.get(lemma)) ?? new Set();
+    const viaKanji = !!kanjiIds.get(lemma)?.size;
+    const ids = (viaKanji ? kanjiIds.get(lemma) : kanaIds.get(lemma)) ?? new Set();
     const cands = [...ids].map(id => byId.get(id)).filter((e): e is JMDictResult => !!e);
-    if (cands.length > 0) result.set(lemma, pickBestEntry(cands, posByLemma?.get(lemma)));
+    if (cands.length > 0) result.set(lemma, pickBestEntry(cands, posByLemma?.get(lemma), !viaKanji));
   }
 
   await applyJlptFallback(result);

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -8,7 +8,7 @@ import { schedule, ratingForReaderEvent, readerEventMayAdvance, seedSrsFromDiffi
 import { decidePacing, isActiveForPacing } from './pacing';
 import { alignReading, hasKanji, loadReadingData } from './furigana';
 import { selectPromotions, type IntakeItem, type IntakeCandidate } from './intake';
-import { TOMBSTONED_WORD_IDS } from './vocabCleanup';
+import { TOMBSTONED_WORD_IDS, RECOVERABLE_WORD_IDS } from './vocabCleanup';
 
 export type MasteryLevel = 'unseen' | 'hard' | 'medium' | 'easy';
 
@@ -227,6 +227,8 @@ interface AppState {
   // One-shot furigana re-align: when the stored furiganaMap back-catalog was last
   // recomputed with the per-kanji reading tables (see realignFurigana).
   lastFuriganaRealignTs: number | null;
+  // Daily throttle for the sync-time JLPT label refresh (server labels win).
+  lastJlptLabelRefreshTs: number | null;
   currentArticle: NewsArticle | null;
   articlesCache: Record<string, NewsArticle>;
   processingArticles: string[];
@@ -323,6 +325,7 @@ export const useAppStore = create<AppState>()(
       lastResetTs: null,
       lastStudyPacingResetTs: null,
       lastFuriganaRealignTs: null,
+      lastJlptLabelRefreshTs: null,
       currentArticle: null,
       articlesCache: {},
       processingArticles: [],
@@ -1291,6 +1294,40 @@ export const useAppStore = create<AppState>()(
         // first-contact difficulty can be seeded. Early-returns once backfilled.
         await get().backfillWordProgress();
 
+        // Refresh JLPT labels for entry-backed words (daily). The local cache
+        // keeps the label captured at lookup time, so server-side retagging
+        // (docs/jlpt_vocab_audit.md) left stale levels behind — 来る displayed
+        // in the N1 list while the server said N5. Server value wins here,
+        // including derived levels for now-untagged entries.
+        const lastLabelTs = get().lastJlptLabelRefreshTs ?? 0;
+        if (Date.now() - lastLabelTs > 24 * 60 * 60 * 1000) {
+          try {
+            const { fetchJlptByEntryIds } = await import('./jmdict');
+            const refreshIds = Object.values(get().wordDatabase)
+              .map((w) => w.jmdictEntryId)
+              .filter((id): id is string => !!id);
+            const levels = await fetchJlptByEntryIds(refreshIds);
+            set((state) => {
+              const db = { ...state.wordDatabase };
+              let changed = 0;
+              for (const [key, w] of Object.entries(db)) {
+                const info = w.jmdictEntryId ? levels.get(w.jmdictEntryId) : undefined;
+                if (!info) continue;
+                if ((w.jlptLevel ?? null) !== info.jlptLevel || (w.jlptDerived ?? false) !== info.jlptDerived) {
+                  db[key] = { ...w, jlptLevel: info.jlptLevel, jlptDerived: info.jlptDerived };
+                  changed++;
+                }
+              }
+              if (changed > 0) console.log(`[store] refreshed JLPT labels on ${changed} word(s)`);
+              return changed > 0
+                ? { wordDatabase: db, lastJlptLabelRefreshTs: Date.now() }
+                : { lastJlptLabelRefreshTs: Date.now() };
+            });
+          } catch (e) {
+            console.warn('[store] JLPT label refresh failed:', e);
+          }
+        }
+
         // Reconcile local → server: words graded locally but ungraded (or absent)
         // on the server never had their grade persisted (legacy rows / failed past
         // syncs). Local is authoritative — it reflects real reading — so push those
@@ -1702,7 +1739,7 @@ export const useAppStore = create<AppState>()(
     }),
     {
       name: 'yugen-storage',
-      version: 8,
+      version: 9,
       // A persist write throws QuotaExceededError once localStorage fills up. That
       // exception used to propagate out of store actions (markArticleRead,
       // recordWordSeen, ...) and abort the tap handler — silently breaking article
@@ -1760,6 +1797,7 @@ export const useAppStore = create<AppState>()(
         lastResetTs: state.lastResetTs,
         lastStudyPacingResetTs: state.lastStudyPacingResetTs,
         lastFuriganaRealignTs: state.lastFuriganaRealignTs,
+        lastJlptLabelRefreshTs: state.lastJlptLabelRefreshTs,
         dismissedArticleIds: capIds(state.dismissedArticleIds),
         readArticleIds: capIds(state.readArticleIds),
         readerFontSize: state.readerFontSize,
@@ -1884,6 +1922,19 @@ export const useAppStore = create<AppState>()(
             const w = wordDatabase[key];
             if (!w) return;
             if (TOMBSTONED_WORD_IDS.has(w.jmdictEntryId ?? key)) delete wordDatabase[key];
+          });
+          state = { ...state, wordDatabase };
+        }
+        // v9: drop local copies of the misattributed homophone rows (する
+        // credited to 擦る, いる to 射る, なる to 生る) ONCE — the server-side
+        // remap moves that progress to the correct entries and it rehydrates
+        // back with fresh dictionary data. No sync block: these are real words.
+        if (version < 9 && state?.wordDatabase) {
+          const wordDatabase = { ...state.wordDatabase };
+          Object.keys(wordDatabase).forEach((key) => {
+            const w = wordDatabase[key];
+            if (!w) return;
+            if (RECOVERABLE_WORD_IDS.has(w.jmdictEntryId ?? key)) delete wordDatabase[key];
           });
           state = { ...state, wordDatabase };
         }

--- a/src/services/vocabCleanup.ts
+++ b/src/services/vocabCleanup.ts
@@ -44,6 +44,8 @@ export const TOMBSTONED_WORD_IDS: ReadonlySet<string> = new Set([
   '1165980', // 一番(ひとつがい) -> 一番(いちばん)
   '2246880', // 貝(バイ) -> 貝(かい)
   // deleted (dictionary noise that only entered via bad JLPT tags)
+  // NOTE: do not add real words here — this set permanently blocks sync for
+  // these ids. One-time fixes for legitimate words go in RECOVERABLE_WORD_IDS.
   '1543920', // 余意
   '1580130', // 出端
   '1000050', // 仝
@@ -54,4 +56,19 @@ export const TOMBSTONED_WORD_IDS: ReadonlySet<string> = new Set([
   '1339500', // 出切る
   '1518450', // 亡い
   '2427850', // 大き(おおき)
+]);
+
+/**
+ * Real words whose progress rows were MISATTRIBUTED by the reader's homophone
+ * tiebreak (pickBestEntry chose the kanji-primary homophone for a kana lemma:
+ * する -> 擦る, いる -> 射る, なる -> 生る). The server-side fix remaps those
+ * rows to the entry actually read; the persist v9 migration drops the local
+ * copies once so the remapped progress rehydrates cleanly. Unlike
+ * TOMBSTONED_WORD_IDS these are NOT blocked from future sync — they are
+ * legitimate words that can be studied for real later.
+ */
+export const RECOVERABLE_WORD_IDS: ReadonlySet<string> = new Set([
+  '1595910', // 擦る(する) -> 為る 1157170
+  '1322180', // 射る(いる) -> 居る 1577980
+  '1611000', // 生る(なる) -> 成る 1375610
 ]);


### PR DESCRIPTION
## Summary

Follow-up to #130. Three issues surfaced by the post-cleanup Progress screen (擦る "to rub" ×155 in the N1 seen list; 来る showing as N1):

1. **Misattributed homophone sightings** — `pickBestEntry` broke ties by freq_rank alone, crediting する to 擦る (×155), いる to 射る (×43), なる to 生る (×108). Kana lemmas now prefer kana-primary entries (no kanji forms / usually-kana senses); `lookupWord`'s kana fallback is ordered the same way.
2. **Server rows remapped** to 為る/居る/成る (already applied + verified). Persist **v9** drops the stale local copies once via `RECOVERABLE_WORD_IDS` — deliberately not tombstoned, these are real words.
3. **Stale local JLPT labels** — sync now refreshes `jlptLevel`/`jlptDerived` daily from the server for entry-backed words, so cached pre-cleanup labels (来る/先 as N1) self-correct.

Enricher: なる pinned to 成る (生る keeps its legitimate N3 deck tag). Retag delta applied: 2 removals / 3 changes / 1 addition.

## Post-merge

Hard-refresh/reinstall the PWA promptly — until v9 reaches devices, local 擦る/生る copies can re-push their old rows (re-run `fix_progress_rows.cjs --apply` if that happens; idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hNsJR1CJrDDmUFgnVvs3G